### PR TITLE
Remove trivial uses of operation logging

### DIFF
--- a/src/ReverseProxy/Middleware/AffinitizeRequestMiddleware.cs
+++ b/src/ReverseProxy/Middleware/AffinitizeRequestMiddleware.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Microsoft.ReverseProxy.Abstractions.Telemetry;
 using Microsoft.ReverseProxy.RuntimeModel;
 using Microsoft.ReverseProxy.Service.SessionAffinity;
 
@@ -20,19 +19,16 @@ namespace Microsoft.ReverseProxy.Middleware
         private readonly Random _random = new Random();
         private readonly RequestDelegate _next;
         private readonly IDictionary<string, ISessionAffinityProvider> _sessionAffinityProviders;
-        private readonly IOperationLogger<AffinitizeRequestMiddleware> _operationLogger;
         private readonly ILogger _logger;
 
         public AffinitizeRequestMiddleware(
             RequestDelegate next,
             IEnumerable<ISessionAffinityProvider> sessionAffinityProviders,
-            IOperationLogger<AffinitizeRequestMiddleware> operationLogger,
             ILogger<AffinitizeRequestMiddleware> logger)
         {
             _next = next ?? throw new ArgumentNullException(nameof(next));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _sessionAffinityProviders = sessionAffinityProviders.ToProviderDictionary();
-            _operationLogger = operationLogger ?? throw new ArgumentNullException(nameof(operationLogger));
         }
 
         public Task Invoke(HttpContext context)
@@ -62,7 +58,7 @@ namespace Microsoft.ReverseProxy.Middleware
                         destinationsFeature.Destinations = chosenDestination;
                     }
 
-                    _operationLogger.Execute("ReverseProxy.AffinitizeRequest", () => AffinitizeRequest(context, options, chosenDestination));
+                    AffinitizeRequest(context, options, chosenDestination);
                 }
             }
 

--- a/src/ReverseProxy/Middleware/LoadBalancingMiddleware.cs
+++ b/src/ReverseProxy/Middleware/LoadBalancingMiddleware.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Microsoft.ReverseProxy.Abstractions.Telemetry;
 using Microsoft.ReverseProxy.RuntimeModel;
 using Microsoft.ReverseProxy.Service.Proxy;
 
@@ -17,19 +16,16 @@ namespace Microsoft.ReverseProxy.Middleware
     internal class LoadBalancingMiddleware
     {
         private readonly ILogger _logger;
-        private readonly IOperationLogger<LoadBalancingMiddleware> _operationLogger;
         private readonly ILoadBalancer _loadBalancer;
         private readonly RequestDelegate _next;
 
         public LoadBalancingMiddleware(
             RequestDelegate next,
             ILogger<LoadBalancingMiddleware> logger,
-            IOperationLogger<LoadBalancingMiddleware> operationLogger,
             ILoadBalancer loadBalancer)
         {
             _next = next ?? throw new ArgumentNullException(nameof(next));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _operationLogger = operationLogger ?? throw new ArgumentNullException(nameof(operationLogger));
             _loadBalancer = loadBalancer ?? throw new ArgumentNullException(nameof(loadBalancer));
         }
 
@@ -42,9 +38,7 @@ namespace Microsoft.ReverseProxy.Middleware
             var loadBalancingOptions = cluster.Config.Value?.LoadBalancingOptions
                 ?? new ClusterConfig.ClusterLoadBalancingOptions(default);
 
-            var destination = _operationLogger.Execute(
-                "ReverseProxy.PickDestination",
-                () => _loadBalancer.PickDestination(destinations, in loadBalancingOptions));
+            var destination = _loadBalancer.PickDestination(destinations, in loadBalancingOptions);
 
             if (destination == null)
             {

--- a/test/ReverseProxy.Tests/Middleware/AffinitizeRequestMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/AffinitizeRequestMiddlewareTests.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Microsoft.ReverseProxy.Abstractions.Telemetry;
 using Microsoft.ReverseProxy.RuntimeModel;
 using Microsoft.ReverseProxy.Service.SessionAffinity;
 using Moq;
@@ -35,7 +34,6 @@ namespace Microsoft.ReverseProxy.Middleware
                     return Task.CompletedTask;
                 },
                 providers.Select(p => p.Object),
-                GetOperationLogger(),
                 new Mock<ILogger<AffinitizeRequestMiddleware>>().Object);
             var context = new DefaultHttpContext();
             context.Features.Set(cluster);
