### PR TITLE
Fix Get-Content encoding error.

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -546,7 +546,7 @@ function InitializeToolset() {
 
   MSBuild-Core $proj $bl /t:__WriteToolsetLocation /clp:ErrorsOnly`;NoSummary /p:__ToolsetLocationOutputFile=$toolsetLocationFile
 
-  $path = Get-Content $toolsetLocationFile -TotalCount 1
+  $path = Get-Content $toolsetLocationFile -Encoding UTF8 -TotalCount 1
   if (!(Test-Path $path)) {
     throw "Invalid toolset path: $path"
   }


### PR DESCRIPTION
When in non-English environment, `Get-Content` will return wrong encoding string, so `Test-Path` will fail.