### PR TITLE
Cross target .NET 5.0 and 3.1

### DIFF
--- a/global.json
+++ b/global.json
@@ -12,6 +12,12 @@
       "dotnet/x86": [
         "$(MicrosoftNETCoreAppPackageVersion)",
         "3.1.0"
+      ],
+      "aspnetcore/x64": [
+        "3.1.0"
+      ],
+      "aspnetcore/x86": [
+        "3.1.0"
       ]
     }
   },

--- a/global.json
+++ b/global.json
@@ -6,10 +6,12 @@
     "dotnet": "5.0.100-preview.5.20251.2",
     "runtimes": {
       "dotnet/x64": [
-        "$(MicrosoftNETCoreAppPackageVersion)"
+        "$(MicrosoftNETCoreAppPackageVersion)",
+        "3.1.0"
       ],
       "dotnet/x86": [
-        "$(MicrosoftNETCoreAppPackageVersion)"
+        "$(MicrosoftNETCoreAppPackageVersion)",
+        "3.1.0"
       ]
     }
   },

--- a/samples/BenchmarkApp/BenchmarkApp.csproj
+++ b/samples/BenchmarkApp/BenchmarkApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp5.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.Sample/ReverseProxy.Sample.csproj
+++ b/samples/ReverseProxy.Sample/ReverseProxy.Sample.csproj
@@ -1,22 +1,17 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Microsoft.ReverseProxy.Sample</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)"/>
-    <InternalsVisibleTo Include="ReverseProxy.Sample.Tests"/>
+    <ProjectReference Include="..\..\src\ReverseProxy\Microsoft.ReverseProxy.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\ReverseProxy\Microsoft.ReverseProxy.csproj"/>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Properties\"/>
+    <Folder Include="Properties\" />
   </ItemGroup>
 
 </Project>

--- a/src/ReverseProxy/Microsoft.ReverseProxy.csproj
+++ b/src/ReverseProxy/Microsoft.ReverseProxy.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.ReverseProxy</RootNamespace>
   </PropertyGroup>

--- a/src/ReverseProxy/Service/Proxy/HttpProxy.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpProxy.cs
@@ -136,11 +136,11 @@ namespace Microsoft.ReverseProxy.Service.Proxy
 
             // :::::::::::::::::::::::::::::::::::::::::::::
             // :: Step 0: Disable ASP .NET Core limits for streaming requests
-            var isIncomingHttp2 = HttpProtocol.IsHttp2(context.Request.Protocol);
+            var isIncomingHttp2 = ProtocolHelper.IsHttp2(context.Request.Protocol);
 
             // NOTE: We heuristically assume gRPC-looking requests may require streaming semantics.
             // See https://github.com/microsoft/reverse-proxy/issues/118 for design discussion.
-            var isStreamingRequest = isIncomingHttp2 && GrpcProtocolHelper.IsGrpcContentType(context.Request.ContentType);
+            var isStreamingRequest = isIncomingHttp2 && ProtocolHelper.IsGrpcContentType(context.Request.ContentType);
             if (isStreamingRequest)
             {
                 DisableMinRequestBodyDataRateAndMaxRequestBodySize(context);

--- a/src/ReverseProxy/Utilities/ProtocolHelper.cs
+++ b/src/ReverseProxy/Utilities/ProtocolHelper.cs
@@ -5,9 +5,20 @@ using System;
 
 namespace Microsoft.ReverseProxy
 {
-    internal static class GrpcProtocolHelper
+    internal static class ProtocolHelper
     {
         internal const string GrpcContentType = "application/grpc";
+
+        public static bool IsHttp2(string protocol)
+        {
+#if NETCOREAPP5_0
+            return Microsoft.AspNetCore.Http.HttpProtocol.IsHttp2(protocol);
+#elif NETCOREAPP3_1
+            return StringComparer.OrdinalIgnoreCase.Equals("HTTP/2", protocol);
+#else
+            TFMs need to be updated
+#endif
+        }
 
         // NOTE: When https://github.com/dotnet/aspnetcore/issues/21265 is addressed,
         // this can be replaced with `MediaTypeHeaderValue.IsSubsetOf(...)`.

--- a/src/ReverseProxy/Utilities/ProtocolHelper.cs
+++ b/src/ReverseProxy/Utilities/ProtocolHelper.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ReverseProxy
 #elif NETCOREAPP3_1
             return StringComparer.OrdinalIgnoreCase.Equals("HTTP/2", protocol);
 #else
-            TFMs need to be updated
+#error A target framework was added to the project and needs to be added to this condition.
 #endif
         }
 

--- a/test/ReverseProxy.Tests/Microsoft.ReverseProxy.Tests.csproj
+++ b/test/ReverseProxy.Tests/Microsoft.ReverseProxy.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.ReverseProxy</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
#159 We were calling one new 5.0 API, Microsoft.AspNetCore.Http.HttpProtocol.IsHttp2. We don't strictly need it, but it does make a good example for how to #if around differences.