### PR TITLE
Moved to use of IRandomFactory in ProxyInvokerMiddleware

### DIFF
--- a/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
+++ b/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
@@ -19,7 +19,7 @@ namespace Microsoft.ReverseProxy.Middleware
     /// </summary>
     internal class ProxyInvokerMiddleware
     {
-        private readonly IRandomFactory _randomFactory = new RandomFactory();
+        private readonly IRandomFactory _randomFactory;
         private readonly RequestDelegate _next; // Unused, this middleware is always terminal
         private readonly ILogger _logger;
         private readonly IOperationLogger<ProxyInvokerMiddleware> _operationLogger;
@@ -29,12 +29,14 @@ namespace Microsoft.ReverseProxy.Middleware
             RequestDelegate next,
             ILogger<ProxyInvokerMiddleware> logger,
             IOperationLogger<ProxyInvokerMiddleware> operationLogger,
-            IHttpProxy httpProxy)
+            IHttpProxy httpProxy,
+            IRandomFactory randomFactory)
         {
             _next = next ?? throw new ArgumentNullException(nameof(next));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _operationLogger = operationLogger ?? throw new ArgumentNullException(nameof(operationLogger));
             _httpProxy = httpProxy ?? throw new ArgumentNullException(nameof(httpProxy));
+            _randomFactory = randomFactory ?? throw new ArgumentNullException(nameof(randomFactory));
         }
 
         /// <inheritdoc/>

--- a/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
+++ b/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
@@ -19,7 +19,7 @@ namespace Microsoft.ReverseProxy.Middleware
     /// </summary>
     internal class ProxyInvokerMiddleware
     {
-        private readonly Random _random = new Random();
+        private readonly IRandomFactory _randomFactory = new RandomFactory();
         private readonly RequestDelegate _next; // Unused, this middleware is always terminal
         private readonly ILogger _logger;
         private readonly IOperationLogger<ProxyInvokerMiddleware> _operationLogger;
@@ -58,8 +58,9 @@ namespace Microsoft.ReverseProxy.Middleware
             var destination = destinations[0];
             if (destinations.Count > 1)
             {
+                var random = _randomFactory.CreateRandomInstance();
                 Log.MultipleDestinationsAvailable(_logger, backend.BackendId);
-                destination = destinations[_random.Next(destinations.Count)];
+                destination = destinations[random.Next(destinations.Count)];
             }
 
             var destinationConfig = destination.Config.Value;

--- a/src/ReverseProxy/Service/HealthProbe/BackendProberFactory.cs
+++ b/src/ReverseProxy/Service/HealthProbe/BackendProberFactory.cs
@@ -25,17 +25,23 @@ namespace Microsoft.ReverseProxy.Service.HealthProbe
         /// <summary>
         /// Initializes a new instance of the <see cref="BackendProberFactory"/> class.
         /// </summary>
-        public BackendProberFactory(IMonotonicTimer timer, ILogger<BackendProber> logger, IOperationLogger<BackendProber> operationLogger, IHealthProbeHttpClientFactory httpClientFactory)
+        public BackendProberFactory(
+            IMonotonicTimer timer,
+            ILogger<BackendProber> logger,
+            IOperationLogger<BackendProber> operationLogger,
+            IHealthProbeHttpClientFactory httpClientFactory,
+            IRandomFactory randomFactory)
         {
             Contracts.CheckValue(timer, nameof(timer));
             Contracts.CheckValue(logger, nameof(logger));
             Contracts.CheckValue(operationLogger, nameof(operationLogger));
             Contracts.CheckValue(httpClientFactory, nameof(httpClientFactory));
+            Contracts.CheckValue(randomFactory, nameof(randomFactory));
 
             _timer = timer;
             _logger = logger;
             _httpClientFactory = httpClientFactory;
-            _randomFactory = new RandomFactory();
+            _randomFactory = randomFactory;
             _operationLogger = operationLogger;
         }
 

--- a/test/ReverseProxy.Tests/Service/HealthProbe/BackendProberFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthProbe/BackendProberFactoryTests.cs
@@ -8,6 +8,7 @@ using Microsoft.ReverseProxy.Abstractions.Telemetry;
 using Microsoft.ReverseProxy.Abstractions.Time;
 using Microsoft.ReverseProxy.RuntimeModel;
 using Microsoft.ReverseProxy.Service.Management;
+using Microsoft.ReverseProxy.Utilities;
 using Moq;
 using Tests.Common;
 using Xunit;
@@ -18,6 +19,7 @@ namespace Microsoft.ReverseProxy.Service.HealthProbe
     {
         private readonly Mock<IMonotonicTimer> _timer;
         private readonly Mock<IOperationLogger<BackendProber>> _operationLogger;
+        private readonly Mock<IRandomFactory> _randomFactory;
         private readonly ILogger<BackendProber> _logger;
         private readonly IHealthProbeHttpClientFactory _httpClientFactory;
 
@@ -27,13 +29,14 @@ namespace Microsoft.ReverseProxy.Service.HealthProbe
             _logger = NullLogger<BackendProber>.Instance;
             _httpClientFactory = new HealthProbeHttpClientFactory();
             _operationLogger = new Mock<IOperationLogger<BackendProber>>();
+            _randomFactory = new Mock<IRandomFactory>();
         }
 
         [Fact]
         public void WithNullParameter_BackendProberFactory_NotCreatebackendProber()
         {
             // Set up the factory.
-            var factory = new BackendProberFactory(_timer.Object, _logger, _operationLogger.Object, _httpClientFactory);
+            var factory = new BackendProberFactory(_timer.Object, _logger, _operationLogger.Object, _httpClientFactory, _randomFactory.Object);
 
             // Create prober should fail when parameter are set to null.
             Assert.Throws<ArgumentNullException>(() => factory.CreateBackendProber(null, null, null));
@@ -43,7 +46,7 @@ namespace Microsoft.ReverseProxy.Service.HealthProbe
         public void BackendProberFactory_CreateBackendProber()
         {
             // Set up the factory.
-            var factory = new BackendProberFactory(_timer.Object, _logger, _operationLogger.Object, _httpClientFactory);
+            var factory = new BackendProberFactory(_timer.Object, _logger, _operationLogger.Object, _httpClientFactory, _randomFactory.Object);
 
             // Create probers.
             var backendId = "example";


### PR DESCRIPTION
closes #186 

Saw this one show up in my email and figured it was an easy fix. Migrated the initialization to use a RandomFactory and then grab a new instance of System.Random from there. 