### PR TITLE
AddAuthorization DI dependency

### DIFF
--- a/src/ReverseProxy/Configuration/DependencyInjection/ReverseProxyServiceCollectionExtensions.cs
+++ b/src/ReverseProxy/Configuration/DependencyInjection/ReverseProxyServiceCollectionExtensions.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddBackgroundWorkers();
 
             services.AddDataProtection();
+            services.AddAuthorization();
 
             return builder;
         }

--- a/test/ReverseProxy.Tests/Service/Config/DynamicConfigBuilderTests.cs
+++ b/test/ReverseProxy.Tests/Service/Config/DynamicConfigBuilderTests.cs
@@ -22,7 +22,6 @@ namespace Microsoft.ReverseProxy.Service.Tests
         {
             var servicesBuilder = new ServiceCollection();
             servicesBuilder.AddOptions();
-            servicesBuilder.AddAuthorization();
             var proxyBuilder = servicesBuilder.AddReverseProxy();
             configProxy?.Invoke(proxyBuilder);
             servicesBuilder.AddSingleton(clusters);


### PR DESCRIPTION
Follow up to #265, I missed a DI dependency. Your average app will already have this from AddControllers, or if they configure AuthZ themselves, but a basic app might not have this dependency. The libraries no-op if they're not used, so adding it is harmless.

```
Unhandled exception. System.AggregateException: Some services are not able to be constructed (Error while validating the service descriptor 'ServiceType: Microsoft.ReverseProxy.Service.IDynamicConfigBuilder Lifetime: Singleton ImplementationType: Microsoft.ReverseProxy.Service.DynamicConfigBuilder': Unable to resolve service for type 'Microsoft.AspNetCore.Authorization.IAuthorizationPolicyProvider' while attempting to activate 'Microsoft.ReverseProxy.Service.RouteValidator'.) (Error while validating the service descriptor 'ServiceType: Microsoft.ReverseProxy.Service.IRouteValidator Lifetime: Singleton ImplementationType: Microsoft.ReverseProxy.Service.RouteValidator': Unable to resolve service for type 'Microsoft.AspNetCore.Authorization.IAuthorizationPolicyProvider' while attempting to activate 'Microsoft.ReverseProxy.Service.RouteValidator'.) (Error while validating the service descriptor 'ServiceType: Microsoft.ReverseProxy.Abstractions.IReverseProxyConfigManager Lifetime: Singleton ImplementationType: Microsoft.ReverseProxy.Service.Management.ReverseProxyConfigManager': Unable to resolve service for type 'Microsoft.AspNetCore.Authorization.IAuthorizationPolicyProvider' while attempting to activate 'Microsoft.ReverseProxy.Service.RouteValidator'.) (Error while validating the service descriptor 'ServiceType: Microsoft.Extensions.Hosting.IHostedService Lifetime: Singleton ImplementationType: Microsoft.ReverseProxy.Configuration.ProxyConfigLoader': Unable to resolve service for type 'Microsoft.AspNetCore.Authorization.IAuthorizationPolicyProvider' while attempting to activate 'Microsoft.ReverseProxy.Service.RouteValidator'.)
 ---> System.InvalidOperationException: Error while validating the service descriptor 'ServiceType: Microsoft.ReverseProxy.Service.IDynamicConfigBuilder Lifetime: Singleton ImplementationType: Microsoft.ReverseProxy.Service.DynamicConfigBuilder': Unable to resolve service for type 'Microsoft.AspNetCore.Authorization.IAuthorizationPolicyProvider' while attempting to activate 'Microsoft.ReverseProxy.Service.RouteValidator'.
 ---> System.InvalidOperationException: Unable to resolve service for type 'Microsoft.AspNetCore.Authorization.IAuthorizationPolicyProvider' while attempting to activate 'Microsoft.ReverseProxy.Service.RouteValidator'.
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateArgumentCallSites(Type serviceType, Type implementationType, CallSiteChain callSiteChain, ParameterInfo[] parameters, Boolean throwIfCallSiteNotFound)
```

Reported by a partner offline.