### PR TITLE
Round robin load balancing 

### DIFF
--- a/src/ReverseProxy.Core/Abstractions/BackendDiscovery/Contract/LoadBalancingMode.cs
+++ b/src/ReverseProxy.Core/Abstractions/BackendDiscovery/Contract/LoadBalancingMode.cs
@@ -22,6 +22,10 @@ namespace Microsoft.ReverseProxy.Core.Abstractions
         /// </summary>
         Random,
         /// <summary>
+        /// Selects an endpoint by cycling through them in order.
+        /// </summary>
+        RoundRobin,
+        /// <summary>
         /// Select the first endpoint without considering load. This is useful for dual endpoint fail-over systems.
         /// </summary>
         First,

--- a/src/ReverseProxy.Core/Middleware/LoadBalancingMiddleware.cs
+++ b/src/ReverseProxy.Core/Middleware/LoadBalancingMiddleware.cs
@@ -41,7 +41,8 @@ namespace Microsoft.ReverseProxy.Core.Middleware
             var endpoints = endpointsFeature?.Endpoints
                 ?? throw new InvalidOperationException("The AvailableBackendEndpoints collection was not set.");
 
-            var loadBalancingOptions = backend.Config.Value?.LoadBalancingOptions ?? default;
+            var loadBalancingOptions = backend.Config.Value?.LoadBalancingOptions
+                ?? new BackendConfig.BackendLoadBalancingOptions(default);
 
             var endpoint = _operationLogger.Execute(
                 "ReverseProxy.PickEndpoint",

--- a/src/ReverseProxy.Core/Service/Proxy/LoadBalancer.cs
+++ b/src/ReverseProxy.Core/Service/Proxy/LoadBalancer.cs
@@ -40,6 +40,9 @@ namespace Microsoft.ReverseProxy.Core.Service.Proxy
             {
                 case LoadBalancingMode.First:
                     return endpoints[0];
+                case LoadBalancingMode.RoundRobin:
+                    var offset = loadBalancingOptions.RoundRobinState.Increment();
+                    return endpoints[offset % endpoints.Count];
                 case LoadBalancingMode.Random:
                     var random = _randomFactory.CreateRandomInstance();
                     return endpoints[random.Next(endpointCount)];

--- a/src/ReverseProxy.Core/Service/RuntimeModel/BackendConfig.cs
+++ b/src/ReverseProxy.Core/Service/RuntimeModel/BackendConfig.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.ReverseProxy.Core.Abstractions;
+using Microsoft.ReverseProxy.Core.Util;
 
 namespace Microsoft.ReverseProxy.Core.RuntimeModel
 {
@@ -79,9 +80,13 @@ namespace Microsoft.ReverseProxy.Core.RuntimeModel
             public BackendLoadBalancingOptions(LoadBalancingMode mode)
             {
                 Mode = mode;
+                // Increment returns the new value and we want the first return value to be 0.
+                RoundRobinState = new AtomicCounter() { Value = -1 };
             }
 
             public LoadBalancingMode Mode { get; }
+
+            public AtomicCounter RoundRobinState { get; }
         }
     }
 }

--- a/src/ReverseProxy.Core/Service/RuntimeModel/BackendConfig.cs
+++ b/src/ReverseProxy.Core/Service/RuntimeModel/BackendConfig.cs
@@ -86,7 +86,7 @@ namespace Microsoft.ReverseProxy.Core.RuntimeModel
 
             public LoadBalancingMode Mode { get; }
 
-            public AtomicCounter RoundRobinState { get; }
+            internal AtomicCounter RoundRobinState { get; }
         }
     }
 }

--- a/src/ReverseProxy.Core/Util/AtomicCounter.cs
+++ b/src/ReverseProxy.Core/Util/AtomicCounter.cs
@@ -12,22 +12,25 @@ namespace Microsoft.ReverseProxy.Core.Util
         /// <summary>
         /// Gets the current value of the counter.
         /// </summary>
-        public int Value => Volatile.Read(ref _value);
+        public int Value {
+            get => Volatile.Read(ref _value);
+            set => Volatile.Write(ref _value, value);
+        }
 
         /// <summary>
         /// Atomically increments the counter value by 1.
         /// </summary>
