### PR TITLE
Pass PathString.Value to prevent encoding

### DIFF
--- a/src/ReverseProxy/Service/Config/TransformBuilder.cs
+++ b/src/ReverseProxy/Service/Config/TransformBuilder.cs
@@ -274,7 +274,7 @@ namespace Microsoft.ReverseProxy.Service.Config
                     {
                         CheckTooManyParameters(rawTransform, expected: 1);
                         var path = MakePathString(pathPattern);
-                        requestTransforms.Add(new PathRouteValuesTransform(path, _binderFactory));
+                        requestTransforms.Add(new PathRouteValuesTransform(path.Value, _binderFactory));
                     }
                     else if (rawTransform.TryGetValue("RequestHeadersCopy", out var copyHeaders))
                     {

--- a/test/ReverseProxy.Tests/Service/Config/ProxyRouteTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Service/Config/ProxyRouteTransformExtensionsTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.ReverseProxy.Service.Config
 
             var requestTransform = Assert.Single(transform.RequestTransforms);
             var pathRouteValuesTransform = Assert.IsType<PathRouteValuesTransform>(requestTransform);
-            Assert.Equal("/path%23", pathRouteValuesTransform.Template.TemplateText);
+            Assert.Equal("/path#", pathRouteValuesTransform.Template.TemplateText);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/microsoft/reverse-proxy/issues/345