### PR TITLE
Fix policy configuration example.

### DIFF
--- a/docs/docfx/articles/authn-authz.md
+++ b/docs/docfx/articles/authn-authz.md
@@ -47,7 +47,7 @@ public void ConfigureServices(IServiceCollection services)
     services.AddAuthorization(options =>
     {
         options.AddPolicy("customPolicy", policy =>
-            policy.Requirements.RequireAuthenticatedUser());
+            policy.RequireAuthenticatedUser());
     });
 }
 ```


### PR DESCRIPTION
```
error CS1061: 'IList<IAuthorizationRequirement>' does not contain a definition for 'RequireAuthenticatedUser' and no accessible extension method 'RequireAuthenticatedUser' accepting a first argument of type 'IList<IAuthorizationRequirement>' could be found (are you missing a using directive or an assembly reference?)
```