-        public void Increment()
+        public int Increment()
         {
-            Interlocked.Increment(ref _value);
+            return Interlocked.Increment(ref _value);
         }
 
         /// <summary>
         /// Atomically decrements the counter value by 1.
         /// </summary>
-        public void Decrement()
+        public int Decrement()
         {
-            Interlocked.Decrement(ref _value);
+            return Interlocked.Decrement(ref _value);
         }
 
         /// <summary>

--- a/test/ReverseProxy.Core.Tests/Middleware/LoadBalancerMiddlewareTests.cs
+++ b/test/ReverseProxy.Core.Tests/Middleware/LoadBalancerMiddlewareTests.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.ReverseProxy.Common.Abstractions.Telemetry;
 using Microsoft.ReverseProxy.Common.Telemetry;
+using Microsoft.ReverseProxy.Core.Abstractions;
 using Microsoft.ReverseProxy.Core.RuntimeModel;
 using Microsoft.ReverseProxy.Core.Service.Management;
 using Microsoft.ReverseProxy.Core.Service.Proxy;
@@ -40,6 +41,7 @@ namespace Microsoft.ReverseProxy.Core.Middleware.Tests
                 backendId: "backend1",
                 endpointManager: new EndpointManager(),
                 proxyHttpClientFactory: proxyHttpClientFactoryMock.Object);
+            backend1.Config.Value = new BackendConfig(default, new BackendConfig.BackendLoadBalancingOptions(LoadBalancingMode.RoundRobin));
             var endpoint1 = backend1.EndpointManager.GetOrCreateItem(
                 "endpoint1",
                 endpoint =>
@@ -66,10 +68,7 @@ namespace Microsoft.ReverseProxy.Core.Middleware.Tests
             aspNetCoreEndpoints.Add(aspNetCoreEndpoint);
             var httpContext = new DefaultHttpContext();
             httpContext.SetEndpoint(aspNetCoreEndpoint);
-
-            Mock<ILoadBalancer>()
-                .Setup(l => l.PickEndpoint(It.IsAny<IReadOnlyList<EndpointInfo>>(),  It.IsAny<BackendConfig.BackendLoadBalancingOptions>()))
-                .Returns(endpoint1);
+            Provide<ILoadBalancer, LoadBalancer>();
 
             httpContext.Features.Set<IAvailableBackendEndpointsFeature>(
                 new AvailableBackendEndpointsFeature() { Endpoints = new List<EndpointInfo>() { endpoint1, endpoint2 }.AsReadOnly() });

--- a/test/ReverseProxy.Core.Tests/Service/Proxy/LoadBalancerTests.cs
+++ b/test/ReverseProxy.Core.Tests/Service/Proxy/LoadBalancerTests.cs
@@ -135,6 +135,29 @@ namespace Microsoft.ReverseProxy.Core.Service.Proxy.Tests
             Assert.Same(result, endpoints[1]);
         }
 
+        [Fact]
+        public void PickEndpoint_RoundRobin_Works()
+        {
+            var loadBalancer = Create<LoadBalancer>();
+            var endpoints = new[]
+            {
+                new EndpointInfo("ep1"),
+                new EndpointInfo("ep2"),
+            };
+            endpoints[0].ConcurrencyCounter.Increment();
+            var options = new BackendConfig.BackendLoadBalancingOptions(LoadBalancingMode.RoundRobin);
+
+            var result0 = loadBalancer.PickEndpoint(endpoints, in options);
+            var result1 = loadBalancer.PickEndpoint(endpoints, in options);
+            var result2 = loadBalancer.PickEndpoint(endpoints, in options);
+            var result3 = loadBalancer.PickEndpoint(endpoints, in options);
+
+            Assert.Same(result0, endpoints[0]);
+            Assert.Same(result1, endpoints[1]);
+            Assert.Same(result2, endpoints[0]);
+            Assert.Same(result3, endpoints[1]);
+        }
+
         internal class TestRandomFactory : IRandomFactory
         {
             internal TestRandom Instance { get; set; }


### PR DESCRIPTION
#72 While we debated more complex backend data storage mechanisms, I wanted to try something simple first. Built in algorithms can avail themselves of built in structures so I added the round robin state tracker to the existing BackendLoadBalancingOptions structure.