### PR TITLE
Update getting_started.md

### DIFF
--- a/docs/docfx/articles/getting_started.md
+++ b/docs/docfx/articles/getting_started.md
@@ -17,7 +17,7 @@ Start by creating an "Empty" ASP.NET Core application using the command line:
 dotnet new web -n MyProxy 
 ```
 
-use `-f` to specify `netcoreapp3.1` or `netcoreapp5.0`.
+use `-f` to specify `netcoreapp3.1` or `net5.0`.
 
 Or create a new ASP.NET Core web application in Visual Studio, and choose "Empty" for the project template. 
 


### PR DESCRIPTION
Fix flag in getting started for `dotnet new` to be `net5.0` instead of `netcoreapp5.0`