### PR TITLE
Preventing negative indexes

### DIFF
--- a/src/ReverseProxy/Service/Proxy/LoadBalancer.cs
+++ b/src/ReverseProxy/Service/Proxy/LoadBalancer.cs
@@ -42,6 +42,10 @@ namespace Microsoft.ReverseProxy.Service.Proxy
                     return endpoints[0];
                 case LoadBalancingMode.RoundRobin:
                     var offset = loadBalancingOptions.RoundRobinState.Increment();
+                    // Preventing negative indicies from being computed.
+                    // Masking instead of Math.Abs to preserve ordering of indices.
+                    // There will be a discontinuity when the sign of `offset` changes every 2B requests
+                    // if `endpoints.Count` does not happen to be a power of 2 but that should be acceptable.
                     return endpoints[(offset & 0x7FFFFFFF) % endpoints.Count];
                 case LoadBalancingMode.Random:
                     var random = _randomFactory.CreateRandomInstance();

--- a/src/ReverseProxy/Service/Proxy/LoadBalancer.cs
+++ b/src/ReverseProxy/Service/Proxy/LoadBalancer.cs
@@ -42,11 +42,10 @@ namespace Microsoft.ReverseProxy.Service.Proxy
                     return endpoints[0];
                 case LoadBalancingMode.RoundRobin:
                     var offset = loadBalancingOptions.RoundRobinState.Increment();
-                    // Preventing negative indicies from being computed by making offset unsigned.
+                    // Preventing negative indicies from being computed by masking off sign.
                     // Ordering of index selection is consistent across all offsets.
-                    // There will only be a discontinuity at Int32.MaxValue -> 0 and only
-                    // if 2^32 is not evenly divisible by endpoints.Count.
-                    return endpoints[(uint)offset % endpoints.Count];
+                    // There may be a discontinuity when the sign of offset changes.
+                    return endpoints[(offset & 0x7FFFFFFF) % endpoints.Count];
                 case LoadBalancingMode.Random:
                     var random = _randomFactory.CreateRandomInstance();
                     return endpoints[random.Next(endpointCount)];

--- a/src/ReverseProxy/Service/Proxy/LoadBalancer.cs
+++ b/src/ReverseProxy/Service/Proxy/LoadBalancer.cs
@@ -42,11 +42,11 @@ namespace Microsoft.ReverseProxy.Service.Proxy
                     return endpoints[0];
                 case LoadBalancingMode.RoundRobin:
                     var offset = loadBalancingOptions.RoundRobinState.Increment();
-                    // Preventing negative indicies from being computed.
-                    // Masking instead of Math.Abs to preserve ordering of indices.
-                    // There may be a discontinuity when the sign of `offset` changes every 2B requests
-                    // but that should be acceptable.
-                    return endpoints[(offset & 0x7FFFFFFF) % endpoints.Count];
+                    // Preventing negative indicies from being computed by making offset unsigned.
+                    // Ordering of index selection is consistent across all offsets.
+                    // There will only be a discontinuity at Int32.MaxValue -> 0 and only
+                    // if 2^32 is not evenly divisible by endpoints.Count.
+                    return endpoints[(uint)offset % endpoints.Count];
                 case LoadBalancingMode.Random:
                     var random = _randomFactory.CreateRandomInstance();
                     return endpoints[random.Next(endpointCount)];

--- a/src/ReverseProxy/Service/Proxy/LoadBalancer.cs
+++ b/src/ReverseProxy/Service/Proxy/LoadBalancer.cs
@@ -42,7 +42,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy
                     return endpoints[0];
                 case LoadBalancingMode.RoundRobin:
                     var offset = loadBalancingOptions.RoundRobinState.Increment();
-                    return endpoints[offset % endpoints.Count];
+                    return endpoints[(offset & 0x7FFFFFFF) % endpoints.Count];
                 case LoadBalancingMode.Random:
                     var random = _randomFactory.CreateRandomInstance();
                     return endpoints[random.Next(endpointCount)];

--- a/src/ReverseProxy/Service/Proxy/LoadBalancer.cs
+++ b/src/ReverseProxy/Service/Proxy/LoadBalancer.cs
@@ -44,8 +44,8 @@ namespace Microsoft.ReverseProxy.Service.Proxy
                     var offset = loadBalancingOptions.RoundRobinState.Increment();
                     // Preventing negative indicies from being computed.
                     // Masking instead of Math.Abs to preserve ordering of indices.
-                    // There will be a discontinuity when the sign of `offset` changes every 2B requests
-                    // if `endpoints.Count` does not happen to be a power of 2 but that should be acceptable.
+                    // There may be a discontinuity when the sign of `offset` changes every 2B requests
+                    // but that should be acceptable.
                     return endpoints[(offset & 0x7FFFFFFF) % endpoints.Count];
                 case LoadBalancingMode.Random:
                     var random = _randomFactory.CreateRandomInstance();


### PR DESCRIPTION
Addressing (#198)

This preserves ordering when `offest` is negative. Using Math.Abs would reverse the ordering when `offset` is negative.

There is a discontinuity when `offset` transitions from positive to negative. This should be acceptable "unfairness" over 2B requests.
For example with `endpoints.Count` of 5:
```
offset		computed index
2147483640	0
2147483641	1
2147483642	2
2147483643	3
2147483644	4
2147483645	0
2147483646	1
2147483647	2
-2147483648	0
-2147483647	1
-2147483646	2
-2147483645	3
-2147483644	4
```