### PR TITLE
Fix capitalization of activate.sh error message command suggestion

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -88,7 +88,7 @@ fi
 printf "${_MAGENTA}Enabled the .NET Core environment. Execute 'deactivate' to exit.${_RESET}\n"
 
 if [ ! -f "$DOTNET_ROOT/dotnet" ]; then
-    printf "${_YELLOW}.NET Core has not been installed yet. Run $DIR/restore.sh to install it.${_RESET}\n"
+    printf "${_YELLOW}.NET Core has not been installed yet. Run $DIR/Restore.sh to install it.${_RESET}\n"
 else
     printf "dotnet = $DOTNET_ROOT/dotnet\n"
 fi


### PR DESCRIPTION
`activate.sh` prompts to install .NET Core with a shell script, however the `Restore.sh` file on disk begins with a capital letter. Since .sh shell scripts are usually run in Linuxy environments and Linuxy environments generally have case-sensitive filesystems, the prompt should also match the file capitalization.

It's a very minor change, but hopefully it will reduce friction for devs trying to get this project to build for the first time.