### PR TITLE
Add AspNetCore dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,6 +5,10 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>47ec733ba79b196e4e09d0c89bad245155002353</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.App" Version="" CoherentParentDependency="Microsoft.NETCore.App">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha />
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20261.9">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,5 +12,7 @@
   <!--Package versions-->
   <PropertyGroup>
     <MicrosoftNETCoreAppPackageVersion>5.0.0-preview.4.20251.6</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftAspNetCoreAppPackageVersion>
+    </MicrosoftAspNetCoreAppPackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Adding the darc dependency for Microsoft.AspNetCore.App. Do not merge until after the branding updates in https://github.com/microsoft/reverse-proxy/pull/175

I wasn't able to get the local dependency update command to fill in the versions.

```
D:\github\reverse-proxy>darc update-dependencies --channel ".NET 5 Preview 5" --name Microsoft.AspNetCore.App
Checking for coherency updates...
fail: Microsoft.DotNet.Darc.Operations.Operation[0]
      Error: Failed to update dependencies.
Microsoft.DotNet.DarcLib.DarcException: Dependency Microsoft.AspNetCore.App has non-existent parent dependency Microsoft.NETCore.App
   at Microsoft.DotNet.DarcLib.Remote.GetRequiredCoherencyUpdatesAsync(IEnumerable`1 dependencies, IRemoteFactory remoteFactory) in /_/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs:line 498
   at Microsoft.DotNet.Darc.Operations.UpdateDependenciesOperation.CoherencyUpdatesAsync(IRemote barOnlyRemote, IRemoteFactory remoteFactory, List`1 currentDependencies, List`1 dependenciesToUpdate) in /_/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateDependenciesOperation.cs:line 284
   at Microsoft.DotNet.Darc.Operations.UpdateDependenciesOperation.ExecuteAsync() in /_/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateDependenciesOperation.cs:line 194
```

If I remove `CoherentParentDependency="Microsoft.NETCore.App"` then I get this instead:
```
D:\github\reverse-proxy>darc update-dependencies --channel ".NET 5 Preview 5" --name Microsoft.AspNetCore.App
Looking up latest build of https://github.com/dotnet/aspnetcore on .NET 5 Preview 5
Checking for coherency updates...
Found no dependencies to update.
```

