### PR TITLE
CustomHeaderSessionAffinityProviderOptions replaces Settings collection

### DIFF
--- a/src/ReverseProxy/Abstractions/BackendDiscovery/Contract/CustomHeaderSessionAffinityProviderOptions.cs
+++ b/src/ReverseProxy/Abstractions/BackendDiscovery/Contract/CustomHeaderSessionAffinityProviderOptions.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.ReverseProxy.Abstractions.BackendDiscovery.Contract
+{
+    /// <summary>
+    /// Defines customer header specific affinity provider options.
+    /// </summary>
+    public class CustomHeaderSessionAffinityProviderOptions
+    {
+        public static readonly string DefaultCustomHeaderName = "X-Microsoft-Proxy-Affinity";
+
+        /// <summary>
+        /// Name of a custom header storing an affinity key.
+        /// </summary>
+        public string CustomHeaderName { get; set; } = DefaultCustomHeaderName;
+    }
+}

--- a/test/ReverseProxy.Tests/Service/SessionAffinity/CookieSessionAffinityProviderTests.cs
+++ b/test/ReverseProxy.Tests/Service/SessionAffinity/CookieSessionAffinityProviderTests.cs
@@ -55,6 +55,15 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
         }
 
         [Fact]
+        public void Ctor_ProviderOptionsIsNull_Throw()
+        {
+            Assert.Throws<ArgumentNullException>(() => new CookieSessionAffinityProvider(
+                null,
+                AffinityTestHelper.GetDataProtector().Object,
+                AffinityTestHelper.GetLogger<CookieSessionAffinityProvider>().Object));
+        }
+
+        [Fact]
         public void AffinitizedRequest_AffinityKeyIsNotExtracted_SetKeyOnResponse()
         {
             var provider = new CookieSessionAffinityProvider(


### PR DESCRIPTION
`CustomHeaderSessionAffinityProvider` uses a new option type to retrieve the custom header name instead of an entry in `SessionAffinityOptions.Settings` collection to be consistent with `CookieSessionAffinityProvider`.

Fixes #236 