### PR TITLE
Add instructions for using daily builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ If you're having trouble building the project, or developing in Visual Studio, p
 
 # Getting started
 
+- See our [Getting Started](https://microsoft.github.io/reverse-proxy/articles/getting_started.html) docs.
 - Try our [previews](https://github.com/microsoft/reverse-proxy/releases).
-- Check out our [docs](https://microsoft.github.io/reverse-proxy/) and tutorials, we'll be publishing more as the project develops!
 - Try our latest [daily build](/docs/DailyBuilds.md).
 
 # Roadmap

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ If you're having trouble building the project, or developing in Visual Studio, p
 
 # Getting started
 
-Take a look at the [sample apps](samples/), for some examples of how to use YARP. We'll be publishing more [docs](https://microsoft.github.io/reverse-proxy/) and tutorials as the project develops!
+- Try our [previews](https://github.com/microsoft/reverse-proxy/releases).
+- Check out our [docs](https://microsoft.github.io/reverse-proxy/) and tutorials, we'll be publishing more as the project develops!
+- Try our latest [daily build](/docs/DailyBuilds.md).
 
 # Roadmap
 

--- a/docs/DailyBuilds.md
+++ b/docs/DailyBuilds.md
@@ -1,0 +1,32 @@
+How to get daily builds of YARP
+===============================
+
+Daily builds include the latest source code changes. They are not supported for production use and are subject to frequent changes, but we strive to make sure daily builds function correctly.
+
+If you want to download the latest daily build and use it in a project, then you need to:
+
+- Obtain the latest [build of the .NET Core SDK](https://github.com/dotnet/core-sdk#installers-and-binaries).
+- Add a NuGet.Config to your project directory with the following content:
+
+  ```xml
+  <?xml version="1.0" encoding="utf-8"?>
+  <configuration>
+      <packageSources>
+          <clear />
+          <add key="net5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+          <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+      </packageSources>
+  </configuration>
+  ```
+
+  *NOTE: This NuGet.Config should be with your application unless you want nightly packages to potentially start being restored for other apps on the machine.*
+
+Some features, such as new target frameworks, may require prerelease tooling builds for Visual Studio.
+These are available in the [Visual Studio Preview](https://www.visualstudio.com/vs/preview/).
+
+#### To debug daily builds using Visual Studio
+
+* *Enable Source Link support* in Visual Studio should be enabled.
+* *Enable source server support* in Visual should be enabled.
+* *Enable Just My Code* should be disabled
+* Under Symbols enable the *Microsoft Symbol Servers* setting.

--- a/docs/DailyBuilds.md
+++ b/docs/DailyBuilds.md
@@ -21,6 +21,8 @@ If you want to download the latest daily build and use it in a project, then you
 
   *NOTE: This NuGet.Config should be with your application unless you want nightly packages to potentially start being restored for other apps on the machine.*
 
+Then follow the [Getting Started](https://microsoft.github.io/reverse-proxy/articles/getting_started.html) guide to set up a project and add the nuget package dependency. Note daily builds use a higher preview version than given in the docs.
+
 Some features, such as new target frameworks, may require prerelease tooling builds for Visual Studio.
 These are available in the [Visual Studio Preview](https://www.visualstudio.com/vs/preview/).
 


### PR DESCRIPTION
We've started publishing daily builds to a feed so this adds instructions for accessing them. They're copied wholesale from [AspNetCore](https://github.com/dotnet/aspnetcore/blob/master/docs/DailyBuilds.md).

I'm also updating the readme to recommend previews and daily builds.

Fixes #271