### PR TITLE
Be specific about what requests will have bodies 

### DIFF
--- a/samples/ReverseProxy.Sample/Controllers/HttpController.cs
+++ b/samples/ReverseProxy.Sample/Controllers/HttpController.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+namespace SampleServer.Controllers
+{
+    /// <summary>
+    /// Sample controller.
+    /// </summary>
+    [ApiController]
+    public class HttpController : ControllerBase
+    {
+        /// <summary>
+        /// Returns a 200 response dumping all info from the incoming request.
+        /// </summary>
+        [HttpGet, HttpPost]
+        [Route("/api/dump")]
+        public IActionResult Dump()
+        {
+            var result = new {
+                Request.Protocol,
+                Request.Method,
+                Request.Scheme,
+                Host = Request.Host.Value,
+                PathBase = Request.PathBase.Value,
+                Path = Request.Path.Value,
+                Query = Request.QueryString.Value,
+                Headers = Request.Headers.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToArray()),
+                Time = DateTimeOffset.UtcNow
+            };
+
+            return Ok(result);
+        }
+    }
+}

--- a/src/ReverseProxy/Service/Proxy/HttpProxy.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpProxy.cs
@@ -156,7 +156,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy
             // :::::::::::::::::::::::::::::::::::::::::::::
             // :: Step 2: Setup copy of request body (background) Downstream --► Proxy --► Upstream
             // Note that we must do this before step (3) because step (3) may also add headers to the HttpContent that we set up here.
-            var bodyToUpstreamContent = SetupCopyBodyUpstream(context.Request.Body, upstreamRequest, in proxyTelemetryContext, isStreamingRequest, longCancellation);
+            var bodyToUpstreamContent = SetupCopyBodyUpstream(context.Request, upstreamRequest, in proxyTelemetryContext, isStreamingRequest, longCancellation);
 
             // :::::::::::::::::::::::::::::::::::::::::::::
             // :: Step 3: Copy request headers Downstream --► Proxy --► Upstream
@@ -372,11 +372,62 @@ namespace Microsoft.ReverseProxy.Service.Proxy
             return new HttpRequestMessage(HttpUtilities.GetHttpMethod(transformContext.Method), targetUri) { Version = transformContext.Version };
         }
 
-        private StreamCopyHttpContent SetupCopyBodyUpstream(Stream source, HttpRequestMessage upstreamRequest, in ProxyTelemetryContext proxyTelemetryContext, bool isStreamingRequest, CancellationToken cancellation)
+        private StreamCopyHttpContent SetupCopyBodyUpstream(HttpRequest request, HttpRequestMessage upstreamRequest, in ProxyTelemetryContext proxyTelemetryContext, bool isStreamingRequest, CancellationToken cancellation)
         {
+            // If we generate an HttpContent without a Content-Length then for HTTP/1.1 HttpClient will add a Transfer-Encoding: chunked header
+            // even if it's a GET request. Some servers reject requests containing a Transfer-Encoding header if they're not expecting a body.
+            // Try to be as specific as possible about the client's intent to send a body. The one thing we don't want to do is to start
+            // reading the body early because that has side-effects like 100-continue.
+            bool? hasBody;
+            var contentLength = request.Headers.ContentLength;
+            var method = request.Method;
+            // https://tools.ietf.org/html/rfc7230#section-3.3.3
+            // All HTTP/1.1 requests should have Transfer-Encoding or Content-Length.
+            // Http.Sys/IIS will even add a Transfer-Encoding header to HTTP/2 requests with bodies for back-compat.
+            // HTTP/1.0 Connection: close bodies are only allowed on responses, not requests.
+            // https://tools.ietf.org/html/rfc1945#section-7.2.2
+            //
+            // Transfer-Encoding overrides Content-Length per spec
+            if (request.Headers.TryGetValue(HeaderNames.TransferEncoding, out var transferEncoding)
+                && transferEncoding.Count == 1
+                && string.Equals("chunked", transferEncoding.ToString(), StringComparison.OrdinalIgnoreCase))
+            {
+                hasBody = true;
+            }
+            else if (contentLength.HasValue)
+            {
+                hasBody = contentLength > 0;
+            }
+            // Kestrel HTTP/2: There are no required headers for there to be a request body so we need to sniff other fields.
+            //
+            // https://tools.ietf.org/html/rfc7231#section-5.1.1
+            // A client MUST NOT generate a 100-continue expectation in a request that does not include a message body.
+            else if (request.Headers.TryGetValue(HeaderNames.Expect, out var expect)
+                && expect.Count == 1
+                && string.Equals("100-continue", expect.ToString(), StringComparison.OrdinalIgnoreCase))
+            {
+                hasBody = true;
+            }
+            // https://tools.ietf.org/html/rfc7231#section-4.3.1
+            // A payload within a GET/HEAD/DELETE/CONNECT request message has no defined semantics; sending a payload body on a
+            // GET/HEAD/DELETE/CONNECT request might cause some existing implementations to reject the request.
+            // A client MUST NOT send a message body in a TRACE request.
+            else if (HttpMethods.IsGet(method)
+                || HttpMethods.IsHead(method)
+                || HttpMethods.IsDelete(method)
+                || HttpMethods.IsConnect(method)
+                || HttpMethods.IsTrace(method))
+            {
+                hasBody = false;
+            }
+            else
+            {
+                hasBody = true;
+            }
+
             StreamCopyHttpContent contentToUpstream = null;
             // TODO: the request body is never null.
-            if (source != null)
+            if (hasBody.Value)
             {
                 ////this.logger.LogInformation($"   Setting up downstream --> Proxy --> upstream body proxying");
 
@@ -397,7 +448,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy
                         routeId: proxyTelemetryContext.RouteId,
                         destinationId: proxyTelemetryContext.DestinationId));
                 contentToUpstream = new StreamCopyHttpContent(
-                    source: source,
+                    source: request.Body,
                     streamCopier: streamCopier,
                     autoFlushHttpClientOutgoingStream: isStreamingRequest,
                     cancellation: cancellation);

--- a/test/ReverseProxy.Tests/Service/Proxy/HttpProxyTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/HttpProxyTests.cs
@@ -362,7 +362,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     Assert.False(request.Headers.TryGetValues(":authority", out var value));
 
                     // The proxy throws if the request body is not read.
-                    await request.Content.CopyToAsync(Stream.Null);
+                    await (request.Content?.CopyToAsync(Stream.Null) ?? Task.CompletedTask);
 
                     var response = new HttpResponseMessage((HttpStatusCode)234);
                     return response;


### PR DESCRIPTION
#323 HttpProxy today always generates an HttpContent request body. That makes HttpClient assume there's a body and it adds the Transfer-Encoding: chunked header to HTTP/1.1 requests. Servers like Azure Web Sites will reject GET requests that have a Transfer-Encoding: chunked header.

In AspNetCore apps we usually tell people to just read the body to see if there is one, but we don't want to do that too soon in the proxy or else it can trigger side-effects like 100-continue.

I read through a the specs for each HTTP version and it's a bit of a mess. See the inline comments for details.

TODO: Tests