### PR TITLE
Add Id to Backend type 

### DIFF
--- a/samples/ReverseProxy.Sample/CustomConfigFilter.cs
+++ b/samples/ReverseProxy.Sample/CustomConfigFilter.cs
@@ -12,7 +12,7 @@ namespace Microsoft.ReverseProxy.Sample
 {
     public class CustomConfigFilter : IProxyConfigFilter
     {
-        public Task ConfigureBackendAsync(string id, Backend backend, CancellationToken cancel)
+        public Task ConfigureBackendAsync(Backend backend, CancellationToken cancel)
         {
             backend.HealthCheckOptions ??= new HealthCheckOptions();
             // How to use custom metadata to configure backends

--- a/samples/ReverseProxy.Sample/ReverseProxy.Sample.csproj
+++ b/samples/ReverseProxy.Sample/ReverseProxy.Sample.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\ReverseProxy.Core\Microsoft.ReverseProxy.Core.csproj"/>
-    <ProjectReference Include="..\..\src\ReverseProxy.Utilities\Microsoft.ReverseProxy.Utilities.csproj"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReverseProxy.Core/Abstractions/BackendDiscovery/Contract/Backend.cs
+++ b/src/ReverseProxy.Core/Abstractions/BackendDiscovery/Contract/Backend.cs
@@ -15,6 +15,11 @@ namespace Microsoft.ReverseProxy.Core.Abstractions
     public sealed class Backend : IDeepCloneable<Backend>
     {
         /// <summary>
+        /// The Id for this backend. This needs to be globally unique.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
         /// Circuit breaker options.
         /// </summary>
         public CircuitBreakerOptions CircuitBreakerOptions { get; set; }
@@ -54,6 +59,7 @@ namespace Microsoft.ReverseProxy.Core.Abstractions
         {
             return new Backend
             {
+                Id = Id,
                 CircuitBreakerOptions = CircuitBreakerOptions?.DeepClone(),
                 QuotaOptions = QuotaOptions?.DeepClone(),
                 PartitioningOptions = PartitioningOptions?.DeepClone(),

--- a/src/ReverseProxy.Core/Configuration/DependencyInjection/ReverseProxyServiceCollectionExtensions.cs
+++ b/src/ReverseProxy.Core/Configuration/DependencyInjection/ReverseProxyServiceCollectionExtensions.cs
@@ -41,6 +41,15 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IReverseProxyBuilder LoadFromConfig(this IReverseProxyBuilder builder, IConfiguration config)
         {
             builder.Services.Configure<ProxyConfigOptions>(config);
+            builder.Services.AddOptions().PostConfigure<ProxyConfigOptions>(options =>
+            {
+                foreach (var (id, backend) in options.Backends)
+                {
+                    // The Object style config binding puts the id as the key in the dictionary, but later we want it on the
+                    // backend object as well.
+                    backend.Id = id;
+                }
+            });
             builder.Services.AddHostedService<ProxyConfigLoader>();
 
             return builder;

--- a/src/ReverseProxy.Core/Service/Config/ConfigErrors.cs
+++ b/src/ReverseProxy.Core/Service/Config/ConfigErrors.cs
@@ -22,6 +22,7 @@ namespace Microsoft.ReverseProxy.Core.Service
         internal const string ParsedRouteRuleMultiplePathMatchers = "ParsedRoute_RuleMultiplePathMatchers";
         internal const string ParsedRouteRuleInvalidMatcher = "ParsedRoute_RuleInvalidMatcher";
 
+        internal const string ConfigBuilderBackendIdMismatch = "ConfigBuilder_BackendIdMismatch";
         internal const string ConfigBuilderBackendException = "ConfigBuilder_BackendException";
         internal const string ConfigBuilderRouteException = "ConfigBuilder_RouteException";
     }

--- a/src/ReverseProxy.Core/Service/Config/DynamicConfigBuilder.cs
+++ b/src/ReverseProxy.Core/Service/Config/DynamicConfigBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
@@ -60,9 +61,16 @@ namespace Microsoft.ReverseProxy.Core.Service
             {
                 try
                 {
+                    if (id != backend.Id)
+                    {
+                        errorReporter.ReportError(ConfigErrors.ConfigBuilderBackendIdMismatch, id,
+                            $"The backend Id '{backend.Id}' and its lookup key '{id}' do not match.");
+                        continue;
+                    }
+
                     foreach (var filter in _filters)
                     {
-                        await filter.ConfigureBackendAsync(id, backend, cancellation);
+                        await filter.ConfigureBackendAsync(backend, cancellation);
                     }
 
                     configuredBackends[id] = backend;

--- a/src/ReverseProxy.Core/Service/Config/IProxyConfigFilter.cs
+++ b/src/ReverseProxy.Core/Service/Config/IProxyConfigFilter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ReverseProxy.Core.Service
         /// </summary>
         /// <param name="id">The id for the backend.</param>
         /// <param name="backend">The Backend instance to configure.</param>
-        Task ConfigureBackendAsync(string id, Backend backend, CancellationToken cancel);
+        Task ConfigureBackendAsync(Backend backend, CancellationToken cancel);
 
         /// <summary>
         /// Allows modification of a route configuration.

--- a/test/ReverseProxy.Core.Tests/Service/Config/DynamicConfigBuilderTests.cs
+++ b/test/ReverseProxy.Core.Tests/Service/Config/DynamicConfigBuilderTests.cs
@@ -71,6 +71,7 @@ namespace Microsoft.ReverseProxy.Core.Service.Tests
                 {
                     "backend1", new Backend
                     {
+                        Id = "backend1",
                         Destinations =
                         {
                             { "d1", new Destination { Address = TestAddress } }
@@ -131,6 +132,7 @@ namespace Microsoft.ReverseProxy.Core.Service.Tests
             Assert.Single(result.Value.Backends);
             var backend = result.Value.Backends["backend1"];
             Assert.NotNull(backend);
+            Assert.Equal("backend1", backend.Id);
             Assert.Single(backend.Destinations);
             var destination = backend.Destinations["d1"];
             Assert.NotNull(destination);
@@ -194,7 +196,7 @@ namespace Microsoft.ReverseProxy.Core.Service.Tests
 
         private class FixRouteHostFilter : IProxyConfigFilter
         {
-            public Task ConfigureBackendAsync(string id, Backend backend, CancellationToken cancel)
+            public Task ConfigureBackendAsync(Backend backend, CancellationToken cancel)
             {
                 return Task.CompletedTask;
             }
@@ -208,7 +210,7 @@ namespace Microsoft.ReverseProxy.Core.Service.Tests
 
         private class BackendAndRouteFilter : IProxyConfigFilter
         {
-            public Task ConfigureBackendAsync(string id, Backend backend, CancellationToken cancel)
+            public Task ConfigureBackendAsync(Backend backend, CancellationToken cancel)
             {
                 backend.HealthCheckOptions = new HealthCheckOptions() { Enabled = true, Interval = TimeSpan.FromSeconds(12) };
                 return Task.CompletedTask;
@@ -249,7 +251,7 @@ namespace Microsoft.ReverseProxy.Core.Service.Tests
 
         private class BackendAndRouteThrows : IProxyConfigFilter
         {
-            public Task ConfigureBackendAsync(string id, Backend backend, CancellationToken cancel)
+            public Task ConfigureBackendAsync(Backend backend, CancellationToken cancel)
             {
                 throw new NotFiniteNumberException("Test exception");
             }


### PR DESCRIPTION
This finishes off the feedback from #9 about inconsistencies between ProxyRoute having an Id and Backend not due to differences in the config structure.

The new field needs to be populated after config binding.