### PR TITLE
[Getting Started] Clarifying word usage

### DIFF
--- a/docs/docfx/articles/getting_started.md
+++ b/docs/docfx/articles/getting_started.md
@@ -84,7 +84,7 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 
 The configuration for YARP is defined in the appsettings.json file. It defines a set of:
 
-Routes - which map incoming requests to the backend clusters based on aspects of the request such as host name, path, method, request headers etc. Specifying a Host is the only required field. Routes are ordered, so the "app1" route needs to be defined first as "route2" will act as a catchall for all paths that have not already been matched. 
+Routes - which map incoming requests to the backend clusters based on aspects of the request such as host name, path, method, request headers etc. Specifying a Host is the only required field. Routes are ordered, so the "app1" route needs to be defined first since "route2" will act as a catchall for all paths that have not already been matched. 
 
 Backends - which are the clusters of destination servers that requests can be routed to and load balanced across.
 


### PR DESCRIPTION
I though it was saying that `"app1" needs to be defined as the value "route2"`