### PR TITLE
Adding catch-all Path

### DIFF
--- a/samples/BenchmarkApp/Startup.cs
+++ b/samples/BenchmarkApp/Startup.cs
@@ -37,7 +37,7 @@ namespace BenchmarkApp
             {
                 { "Routes:0:RouteId", "route" },
                 { "Routes:0:ClusterId", "cluster" },
-                { "Routes:0:Match:Host", new Uri(urls.Split(';', 1)[0]).Host },
+                { "Routes:0:Match:Hosts:0", new Uri(urls.Split(';', 1)[0]).Host },
                 { "Routes:0:Match:Path", "/{**catchall}" }
             };
 

--- a/samples/BenchmarkApp/Startup.cs
+++ b/samples/BenchmarkApp/Startup.cs
@@ -38,6 +38,7 @@ namespace BenchmarkApp
                 { "Routes:0:RouteId", "route" },
                 { "Routes:0:ClusterId", "cluster" },
                 { "Routes:0:Match:Host", new Uri(urls.Split(';', 1)[0]).Host },
+                { "Routes:0:Match:Path", "/{**catchall}" }
             };
 
             var clusterCount = 0;


### PR DESCRIPTION
Without this I get 

```
fai: Microsoft.ReverseProxy.Service.RouteValidator[51]
      Route `route` requires Hosts or Path specified. Set the Path to `/{**catchall}` to match all requests.
```
