### PR TITLE
Fix upgraded request copy logic

### DIFF
--- a/src/ReverseProxy.Core/Service/Proxy/HttpProxy.cs
+++ b/src/ReverseProxy.Core/Service/Proxy/HttpProxy.cs
@@ -77,6 +77,8 @@ namespace Microsoft.ReverseProxy.Core.Service.Proxy
         /// (a) and (b) show the *request* path, going *upstream* from the client to the target.
         /// (c) and (d) show the *response* path, going *downstream* from the target back to the client.
         /// </remarks>
+        /// <param name="longCancellation">This should be linked to a client disconnect notification like <see cref="HttpContext.RequestAborted"/>
+        /// to avoid leaking long running requests.</param>
         public Task ProxyAsync(
             HttpContext context,
             Uri targetUri,

--- a/src/ReverseProxy.Core/Service/Proxy/IHttpProxy.cs
+++ b/src/ReverseProxy.Core/Service/Proxy/IHttpProxy.cs
@@ -17,6 +17,8 @@ namespace Microsoft.ReverseProxy.Core.Service.Proxy
         /// <summary>
         /// Proxies the incoming request to the upstream server, and the response back to our client.
         /// </summary>
+        /// <param name="longCancellation">This should be linked to a client disconnect notification like <see cref="HttpContext.RequestAborted"/>
+        /// to avoid leaking long running requests.</param>
         Task ProxyAsync(
             HttpContext context,
             Uri targetUri,


### PR DESCRIPTION
#34 ProxyAsync_UpgradableRequest_Works was flaky when we started running it on the CI and I tracked it down to a product issue in the upgrade stream copy logic. It sets up two loops to stream content up and down, but as soon as one direction closes it cancels the other one rather than waiting for it to finish. In the test this means one random direction doesn't get to finish copying content and the test fails. In production this wouldn't be correct either because an upgrade channel / websocket can be half-closed and still stream in the other direction. When one direction ends we expect the other to end naturally/fail, we shouldn't have to explicitly cancel it.

I was able to repro this by inserting a random delay at the start of the copy loop to highlight the scenario where one completes much sooner than the other.

Compare to our prior prototype that waited for both directions to complete.
https://github.com/aspnet/AspLabs/blob/dc723315dfbe3150fedd7524d2454788f3bf3f30/src/Proxy/src/ProxyAdvancedExtensions.cs#L122