### PR TITLE
manually update dependencies to .NET 5

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
+    <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-preview.4.20215.10">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>5395b14eb4b924419b3d4732582a22ac72571d9f</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20201.2">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,4 +4,8 @@
     <VersionPrefix>0.1.0</VersionPrefix>
     <PreReleaseVersionLabel>alpha1</PreReleaseVersionLabel>
   </PropertyGroup>
+  <!--Package versions-->
+  <PropertyGroup>
+    <MicrosoftNETCoreAppPackageVersion>5.0.0-preview.4.20215.10</MicrosoftNETCoreAppPackageVersion>
+  </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,12 +1,15 @@
 {
+  "sdk": {
+    "version": "5.0.100-preview.2.20120.3"
+  },
   "tools": {
-    "dotnet": "3.1.201",
+    "dotnet": "5.0.100-preview.2.20120.3",
     "runtimes": {
-      "dotnet": [
-        "3.1.3"
+      "dotnet/x64": [
+        "$(MicrosoftNETCoreAppPackageVersion)"
       ],
-      "aspnetcore": [
-        "3.1.3"
+      "dotnet/x86": [
+        "$(MicrosoftNETCoreAppPackageVersion)"
       ]
     }
   },

--- a/samples/ReverseProxy.Sample/ReverseProxy.Sample.csproj
+++ b/samples/ReverseProxy.Sample/ReverseProxy.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <RootNamespace>ReverseProxy.Sample</RootNamespace>
   </PropertyGroup>

--- a/samples/SampleClient/SampleClient.csproj
+++ b/samples/SampleClient/SampleClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/samples/SampleServer/SampleServer.csproj
+++ b/samples/SampleServer/SampleServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <RootNamespace>SampleServer</RootNamespace>
   </PropertyGroup>

--- a/src/ReverseProxy.Common/Microsoft.ReverseProxy.Common.csproj
+++ b/src/ReverseProxy.Common/Microsoft.ReverseProxy.Common.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 

--- a/src/ReverseProxy.Core/Microsoft.ReverseProxy.Core.csproj
+++ b/src/ReverseProxy.Core/Microsoft.ReverseProxy.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>ReverseProxy.Core</RootNamespace>
   </PropertyGroup>

--- a/src/ReverseProxy.Signals/Microsoft.ReverseProxy.Signals.csproj
+++ b/src/ReverseProxy.Signals/Microsoft.ReverseProxy.Signals.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 

--- a/src/ReverseProxy.Utilities/Microsoft.ReverseProxy.Utilities.csproj
+++ b/src/ReverseProxy.Utilities/Microsoft.ReverseProxy.Utilities.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 

--- a/test/ReverseProxy.Common.Tests/Microsoft.ReverseProxy.Common.Tests.csproj
+++ b/test/ReverseProxy.Common.Tests/Microsoft.ReverseProxy.Common.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>ReverseProxy.Common</RootNamespace>
   </PropertyGroup>

--- a/test/ReverseProxy.Core.Tests/Microsoft.ReverseProxy.Core.Tests.csproj
+++ b/test/ReverseProxy.Core.Tests/Microsoft.ReverseProxy.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>ReverseProxy.Core</RootNamespace>
   </PropertyGroup>

--- a/test/ReverseProxy.Signals.Tests/Microsoft.ReverseProxy.Signals.Tests.csproj
+++ b/test/ReverseProxy.Signals.Tests/Microsoft.ReverseProxy.Signals.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>ReverseProxy.Signals</RootNamespace>
   </PropertyGroup>

--- a/test/ReverseProxy.Utilities.Tests/Microsoft.ReverseProxy.Utilities.Tests.csproj
+++ b/test/ReverseProxy.Utilities.Tests/Microsoft.ReverseProxy.Utilities.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>ReverseProxy.Utilities</RootNamespace>
   </PropertyGroup>

--- a/test/Tests.Common/Tests.Common.csproj
+++ b/test/Tests.Common/Tests.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
     <OutputType>Library</OutputType>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #27 

I added `Microsoft.NETCore.App` as a Darc-tracked dependency and then did a manual `darc update-dependencies` to get the latest .NET 5 build in. Then I updated all the TFMs. Everything seems to be working and using .NET 5!

Once this is in, I can update darc to bring in new builds at whatever cadence we want. The trade off there is that more frequent updates means we have the latest and greatest, at the cost of more dependency update PRs. The dependency update PRs *should* auto-merge, but we may have to watch out for breaking changes. Also, more updates means more commits that are just "update dependencies" :).

TODO at merge:
* [x] Confirm the packages build `netcoreapp5.0` binaries.
* [x] Decide on update cadence (options: 'none', 'everyDay', 'everyBuild', 'twiceDaily', 'everyWeek') **thoughts?**
* [ ] Update Darc subscription (that's controlled outside the repo so I wanted to get a manual update in first)