### PR TITLE
Fix blog post link in AsyncSemaphore

### DIFF
--- a/src/ReverseProxy.Utilities/Utils/AsyncSemaphore.cs
+++ b/src/ReverseProxy.Utilities/Utils/AsyncSemaphore.cs
@@ -10,7 +10,7 @@ namespace Microsoft.ReverseProxy.Utilities
     /// Alternative to SemaphoreSlim that respects the current thread scheduler.
     /// </summary>
     /// <remarks>
-    /// Based on <c>https://blogs.msdn.microsoft.com/pfxteam/2012/02/12/building-async-coordination-primitives-part-5-asyncsemaphore/</c>.
+    /// Based on <c>https://devblogs.microsoft.com/pfxteam/building-async-coordination-primitives-part-5-asyncsemaphore/</c>.
     /// </remarks>
     public sealed class AsyncSemaphore
     {


### PR DESCRIPTION
Perhaps it's a misconfigured redirect and the correct resolution is not to change the code, but the current link currently redirects to https://devblogs.microsoft.com/pfxteam/https:/devblogs.microsoft.com/iotdev/https:/devblogs.microsoft.com/iotdev/https:/devblogs.microsoft.com/iotdev/building-async-coordination-primitives-part-5-asyncsemaphore/