### PR TITLE
TargetFramework set to .net5.0

### DIFF
--- a/docs/docfx/articles/getting_started.md
+++ b/docs/docfx/articles/getting_started.md
@@ -7,7 +7,7 @@ title: Getting Started with YARP
 
 YARP is designed as a library that provides the core proxy functionality which you can then customize by adding or replacing modules. YARP is currently provided as a NuGet package and code snippets. We plan on providing a project template and pre-built exe in the future. 
 
-YARP supports ASP.NET Core 3.1 and 5.0.0 Preview 4 or later. You can download the .NET 5 Preview 4 SDK from https://dotnet.microsoft.com/download/dotnet/5.0.
+YARP supports ASP.NET Core 3.1 and 5.0.0 Preview 4 or later. You can download the .NET 5 Preview 4 SDK from https://dotnet.microsoft.com/download/dotnet/5.0. It requires Visual Studio 2019 (v16.6) or newer.
 
 ### Create a new project
 
@@ -27,7 +27,7 @@ Open the Project and make sure it includes the appropriate target framework:
  
  ```
 <PropertyGroup>
-  <TargetFramework>netcoreapp5.0</TargetFramework>
+  <TargetFramework>net5.0</TargetFramework>
 </PropertyGroup> 
 ```
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-    "version": "5.0.100-preview.6.20266.3"
+    "version": "5.0",
+    "rollForward": "latestMinor"
   },
   "tools": {
     "dotnet": "5.0.100-preview.6.20266.3",

--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
   "sdk": {
-    "version": "5.0",
-    "rollForward": "latestMinor"
+    "version": "5.0.100-preview.6.20266.3"
   },
   "tools": {
     "dotnet": "5.0.100-preview.6.20266.3",

--- a/samples/BenchmarkApp/BenchmarkApp.csproj
+++ b/samples/BenchmarkApp/BenchmarkApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.Sample/ReverseProxy.Sample.csproj
+++ b/samples/ReverseProxy.Sample/ReverseProxy.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Microsoft.ReverseProxy.Sample</RootNamespace>
   </PropertyGroup>

--- a/samples/SampleClient/SampleClient.csproj
+++ b/samples/SampleClient/SampleClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/samples/SampleServer/SampleServer.csproj
+++ b/samples/SampleServer/SampleServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <RootNamespace>SampleServer</RootNamespace>
   </PropertyGroup>

--- a/src/ReverseProxy/Microsoft.ReverseProxy.csproj
+++ b/src/ReverseProxy/Microsoft.ReverseProxy.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Reverse proxy toolkit for building fast proxy servers in .NET using the infrastructure from ASP.NET and .NET</Description>
-    <TargetFrameworks>netcoreapp5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.ReverseProxy</RootNamespace>
   </PropertyGroup>

--- a/test/ReverseProxy.Tests/Microsoft.ReverseProxy.Tests.csproj
+++ b/test/ReverseProxy.Tests/Microsoft.ReverseProxy.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.ReverseProxy</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
TFM set to `.net5.0` in all project. Additionally, `rollForward` is enabled and set to `latestMinor`

**Note.** `dotnet new` does **not** support `.net5.0` TFM, yet.

Fixes #189 