### PR TITLE
Fix articles TOC

### DIFF
--- a/docs/docfx/articles/toc.yml
+++ b/docs/docfx/articles/toc.yml
@@ -2,9 +2,9 @@
   href: getting_started.md
 - name: Supported Runtimes
   href: runtimes.md
-  name: Authentication and Authorization
+- name: Authentication and Authorization
   href: authn-authz.md
-  name: Cross-Origin Requests (CORS)
+- name: Cross-Origin Requests (CORS)
   href: cors.md
 - name: Session Affinity
   href: session-affinity.md


### PR DESCRIPTION
The https://microsoft.github.io/reverse-proxy/articles/ TOC was missing a few entries. Turns out it was an issue with the yaml.