### PR TITLE
Remove CreateUpgradableClient from the client factory 

### DIFF
--- a/src/ReverseProxy/Service/Proxy/HttpProxy.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpProxy.cs
@@ -98,11 +98,11 @@ namespace Microsoft.ReverseProxy.Service.Proxy
 
             if (isUpgrade)
             {
-                return UpgradableProxyAsync(context, upgradeFeature, request, transforms, httpClientFactory.CreateUpgradableClient(), proxyTelemetryContext, shortCancellation, longCancellation);
+                return UpgradableProxyAsync(context, upgradeFeature, request, transforms, httpClientFactory.CreateClient(), proxyTelemetryContext, shortCancellation, longCancellation);
             }
             else
             {
-                return NormalProxyAsync(context, request, transforms, httpClientFactory.CreateNormalClient(), proxyTelemetryContext, shortCancellation, longCancellation);
+                return NormalProxyAsync(context, request, transforms, httpClientFactory.CreateClient(), proxyTelemetryContext, shortCancellation, longCancellation);
             }
         }
 

--- a/src/ReverseProxy/Service/Proxy/Infrastructure/IProxyHttpClientFactory.cs
+++ b/src/ReverseProxy/Service/Proxy/Infrastructure/IProxyHttpClientFactory.cs
@@ -23,30 +23,13 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Infrastructure
         /// </summary>
         /// <remarks>
         /// <para>
-        /// Each call to <see cref="CreateNormalClient()"/> is guaranteed
-        /// to return a new <see cref="HttpMessageInvoker"/> instance.
-        /// It is generally not necessary to dispose of the <see cref="HttpMessageInvoker"/>
-        /// as the <see cref="IProxyHttpClientFactory"/> tracks and disposes resources
-        /// used by the <see cref="HttpClient"/>.
-        /// </para>
-        /// </remarks>
-        HttpMessageInvoker CreateNormalClient();
-
-        /// <summary>
-        /// Creates and configures an <see cref="HttpMessageInvoker"/> instance
-        /// that can be used for proxying upgradable requests to an upstream server.
-        /// Upgradable requests are treated differently than normal requests because
-        /// upgradable connections cannot be reused.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// Each call to <see cref="CreateUpgradableClient()"/> is guaranteed
+        /// Each call to <see cref="CreateClient()"/> is guaranteed
         /// to return a new <see cref="HttpMessageInvoker"/> instance.
         /// It is generally not necessary to dispose of the <see cref="HttpMessageInvoker"/>
         /// as the <see cref="IProxyHttpClientFactory"/> tracks and disposes resources
         /// used by the <see cref="HttpMessageInvoker"/>.
         /// </para>
         /// </remarks>
-        HttpMessageInvoker CreateUpgradableClient();
+        HttpMessageInvoker CreateClient();
     }
 }

--- a/test/ReverseProxy.Tests/Service/Proxy/HttpProxyTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/HttpProxyTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return response;
                 });
             var factoryMock = new Mock<IProxyHttpClientFactory>();
-            factoryMock.Setup(f => f.CreateNormalClient()).Returns(client);
+            factoryMock.Setup(f => f.CreateClient()).Returns(client);
 
             var proxyTelemetryContext = new ProxyTelemetryContext(
                 clusterId: "be1",
@@ -189,7 +189,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return response;
                 });
             var factoryMock = new Mock<IProxyHttpClientFactory>();
-            factoryMock.Setup(f => f.CreateNormalClient()).Returns(client);
+            factoryMock.Setup(f => f.CreateClient()).Returns(client);
 
             var proxyTelemetryContext = new ProxyTelemetryContext(
                 clusterId: "be1",
@@ -286,7 +286,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return response;
                 });
             var factoryMock = new Mock<IProxyHttpClientFactory>();
-            factoryMock.Setup(f => f.CreateNormalClient()).Returns(client);
+            factoryMock.Setup(f => f.CreateClient()).Returns(client);
 
             var proxyTelemetryContext = new ProxyTelemetryContext(
                 clusterId: "be1",
@@ -368,7 +368,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return response;
                 });
             var factoryMock = new Mock<IProxyHttpClientFactory>();
-            factoryMock.Setup(f => f.CreateNormalClient()).Returns(client);
+            factoryMock.Setup(f => f.CreateClient()).Returns(client);
 
             var proxyTelemetryContext = new ProxyTelemetryContext(
                 clusterId: "be1",
@@ -433,7 +433,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return response;
                 });
             var factoryMock = new Mock<IProxyHttpClientFactory>();
-            factoryMock.Setup(f => f.CreateUpgradableClient()).Returns(client);
+            factoryMock.Setup(f => f.CreateClient()).Returns(client);
 
             var proxyTelemetryContext = new ProxyTelemetryContext(
                 clusterId: "be1",
@@ -502,7 +502,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return response;
                 });
             var factoryMock = new Mock<IProxyHttpClientFactory>();
-            factoryMock.Setup(f => f.CreateUpgradableClient()).Returns(client);
+            factoryMock.Setup(f => f.CreateClient()).Returns(client);
 
             var proxyTelemetryContext = new ProxyTelemetryContext(
                 clusterId: "be1",

--- a/test/ReverseProxy.Tests/Service/Proxy/Infrastructure/ProxyHttpClientFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/Infrastructure/ProxyHttpClientFactoryTests.cs
@@ -16,30 +16,14 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
         }
 
         [Fact]
-        public void CreateNormalClient_Works()
+        public void CreateClient_Works()
         {
             // Arrange
             var factory = new ProxyHttpClientFactory();
 
             // Act
-            var actual1 = factory.CreateNormalClient();
-            var actual2 = factory.CreateNormalClient();
-
-            // Assert
-            Assert.NotNull(actual1);
-            Assert.NotNull(actual2);
-            Assert.NotSame(actual2, actual1);
-        }
-
-        [Fact]
-        public void CreateUpgradableClient_Works()
-        {
-            // Arrange
-            var factory = new ProxyHttpClientFactory();
-
-            // Act
-            var actual1 = factory.CreateUpgradableClient();
-            var actual2 = factory.CreateUpgradableClient();
+            var actual1 = factory.CreateClient();
+            var actual2 = factory.CreateClient();
 
             // Assert
             Assert.NotNull(actual1);


### PR DESCRIPTION
Contributes to #137. We still need to finish the design around the client factory but this part was well understood. The separate handler with its own config is not needed for WebSocket/Upgrade scenarios. The pooling setting was an optimization copied from ClientWebSocket. 

I need to do some refactoring in HttpProxy and it will be easier if I get this out of the way first.