### PR TITLE
Disable official builds for linux

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -117,7 +117,7 @@ stages:
         - script: eng/common/cibuild.sh
             --configuration $(_BuildConfig)
             --prepareMachine
-            $(_OfficialBuildArgs)
+            $(_InternalRuntimeDownloadArgs)
           displayName: Build
         - task: PublishBuildArtifacts@1
           displayName: Upload TestResults


### PR DESCRIPTION
Follow-up, it keeps trying to publish symbols from the linux build which we don't care about. This changes it to match the mac build.