@@ -69,7 +67,6 @@ namespace Microsoft.ReverseProxy.Middleware
                 return Task.CompletedTask;
             },
                 providers.Select(p => p.Object),
-                GetOperationLogger(),
                 logger.Object);
             var context = new DefaultHttpContext();
             context.Features.Set(cluster);
@@ -103,7 +100,6 @@ namespace Microsoft.ReverseProxy.Middleware
                     return Task.CompletedTask;
                 },
                 new ISessionAffinityProvider[0],
-                GetOperationLogger(),
                 logger.Object);
             var context = new DefaultHttpContext();
             context.Features.Set(cluster);
@@ -117,13 +113,6 @@ namespace Microsoft.ReverseProxy.Middleware
                 l => l.Log(LogLevel.Warning, EventIds.NoDestinationOnClusterToEstablishRequestAffinity, It.IsAny<It.IsAnyType>(), null, (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
                 Times.Once);
             Assert.Equal(0, destinationFeature.Destinations.Count);
-        }
-
-        private IOperationLogger<AffinitizeRequestMiddleware> GetOperationLogger()
-        {
-            var result = new Mock<IOperationLogger<AffinitizeRequestMiddleware>>(MockBehavior.Strict);
-            result.Setup(l => l.Execute(It.IsAny<string>(), It.IsAny<Action>())).Callback((string name, Action callback) => callback());
-            return result.Object;
         }
 
         private Mock<ISessionAffinityProvider> GetProviderForRandomDestination(string mode, IReadOnlyList<DestinationInfo> destinations, Action<ISessionAffinityProvider> callback)

--- a/test/ReverseProxy.Tests/Middleware/AffinitizedDestinationLookupMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/AffinitizedDestinationLookupMiddlewareTests.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Microsoft.ReverseProxy.Abstractions.Telemetry;
 using Microsoft.ReverseProxy.Service.SessionAffinity;
 using Microsoft.ReverseProxy.Signals;
 using Moq;
@@ -37,7 +36,6 @@ namespace Microsoft.ReverseProxy.Middleware
                     return Task.CompletedTask;
                 },
                 providers.Select(p => p.Object), new IAffinityFailurePolicy[0],
-                GetOperationLogger(false),
                 new Mock<ILogger<AffinitizedDestinationLookupMiddleware>>().Object);
             var context = new DefaultHttpContext();
             context.Features.Set(cluster);
@@ -85,7 +83,6 @@ namespace Microsoft.ReverseProxy.Middleware
                     return Task.CompletedTask;
                 },
                 providers.Select(p => p.Object), failurePolicies.Select(p => p.Object),
-                GetOperationLogger(true),
                 logger.Object);
             var context = new DefaultHttpContext();
             context.Features.Set(cluster);
@@ -105,17 +102,6 @@ namespace Microsoft.ReverseProxy.Middleware
                     l => l.Log(LogLevel.Warning, EventIds.AffinityResolutionFailedForCluster, It.IsAny<It.IsAnyType>(), null, (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
                     Times.Once);
             }
-        }
-
-        private IOperationLogger<AffinitizedDestinationLookupMiddleware> GetOperationLogger(bool callFailurePolicy)
-        {
-            var result = new Mock<IOperationLogger<AffinitizedDestinationLookupMiddleware>>(MockBehavior.Strict);
-            result.Setup(l => l.Execute(It.IsAny<string>(), It.IsAny<Func<AffinityResult>>())).Returns((string name, Func<AffinityResult> callback) => callback());
-            if (callFailurePolicy)
-            {
-                result.Setup(l => l.ExecuteAsync(It.IsAny<string>(), It.IsAny<Func<Task<bool>>>())).Returns(async (string name, Func<Task<bool>> callback) => await callback());
-            }
-            return result.Object;
         }
     }
 }


### PR DESCRIPTION
- The operation logger isn't a profiler API and should only be used for non trivial work (like proxying the request to the destination).