### PR TITLE
Change gh-pages commit author

### DIFF
--- a/.github/workflows/docfx_build.yml
+++ b/.github/workflows/docfx_build.yml
@@ -39,8 +39,8 @@ jobs:
           if ($LASTEXITCODE -eq 0) {
             Write-Host "No changes to commit!"
           } else {
-            git config --global user.name "$env:GITHUB_ACTOR"
-            git config --global user.email "$env:GITHUB_ACTOR@users.noreply.github.com"
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git commit -m"Updated docs from commit $env:GITHUB_SHA on $env:GITHUB_REF"
             git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
             git push origin gh-pages


### PR DESCRIPTION
Use the github-actions "bot" account as the author for the commit made to update the docs. Currently it uses the user who triggered the action (i.e. the committer of the PR that was merged in to master), but the GitHub Action is the one actually creating the content so this seems clearer

I borrowed this technique from https://github.com/peter-evans/create-pull-request/blob/25902ccdd12cde734aa20ca940ee41c07f33e906/src/cpr/create_pull_request.py#L17

After merging, I'll keep an eye on https://github.com/microsoft/reverse-proxy/actions to double check that it worked out.