### PR TITLE
Mitigate POST issue in IIS 

### DIFF
--- a/samples/SampleServer/Controllers/HttpController.cs
+++ b/samples/SampleServer/Controllers/HttpController.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -27,10 +28,10 @@ namespace SampleServer.Controllers
         /// <summary>
         /// Returns a 200 response dumping all info from the incoming request.
         /// </summary>
-        [HttpGet]
+        [HttpGet, HttpPost]
         [Route("/api/dump")]
         [Route("/{**catchall}", Order = int.MaxValue)] // Make this the default route if nothing matches
-        public IActionResult Dump()
+        public async Task<IActionResult> Dump()
         {
             var result = new {
                 Request.Protocol,
@@ -41,7 +42,8 @@ namespace SampleServer.Controllers
                 Path = Request.Path.Value,
                 Query = Request.QueryString.Value,
                 Headers = Request.Headers.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToArray()),
-                Time = DateTimeOffset.UtcNow
+                Time = DateTimeOffset.UtcNow,
+                Body = await new StreamReader(Request.Body).ReadToEndAsync(),
             };
 
             return Ok(result);

--- a/test/ReverseProxy.Tests/Service/Proxy/HttpProxyTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/HttpProxyTests.cs
@@ -397,6 +397,9 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
             httpContext.Request.Headers.Add("x-ms-request-test", "request");
             httpContext.Connection.RemoteIpAddress = IPAddress.Loopback;
 
+            // TODO: https://github.com/microsoft/reverse-proxy/issues/255
+            httpContext.Request.Headers.Add("Upgrade", "WebSocket");
+
             var downstreamStream = new DuplexStream(
                 readStream: StringToStream("request content"),
                 writeStream: new MemoryStream());
@@ -471,6 +474,9 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
             httpContext.Request.QueryString = new QueryString("?a=b&c=d");
             httpContext.Request.Headers.Add(":host", "example.com");
             httpContext.Request.Headers.Add("x-ms-request-test", "request");
+
+            // TODO: https://github.com/microsoft/reverse-proxy/issues/255
+            httpContext.Request.Headers.Add("Upgrade", "WebSocket");
 
             var proxyResponseStream = new MemoryStream();
             httpContext.Response.Body = proxyResponseStream;


### PR DESCRIPTION
This is a temporary mitigation for #255. IIS marks all requests as upgradable, and we don't proxy the request body for upgradable requests, so that breaks all POST requests in IIS.

Mitigation: Constrain upgrades to WebSocket requests. In theory Upgrade can be used for other things but we haven't seen that in practice.

We've had at least three separate reports of this now, so I want to get this mitigation into preview3.