### PR TITLE
workaround arcade signing issue

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,0 +1,3 @@
+<Project>
+  <!-- Arcade currently requires this file, though it doesn't require any content in it I believe. -->
+</Project>


### PR DESCRIPTION
Signing validation in our internal builds is failing because this file is missing. As far as I can tell, the content is optional but the load is happening unconditionally (I think that's fixed in the latest Arcade).

I'm going to merge this quickly so I can get it in to the internal branch and make sure it unblocks the build.