### PR TITLE
Implement Equals for ProxyRoute & Cluster

### DIFF
--- a/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/CircuitBreakerOptions.cs
+++ b/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/CircuitBreakerOptions.cs
@@ -30,5 +30,21 @@ namespace Microsoft.ReverseProxy.Abstractions
                 MaxConcurrentRetries = MaxConcurrentRetries,
             };
         }
+
+        internal static bool Equals(CircuitBreakerOptions options1, CircuitBreakerOptions options2)
+        {
+            if (options1 == null && options2 == null)
+            {
+                return true;
+            }
+
+            if (options1 == null || options2 == null)
+            {
+                return false;
+            }
+
+            return options1.MaxConcurrentRequests == options2.MaxConcurrentRequests
+                && options1.MaxConcurrentRetries == options2.MaxConcurrentRetries;
+        }
     }
 }

--- a/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/Cluster.cs
+++ b/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/Cluster.cs
@@ -102,6 +102,7 @@ namespace Microsoft.ReverseProxy.Abstractions
                 && LoadBalancingOptions.Equals(cluster1.LoadBalancing, cluster2.LoadBalancing)
                 && SessionAffinityOptions.Equals(cluster1.SessionAffinity, cluster2.SessionAffinity)
                 && HealthCheckOptions.Equals(cluster1.HealthCheck, cluster2.HealthCheck)
+                && ProxyHttpClientOptions.Equals(cluster1.HttpClient, cluster2.HttpClient)
                 && CaseInsensitiveEqualHelper.Equals(cluster1.Destinations, cluster2.Destinations, Destination.Equals)
                 && CaseInsensitiveEqualHelper.Equals(cluster1.Metadata, cluster2.Metadata);
         }

--- a/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/Cluster.cs
+++ b/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/Cluster.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.ReverseProxy.Abstractions.ClusterDiscovery.Contract;
+using Microsoft.ReverseProxy.Utilities;
 
 namespace Microsoft.ReverseProxy.Abstractions
 {
@@ -81,6 +81,29 @@ namespace Microsoft.ReverseProxy.Abstractions
                 Destinations = Destinations.DeepClone(StringComparer.OrdinalIgnoreCase),
                 Metadata = Metadata?.DeepClone(StringComparer.OrdinalIgnoreCase),
             };
+        }
+
+        internal static bool Equals(Cluster cluster1, Cluster cluster2)
+        {
+            if (cluster1 == null && cluster2 == null)
+            {
+                return true;
+            }
+
+            if (cluster1 == null || cluster2 == null)
+            {
+                return false;
+            }
+
+            return string.Equals(cluster1.Id, cluster2.Id, StringComparison.OrdinalIgnoreCase)
+                && CircuitBreakerOptions.Equals(cluster1.CircuitBreaker, cluster2.CircuitBreaker)
+                && QuotaOptions.Equals(cluster1.Quota, cluster2.Quota)
+                && ClusterPartitioningOptions.Equals(cluster1.Partitioning, cluster2.Partitioning)
+                && LoadBalancingOptions.Equals(cluster1.LoadBalancing, cluster2.LoadBalancing)
+                && SessionAffinityOptions.Equals(cluster1.SessionAffinity, cluster2.SessionAffinity)
+                && HealthCheckOptions.Equals(cluster1.HealthCheck, cluster2.HealthCheck)
+                && CaseInsensitiveEqualHelper.Equals(cluster1.Destinations, cluster2.Destinations, Destination.Equals)
+                && CaseInsensitiveEqualHelper.Equals(cluster1.Metadata, cluster2.Metadata);
         }
     }
 }

--- a/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/ClusterPartitioningOptions.cs
+++ b/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/ClusterPartitioningOptions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Microsoft.ReverseProxy.Abstractions
 {
     /// <summary>
@@ -32,6 +34,23 @@ namespace Microsoft.ReverseProxy.Abstractions
                 PartitionKeyExtractor = PartitionKeyExtractor,
                 PartitioningAlgorithm = PartitioningAlgorithm,
             };
+        }
+
+        internal static bool Equals(ClusterPartitioningOptions options1, ClusterPartitioningOptions options2)
+        {
+            if (options1 == null && options2 == null)
+            {
+                return true;
+            }
+
+            if (options1 == null || options2 == null)
+            {
+                return false;
+            }
+
+            return options1.PartitionCount == options2.PartitionCount
+                && string.Equals(options1.PartitionKeyExtractor, options2.PartitionKeyExtractor, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(options1.PartitioningAlgorithm, options2.PartitioningAlgorithm, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/HealthCheckOptions.cs
+++ b/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/HealthCheckOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -46,6 +46,25 @@ namespace Microsoft.ReverseProxy.Abstractions
                 Port = Port,
                 Path = Path,
             };
+        }
+
+        internal static bool Equals(HealthCheckOptions options1, HealthCheckOptions options2)
+        {
+            if (options1 == null && options2 == null)
+            {
+                return true;
+            }
+
+            if (options1 == null || options2 == null)
+            {
+                return false;
+            }
+
+            return options1.Enabled == options2.Enabled
+                && options1.Interval == options2.Interval
+                && options1.Timeout == options2.Timeout
+                && options1.Port == options2.Port
+                && string.Equals(options1.Path, options2.Path, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/LoadBalancingOptions.cs
+++ b/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/LoadBalancingOptions.cs
@@ -17,5 +17,20 @@ namespace Microsoft.ReverseProxy.Abstractions
                 Mode = Mode,
             };
         }
+
+        internal static bool Equals(LoadBalancingOptions options1, LoadBalancingOptions options2)
+        {
+            if (options1 == null && options2 == null)
+            {
+                return true;
+            }
+
+            if (options1 == null || options2 == null)
+            {
+                return false;
+            }
+
+            return options1.Mode == options2.Mode;
+        }
     }
 }

--- a/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/ProxyHttpClientOptions.cs
+++ b/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/ProxyHttpClientOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 
@@ -29,6 +30,39 @@ namespace Microsoft.ReverseProxy.Abstractions
                 ClientCertificate = ClientCertificate,
                 MaxConnectionsPerServer = MaxConnectionsPerServer
             };
+        }
+
+        internal static bool Equals(ProxyHttpClientOptions options1, ProxyHttpClientOptions options2)
+        {
+            if (options1 == null && options2 == null)
+            {
+                return true;
+            }
+
+            if (options1 == null || options2 == null)
+            {
+                return false;
+            }
+
+            return options1.SslProtocols == options2.SslProtocols
+                && Equals(options1.ClientCertificate, options2.ClientCertificate)
+                && options1.MaxConnectionsPerServer == options2.MaxConnectionsPerServer
+                && options1.MaxConnectionsPerServer == options2.MaxConnectionsPerServer;
+        }
+
+        private static bool Equals(X509Certificate2 certificate1, X509Certificate2 certificate2)
+        {
+            if (certificate1 == null && certificate2 == null)
+            {
+                return true;
+            }
+
+            if (certificate1 == null || certificate2 == null)
+            {
+                return false;
+            }
+
+            return string.Equals(certificate1.Thumbprint, certificate1.Thumbprint, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/ProxyHttpClientOptions.cs
+++ b/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/ProxyHttpClientOptions.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ReverseProxy.Abstractions
 
             return options1.SslProtocols == options2.SslProtocols
                 && Equals(options1.ClientCertificate, options2.ClientCertificate)
-                && options1.MaxConnectionsPerServer == options2.MaxConnectionsPerServer
+                && options1.DangerousAcceptAnyServerCertificate == options2.DangerousAcceptAnyServerCertificate
                 && options1.MaxConnectionsPerServer == options2.MaxConnectionsPerServer;
         }
 

--- a/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/ProxyHttpClientOptions.cs
+++ b/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/ProxyHttpClientOptions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.ReverseProxy.Abstractions
                 return false;
             }
 
-            return string.Equals(certificate1.Thumbprint, certificate1.Thumbprint, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(certificate1.Thumbprint, certificate2.Thumbprint, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/QuotaOptions.cs
+++ b/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/QuotaOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.ReverseProxy.Abstractions
@@ -26,6 +26,22 @@ namespace Microsoft.ReverseProxy.Abstractions
                 Average = Average,
                 Burst = Burst,
             };
+        }
+
+        internal static bool Equals(QuotaOptions options1, QuotaOptions options2)
+        {
+            if (options1 == null && options2 == null)
+            {
+                return true;
+            }
+
+            if (options1 == null || options2 == null)
+            {
+                return false;
+            }
+
+            return options1.Average == options2.Average
+                && options1.Burst == options2.Burst;
         }
     }
 }

--- a/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/SessionAffinityOptions.cs
+++ b/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/SessionAffinityOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.ReverseProxy.Utilities;
 
 namespace Microsoft.ReverseProxy.Abstractions
 {
@@ -40,6 +41,24 @@ namespace Microsoft.ReverseProxy.Abstractions
                 FailurePolicy = FailurePolicy,
                 Settings = Settings?.DeepClone(StringComparer.OrdinalIgnoreCase)
             };
+        }
+
+        internal static bool Equals(SessionAffinityOptions options1, SessionAffinityOptions options2)
+        {
+            if (options1 == null && options2 == null)
+            {
+                return true;
+            }
+
+            if (options1 == null || options2 == null)
+            {
+                return false;
+            }
+
+            return options1.Enabled == options2.Enabled
+                && string.Equals(options1.Mode, options2.Mode, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(options1.FailurePolicy, options2.FailurePolicy, StringComparison.OrdinalIgnoreCase)
+                && CaseInsensitiveEqualHelper.Equals(options1.Settings, options2.Settings);
         }
     }
 }

--- a/src/ReverseProxy/Abstractions/DestinationDiscovery/Contract/Destination.cs
+++ b/src/ReverseProxy/Abstractions/DestinationDiscovery/Contract/Destination.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.ReverseProxy.Utilities;
 
 namespace Microsoft.ReverseProxy.Abstractions
 {
@@ -29,6 +30,22 @@ namespace Microsoft.ReverseProxy.Abstractions
                 Address = Address,
                 Metadata = Metadata?.DeepClone(StringComparer.OrdinalIgnoreCase),
             };
+        }
+
+        internal static bool Equals(Destination destination1, Destination destination2)
+        {
+            if (destination1 == null && destination2 == null)
+            {
+                return true;
+            }
+
+            if (destination1 == null || destination2 == null)
+            {
+                return false;
+            }
+
+            return string.Equals(destination1.Address, destination2.Address, StringComparison.OrdinalIgnoreCase)
+                && CaseInsensitiveEqualHelper.Equals(destination1.Metadata, destination2.Metadata);
         }
     }
 }

--- a/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/ProxyMatch.cs
+++ b/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/ProxyMatch.cs
@@ -1,14 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ReverseProxy.Utilities;
 
 namespace Microsoft.ReverseProxy.Abstractions
 {
-     /// <summary>
-     /// Describes the matching criteria for a route.
-     /// </summary>
+    /// <summary>
+    /// Describes the matching criteria for a route.
+    /// </summary>
     public class ProxyMatch : IDeepCloneable<ProxyMatch>
     {
         /// <summary>
@@ -47,6 +49,23 @@ namespace Microsoft.ReverseProxy.Abstractions
                 Path = Path,
                 // Headers = Headers.DeepClone(); // TODO:
             };
+        }
+
+        internal static bool Equals(ProxyMatch proxyMatch1, ProxyMatch proxyMatch2)
+        {
+            if (proxyMatch1 == null && proxyMatch2 == null)
+            {
+                return true;
+            }
+
+            if (proxyMatch1 == null || proxyMatch2 == null)
+            {
+                return false;
+            }
+
+            return string.Equals(proxyMatch1.Path, proxyMatch2.Path, StringComparison.OrdinalIgnoreCase)
+                && CaseInsensitiveEqualHelper.Equals(proxyMatch1.Hosts, proxyMatch2.Hosts)
+                && CaseInsensitiveEqualHelper.Equals(proxyMatch1.Methods, proxyMatch2.Methods);
         }
     }
 }

--- a/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/ProxyRoute.cs
+++ b/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/ProxyRoute.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ReverseProxy.Utilities;
 
 namespace Microsoft.ReverseProxy.Abstractions
 {
@@ -72,70 +73,26 @@ namespace Microsoft.ReverseProxy.Abstractions
             };
         }
 
-        // Used to diff for config changes
-        internal int GetConfigHash()
+        internal static bool Equals(ProxyRoute proxyRoute1, ProxyRoute proxyRoute2)
         {
-            var hash = 0;
-
-            if (!string.IsNullOrEmpty(RouteId))
+            if (proxyRoute1 == null && proxyRoute2 == null)
             {
-                hash ^= RouteId.GetHashCode();
+                return true;
             }
 
-            if (Match.Methods != null && Match.Methods.Count > 0)
+            if (proxyRoute1 == null || proxyRoute2 == null)
             {
-                // Assumes un-ordered
-                hash ^= Match.Methods.Select(item => item.GetHashCode())
-                    .Aggregate((total, nextCode) => total ^ nextCode);
+                return false;
             }
 
-            if (Match.Hosts != null && Match.Hosts.Count > 0)
-            {
-                // Assumes un-ordered
-                hash ^= Match.Hosts.Select(item => item.GetHashCode())
-                    .Aggregate((total, nextCode) => total ^ nextCode);
-            }
-
-            if (!string.IsNullOrEmpty(Match.Path))
-            {
-                hash ^= Match.Path.GetHashCode();
-            }
-
-            if (Order.HasValue)
-            {
-                hash ^= Order.GetHashCode();
-            }
-
-            if (!string.IsNullOrEmpty(ClusterId))
-            {
-                hash ^= ClusterId.GetHashCode();
-            }
-
-            if (!string.IsNullOrEmpty(AuthorizationPolicy))
-            {
-                hash ^= AuthorizationPolicy.GetHashCode();
-            }
-
-            if (!string.IsNullOrEmpty(CorsPolicy))
-            {
-                hash ^= CorsPolicy.GetHashCode();
-            }
-
-            if (Metadata != null)
-            {
-                hash ^= Metadata.Select(item => HashCode.Combine(item.Key.GetHashCode(), item.Value.GetHashCode()))
-                    .Aggregate((total, nextCode) => total ^ nextCode);
-            }
-
-            if (Transforms != null)
-            {
-                hash ^= Transforms.Select(transform =>
-                    transform.Select(item => HashCode.Combine(item.Key.GetHashCode(), item.Value.GetHashCode()))
-                        .Aggregate((total, nextCode) => total ^ nextCode)) // Unordered Dictionary
-                    .Aggregate(seed: 397, (total, nextCode) => total * 31 ^ nextCode); // Ordered List
-            }
-
-            return hash;
+            return proxyRoute1.Order == proxyRoute2.Order
+                && string.Equals(proxyRoute1.RouteId, proxyRoute2.RouteId, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(proxyRoute1.ClusterId, proxyRoute2.ClusterId, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(proxyRoute1.AuthorizationPolicy, proxyRoute2.AuthorizationPolicy, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(proxyRoute1.CorsPolicy, proxyRoute2.CorsPolicy, StringComparison.OrdinalIgnoreCase)
+                && ProxyMatch.Equals(proxyRoute1.Match, proxyRoute2.Match)
+                && CaseInsensitiveEqualHelper.Equals(proxyRoute1.Metadata, proxyRoute2.Metadata)
+                && CaseInsensitiveEqualHelper.Equals(proxyRoute1.Transforms, proxyRoute2.Transforms);
         }
     }
 }

--- a/src/ReverseProxy/Service/Config/RuntimeRouteBuilder.cs
+++ b/src/ReverseProxy/Service/Config/RuntimeRouteBuilder.cs
@@ -55,8 +55,7 @@ namespace Microsoft.ReverseProxy.Service
             var aspNetCoreEndpoints = new List<Endpoint>(1);
             var newRouteConfig = new RouteConfig(
                 runtimeRoute,
-                source.GetConfigHash(),
-                source.Order,
+                source,
                 cluster,
                 aspNetCoreEndpoints.AsReadOnly(),
                 transforms);

--- a/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
@@ -286,6 +286,7 @@ namespace Microsoft.ReverseProxy.Service.Management
                         });
 
                         var newClusterConfig = new ClusterConfig(
+                                newCluster,
                                 new ClusterConfig.ClusterHealthCheckOptions(
                                     enabled: newCluster.HealthCheck?.Enabled ?? false,
                                     interval: newCluster.HealthCheck?.Interval ?? TimeSpan.FromSeconds(0),

--- a/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
@@ -305,11 +305,7 @@ namespace Microsoft.ReverseProxy.Service.Management
                                 (IReadOnlyDictionary<string, string>)newCluster.Metadata);
 
                         if (currentClusterConfig == null ||
-                            currentClusterConfig.HealthCheckOptions.Enabled != newClusterConfig.HealthCheckOptions.Enabled ||
-                            currentClusterConfig.HealthCheckOptions.Interval != newClusterConfig.HealthCheckOptions.Interval ||
-                            currentClusterConfig.HealthCheckOptions.Timeout != newClusterConfig.HealthCheckOptions.Timeout ||
-                            currentClusterConfig.HealthCheckOptions.Port != newClusterConfig.HealthCheckOptions.Port ||
-                            currentClusterConfig.HealthCheckOptions.Path != newClusterConfig.HealthCheckOptions.Path)
+                            currentClusterConfig.HasConfigChanged(newClusterConfig))
                         {
                             if (currentClusterConfig == null)
                             {

--- a/src/ReverseProxy/Service/RuntimeModel/ClusterConfig.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/ClusterConfig.cs
@@ -62,19 +62,9 @@ namespace Microsoft.ReverseProxy.RuntimeModel
         /// </summary>
         public IReadOnlyDictionary<string, string> Metadata { get; }
 
-        internal static bool Equals(ClusterConfig configCluster1, ClusterConfig configCluster2)
+        internal bool HasConfigChanged(ClusterConfig newClusterConfig)
         {
-            if (configCluster1 == null && configCluster2 == null)
-            {
-                return true;
-            }
-
-            if (configCluster1 == null || configCluster2 == null)
-            {
-                return false;
-            }
-
-            return Cluster.Equals(configCluster1._cluster, configCluster2._cluster);
+            return !Cluster.Equals(_cluster, newClusterConfig._cluster);
         }
 
         /// <summary>

--- a/src/ReverseProxy/Service/RuntimeModel/ClusterConfig.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/ClusterConfig.cs
@@ -24,7 +24,10 @@ namespace Microsoft.ReverseProxy.RuntimeModel
     /// </remarks>
     public sealed class ClusterConfig
     {
+        private readonly Cluster _cluster;
+
         public ClusterConfig(
+            Cluster cluster,
             ClusterHealthCheckOptions healthCheckOptions,
             ClusterLoadBalancingOptions loadBalancingOptions,
             ClusterSessionAffinityOptions sessionAffinityOptions,
@@ -32,6 +35,7 @@ namespace Microsoft.ReverseProxy.RuntimeModel
             ClusterProxyHttpClientOptions httpClientOptions,
             IReadOnlyDictionary<string, string> metadata)
         {
+            _cluster = cluster;
             HealthCheckOptions = healthCheckOptions;
             LoadBalancingOptions = loadBalancingOptions;
             SessionAffinityOptions = sessionAffinityOptions;
@@ -57,6 +61,21 @@ namespace Microsoft.ReverseProxy.RuntimeModel
         /// Arbitrary key-value pairs that further describe this cluster.
         /// </summary>
         public IReadOnlyDictionary<string, string> Metadata { get; }
+
+        internal static bool Equals(ClusterConfig configCluster1, ClusterConfig configCluster2)
+        {
+            if (configCluster1 == null && configCluster2 == null)
+            {
+                return true;
+            }
+
+            if (configCluster1 == null || configCluster2 == null)
+            {
+                return false;
+            }
+
+            return Cluster.Equals(configCluster1._cluster, configCluster2._cluster);
+        }
 
         /// <summary>
         /// Active health probing options for a cluster.
@@ -132,7 +151,7 @@ namespace Microsoft.ReverseProxy.RuntimeModel
 
             public string FailurePolicy { get; }
 
-            public IReadOnlyDictionary<string, string> Settings { get;  }
+            public IReadOnlyDictionary<string, string> Settings { get; }
         }
 
         public readonly struct ClusterProxyHttpClientOptions : IEquatable<ClusterProxyHttpClientOptions>

--- a/src/ReverseProxy/Service/RuntimeModel/ClusterInfo.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/ClusterInfo.cs
@@ -79,20 +79,5 @@ namespace Microsoft.ReverseProxy.RuntimeModel
                             healthyDestinations: healthyDestinations);
                     });
         }
-
-        internal static bool Equals(ClusterInfo clusterInfo1, ClusterInfo clusterInfo2)
-        {
-            if (clusterInfo1 == null && clusterInfo2 == null)
-            {
-                return true;
-            }
-
-            if (clusterInfo1 == null || clusterInfo2 == null)
-            {
-                return false;
-            }
-
-            return ClusterConfig.Equals(clusterInfo1.Config.Value, clusterInfo2.Config.Value);
-        }
     }
 }

--- a/src/ReverseProxy/Service/RuntimeModel/ClusterInfo.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/ClusterInfo.cs
@@ -79,5 +79,20 @@ namespace Microsoft.ReverseProxy.RuntimeModel
                             healthyDestinations: healthyDestinations);
                     });
         }
+
+        internal static bool Equals(ClusterInfo clusterInfo1, ClusterInfo clusterInfo2)
+        {
+            if (clusterInfo1 == null && clusterInfo2 == null)
+            {
+                return true;
+            }
+
+            if (clusterInfo1 == null || clusterInfo2 == null)
+            {
+                return false;
+            }
+
+            return ClusterConfig.Equals(clusterInfo1.Config.Value, clusterInfo2.Config.Value);
+        }
     }
 }

--- a/src/ReverseProxy/Service/RuntimeModel/RouteConfig.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/RouteConfig.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ReverseProxy.RuntimeModel
 
         public bool HasConfigChanged(ProxyRoute newConfig, ClusterInfo cluster)
         {
-            return !ClusterInfo.Equals(Cluster, cluster)
+            return Cluster != cluster
                 || !ProxyRoute.Equals(_proxyRoute, newConfig);
         }
     }

--- a/src/ReverseProxy/Service/RuntimeModel/RouteConfig.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/RouteConfig.cs
@@ -20,10 +20,11 @@ namespace Microsoft.ReverseProxy.RuntimeModel
     /// </remarks>
     internal sealed class RouteConfig
     {
+        private readonly ProxyRoute _proxyRoute;
+
         public RouteConfig(
             RouteInfo route,
-            int configHash,
-            int? order,
+            ProxyRoute proxyRoute,
             ClusterInfo cluster,
             IReadOnlyList<AspNetCore.Http.Endpoint> aspNetCoreEndpoints,
             Transforms transforms)
@@ -31,15 +32,13 @@ namespace Microsoft.ReverseProxy.RuntimeModel
             Route = route ?? throw new ArgumentNullException(nameof(route));
             Endpoints = aspNetCoreEndpoints ?? throw new ArgumentNullException(nameof(aspNetCoreEndpoints));
 
-            ConfigHash = configHash;
-            Order = order;
+            _proxyRoute = proxyRoute;
+            Order = proxyRoute.Order;
             Cluster = cluster;
             Transforms = transforms;
         }
 
         public RouteInfo Route { get; }
-
-        internal int ConfigHash { get; }
 
         public int? Order { get; }
 
@@ -52,8 +51,8 @@ namespace Microsoft.ReverseProxy.RuntimeModel
 
         public bool HasConfigChanged(ProxyRoute newConfig, ClusterInfo cluster)
         {
-            return Cluster != cluster
-                || !ConfigHash.Equals(newConfig.GetConfigHash());
+            return !ClusterInfo.Equals(Cluster, cluster)
+                || !ProxyRoute.Equals(_proxyRoute, newConfig);
         }
     }
 }

--- a/src/ReverseProxy/Utilities/CaseInsensitiveEqualHelper.cs
+++ b/src/ReverseProxy/Utilities/CaseInsensitiveEqualHelper.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 

--- a/src/ReverseProxy/Utilities/CaseInsensitiveEqualHelper.cs
+++ b/src/ReverseProxy/Utilities/CaseInsensitiveEqualHelper.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.ReverseProxy.Utilities
+{
+    internal class CaseInsensitiveEqualHelper
+    {
+        internal static bool Equals(IReadOnlyList<string> list1, IReadOnlyList<string> list2)
+        {
+            if (ReferenceEquals(list1, list2))
+            {
+                return true;
+            }
+
+            if ((list1?.Count ?? 0) == 0 && (list2?.Count ?? 0) == 0)
+            {
+                return true;
+            }
+
+            if (list1 != null && list2 == null || list1 == null && list2 != null)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < list1.Count; i++)
+            {
+                if (!string.Equals(list1[i], list2[i], StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        internal static bool Equals(IList<IDictionary<string, string>> dictionaryList1, IList<IDictionary<string, string>> dictionaryList2)
+        {
+            if (ReferenceEquals(dictionaryList1, dictionaryList2))
+            {
+                return true;
+            }
+
+            if ((dictionaryList1?.Count ?? 0) == 0 && (dictionaryList2?.Count ?? 0) == 0)
+            {
+                return true;
+            }
+
+            if (dictionaryList1 != null && dictionaryList2 == null || dictionaryList1 == null && dictionaryList2 != null)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < dictionaryList1.Count; i++)
+            {
+                if (!Equals(dictionaryList1[i], dictionaryList2[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        internal static bool Equals(IDictionary<string, string> dictionary1, IDictionary<string, string> dictionary2)
+        {
+            return Equals(dictionary1, dictionary2, StringEquals);
+        }
+
+        private static bool StringEquals(string value1, string value2)
+        {
+            return string.Equals(value1, value2, StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static bool Equals<T>(IDictionary<string, T> dictionary1, IDictionary<string, T> dictionary2, Func<T, T, bool> comparer)
+        {
+            if (ReferenceEquals(dictionary1, dictionary2))
+            {
+                return true;
+            }
+
+            if ((dictionary1?.Count ?? 0) == 0 && (dictionary2?.Count ?? 0) == 0)
+            {
+                return true;
+            }
+
+            if (dictionary1 != null && dictionary2 == null || dictionary1 == null && dictionary2 != null)
+            {
+                return false;
+            }
+
+            foreach (var (key, value1) in dictionary1)
+            {
+                if (dictionary2.TryGetValue(key, out var value2))
+                {
+                    if (!comparer(value1, value2))
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/ReverseProxy/Utilities/CaseInsensitiveEqualHelper.cs
+++ b/src/ReverseProxy/Utilities/CaseInsensitiveEqualHelper.cs
@@ -25,6 +25,11 @@ namespace Microsoft.ReverseProxy.Utilities
                 return false;
             }
 
+            if (list1.Count != list2.Count)
+            {
+                return false;
+            }
+
             for (var i = 0; i < list1.Count; i++)
             {
                 if (!string.Equals(list1[i], list2[i], StringComparison.OrdinalIgnoreCase))
@@ -49,6 +54,11 @@ namespace Microsoft.ReverseProxy.Utilities
             }
 
             if (dictionaryList1 != null && dictionaryList2 == null || dictionaryList1 == null && dictionaryList2 != null)
+            {
+                return false;
+            }
+
+            if (dictionaryList1.Count != dictionaryList2.Count)
             {
                 return false;
             }
@@ -87,6 +97,11 @@ namespace Microsoft.ReverseProxy.Utilities
             }
 
             if (dictionary1 != null && dictionary2 == null || dictionary1 == null && dictionary2 != null)
+            {
+                return false;
+            }
+
+            if (dictionary1.Count != dictionary2.Count)
             {
                 return false;
             }

--- a/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/CircuitBreakerOptionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/CircuitBreakerOptionsTests.cs
@@ -31,6 +31,98 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
             Assert.Equal(sut.MaxConcurrentRequests, clone.MaxConcurrentRequests);
             Assert.Equal(sut.MaxConcurrentRetries, clone.MaxConcurrentRetries);
         }
+
+        [Fact]
+        public void Equals_Same_Value_Returns_True()
+        {
+            // Arrange
+            var options1 = new CircuitBreakerOptions
+            {
+                MaxConcurrentRequests = 10,
+                MaxConcurrentRetries = 5,
+            };
+
+            var options2 = new CircuitBreakerOptions
+            {
+                MaxConcurrentRequests = 10,
+                MaxConcurrentRetries = 5,
+            };
+
+            // Act
+            var equals = CircuitBreakerOptions.Equals(options1, options2);
+
+            // Assert
+            Assert.True(equals);
+        }
+
+        [Fact]
+        public void Equals_Different_Value_Returns_False()
+        {
+            // Arrange
+            var options1 = new CircuitBreakerOptions
+            {
+                MaxConcurrentRequests = 10,
+                MaxConcurrentRetries = 5,
+            };
+
+            var options2 = new CircuitBreakerOptions
+            {
+                MaxConcurrentRequests = 20,
+                MaxConcurrentRetries = 10,
+            };
+
+            // Act
+            var equals = CircuitBreakerOptions.Equals(options1, options2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_First_Null_Returns_False()
+        {
+            // Arrange
+            var options2 = new CircuitBreakerOptions
+            {
+                MaxConcurrentRequests = 20,
+                MaxConcurrentRetries = 10,
+            };
+
+            // Act
+            var equals = CircuitBreakerOptions.Equals(null, options2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_Second_Null_Returns_False()
+        {
+            // Arrange
+            var options1 = new CircuitBreakerOptions
+            {
+                MaxConcurrentRequests = 10,
+                MaxConcurrentRetries = 5,
+            };
+
+            // Act
+            var equals = CircuitBreakerOptions.Equals(options1, null);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_Both_Null_Returns_True()
+        {
+            // Arrange
+
+            // Act
+            var equals = CircuitBreakerOptions.Equals(null, null);
+
+            // Assert
+            Assert.True(equals);
+        }
     }
 }
 

--- a/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/ClusterPartitioningOptionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/ClusterPartitioningOptionsTests.cs
@@ -33,5 +33,103 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
             Assert.Equal(sut.PartitionKeyExtractor, clone.PartitionKeyExtractor);
             Assert.Equal(sut.PartitioningAlgorithm, clone.PartitioningAlgorithm);
         }
+
+        [Fact]
+        public void Equals_Same_Value_Returns_True()
+        {
+            // Arrange
+            var options1 = new ClusterPartitioningOptions
+            {
+                PartitionCount = 10,
+                PartitionKeyExtractor = "Header('x-ms-org-id')",
+                PartitioningAlgorithm = "alg1",
+            };
+
+            var options2 = new ClusterPartitioningOptions
+            {
+                PartitionCount = 10,
+                PartitionKeyExtractor = "Header('x-ms-org-id')",
+                PartitioningAlgorithm = "alg1",
+            };
+
+            // Act
+            var equals = ClusterPartitioningOptions.Equals(options1, options2);
+
+            // Assert
+            Assert.True(equals);
+        }
+
+        [Fact]
+        public void Equals_Different_Value_Returns_False()
+        {
+            // Arrange
+            var options1 = new ClusterPartitioningOptions
+            {
+                PartitionCount = 10,
+                PartitionKeyExtractor = "Header('x-ms-org-id')",
+                PartitioningAlgorithm = "alg1",
+            };
+
+            var options2 = new ClusterPartitioningOptions
+            {
+                PartitionCount = 20,
+                PartitionKeyExtractor = "Header('x-ms-org-code')",
+                PartitioningAlgorithm = "alg2",
+            };
+
+            // Act
+            var equals = ClusterPartitioningOptions.Equals(options1, options2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_First_Null_Returns_False()
+        {
+            // Arrange
+            var options2 = new ClusterPartitioningOptions
+            {
+                PartitionCount = 20,
+                PartitionKeyExtractor = "Header('x-ms-org-code')",
+                PartitioningAlgorithm = "alg2",
+            };
+
+            // Act
+            var equals = ClusterPartitioningOptions.Equals(null, options2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_Second_Null_Returns_False()
+        {
+            // Arrange
+            var options1 = new ClusterPartitioningOptions
+            {
+                PartitionCount = 10,
+                PartitionKeyExtractor = "Header('x-ms-org-id')",
+                PartitioningAlgorithm = "alg1",
+            };
+
+            // Act
+            var equals = ClusterPartitioningOptions.Equals(options1, null);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_Both_Null_Returns_True()
+        {
+            // Arrange
+
+            // Act
+            var equals = ClusterPartitioningOptions.Equals(null, null);
+
+            // Assert
+            Assert.True(equals);
+        }
     }
 }

--- a/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/HealthCheckOptionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/HealthCheckOptionsTests.cs
@@ -38,5 +38,115 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
             Assert.Equal(sut.Port, clone.Port);
             Assert.Equal(sut.Path, clone.Path);
         }
+
+        [Fact]
+        public void Equals_Same_Value_Returns_True()
+        {
+            // Arrange
+            var options1 = new HealthCheckOptions
+            {
+                Enabled = true,
+                Interval = TimeSpan.FromSeconds(2),
+                Timeout = TimeSpan.FromSeconds(1),
+                Port = 123,
+                Path = "/a",
+            };
+
+            var options2 = new HealthCheckOptions
+            {
+                Enabled = true,
+                Interval = TimeSpan.FromSeconds(2),
+                Timeout = TimeSpan.FromSeconds(1),
+                Port = 123,
+                Path = "/a",
+            };
+
+            // Act
+            var equals = HealthCheckOptions.Equals(options1, options2);
+
+            // Assert
+            Assert.True(equals);
+        }
+
+        [Fact]
+        public void Equals_Different_Value_Returns_False()
+        {
+            // Arrange
+            var options1 = new HealthCheckOptions
+            {
+                Enabled = true,
+                Interval = TimeSpan.FromSeconds(2),
+                Timeout = TimeSpan.FromSeconds(1),
+                Port = 123,
+                Path = "/a",
+            };
+
+            var options2 = new HealthCheckOptions
+            {
+                Enabled = false,
+                Interval = TimeSpan.FromSeconds(4),
+                Timeout = TimeSpan.FromSeconds(2),
+                Port = 246,
+                Path = "/b",
+            };
+
+            // Act
+            var equals = HealthCheckOptions.Equals(options1, options2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_First_Null_Returns_False()
+        {
+            // Arrange
+            var options2 = new HealthCheckOptions
+            {
+                Enabled = false,
+                Interval = TimeSpan.FromSeconds(4),
+                Timeout = TimeSpan.FromSeconds(2),
+                Port = 246,
+                Path = "/b",
+            };
+
+            // Act
+            var equals = HealthCheckOptions.Equals(null, options2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_Second_Null_Returns_False()
+        {
+            // Arrange
+            var options1 = new HealthCheckOptions
+            {
+                Enabled = true,
+                Interval = TimeSpan.FromSeconds(2),
+                Timeout = TimeSpan.FromSeconds(1),
+                Port = 123,
+                Path = "/a",
+            };
+
+            // Act
+            var equals = HealthCheckOptions.Equals(options1, null);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_Both_Null_Returns_True()
+        {
+            // Arrange
+
+            // Act
+            var equals = HealthCheckOptions.Equals(null, null);
+
+            // Assert
+            Assert.True(equals);
+        }
     }
 }

--- a/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/LoadBalancingOptionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/LoadBalancingOptionsTests.cs
@@ -27,5 +27,91 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
             // Assert
             Assert.NotSame(sut, clone);
         }
+
+        [Fact]
+        public void Equals_Same_Value_Returns_True()
+        {
+            // Arrange
+            var options1 = new LoadBalancingOptions
+            {
+                Mode = LoadBalancingMode.First
+            };
+
+            var options2 = new LoadBalancingOptions
+            {
+                Mode = LoadBalancingMode.First
+            };
+
+            // Act
+            var equals = LoadBalancingOptions.Equals(options1, options2);
+
+            // Assert
+            Assert.True(equals);
+        }
+
+        [Fact]
+        public void Equals_Different_Value_Returns_False()
+        {
+            // Arrange
+            var options1 = new LoadBalancingOptions
+            {
+                Mode = LoadBalancingMode.First
+            };
+
+            var options2 = new LoadBalancingOptions
+            {
+                Mode = LoadBalancingMode.PowerOfTwoChoices
+            };
+
+            // Act
+            var equals = LoadBalancingOptions.Equals(options1, options2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_First_Null_Returns_False()
+        {
+            // Arrange
+            var options2 = new LoadBalancingOptions
+            {
+                Mode = LoadBalancingMode.PowerOfTwoChoices
+            };
+
+            // Act
+            var equals = LoadBalancingOptions.Equals(null, options2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_Second_Null_Returns_False()
+        {
+            // Arrange
+            var options1 = new LoadBalancingOptions
+            {
+                Mode = LoadBalancingMode.First
+            };
+
+            // Act
+            var equals = LoadBalancingOptions.Equals(options1, null);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_Both_Null_Returns_True()
+        {
+            // Arrange
+
+            // Act
+            var equals = LoadBalancingOptions.Equals(null, null);
+
+            // Assert
+            Assert.True(equals);
+        }
     }
 }

--- a/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/ProxyHttpClientOptionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/ProxyHttpClientOptionsTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
 using System.Security.Authentication;
 using Microsoft.ReverseProxy.Utilities.Tests;
 using Xunit;

--- a/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/ProxyHttpClientOptionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/ProxyHttpClientOptionsTests.cs
@@ -38,5 +38,110 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
             Assert.Same(options.ClientCertificate, clone.ClientCertificate);
             Assert.Equal(options.MaxConnectionsPerServer, clone.MaxConnectionsPerServer);
         }
+
+
+        [Fact]
+        public void Equals_Same_Value_Returns_True()
+        {
+            // Arrange
+            var options1 = new ProxyHttpClientOptions
+            {
+                SslProtocols = SslProtocols.Tls11,
+                DangerousAcceptAnyServerCertificate = false,
+                ClientCertificate = TestResources.GetTestCertificate(),
+                MaxConnectionsPerServer = 20
+            };
+
+            var options2 = new ProxyHttpClientOptions
+            {
+                SslProtocols = SslProtocols.Tls11,
+                DangerousAcceptAnyServerCertificate = false,
+                ClientCertificate = TestResources.GetTestCertificate(),
+                MaxConnectionsPerServer = 20
+            };
+
+            // Act
+            var equals = ProxyHttpClientOptions.Equals(options1, options2);
+
+            // Assert
+            Assert.True(equals);
+        }
+
+        [Fact]
+        public void Equals_Different_Value_Returns_False()
+        {
+            // Arrange
+            var options1 = new ProxyHttpClientOptions
+            {
+                SslProtocols = SslProtocols.Tls11,
+                DangerousAcceptAnyServerCertificate = false,
+                ClientCertificate = TestResources.GetTestCertificate(),
+                MaxConnectionsPerServer = 20
+            };
+
+            var options2 = new ProxyHttpClientOptions
+            {
+                SslProtocols = SslProtocols.Tls12,
+                DangerousAcceptAnyServerCertificate = true,
+                ClientCertificate = TestResources.GetTestCertificate(),
+                MaxConnectionsPerServer = 20
+            };
+
+            // Act
+            var equals = ProxyHttpClientOptions.Equals(options1, options2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_First_Null_Returns_False()
+        {
+            // Arrange
+            var options2 = new ProxyHttpClientOptions
+            {
+                SslProtocols = SslProtocols.Tls12,
+                DangerousAcceptAnyServerCertificate = true,
+                ClientCertificate = TestResources.GetTestCertificate(),
+                MaxConnectionsPerServer = 20
+            };
+
+            // Act
+            var equals = ProxyHttpClientOptions.Equals(null, options2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_Second_Null_Returns_False()
+        {
+            // Arrange
+            var options1 = new ProxyHttpClientOptions
+            {
+                SslProtocols = SslProtocols.Tls11,
+                DangerousAcceptAnyServerCertificate = false,
+                ClientCertificate = TestResources.GetTestCertificate(),
+                MaxConnectionsPerServer = 20
+            };
+
+            // Act
+            var equals = ProxyHttpClientOptions.Equals(options1, null);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_Both_Null_Returns_True()
+        {
+            // Arrange
+
+            // Act
+            var equals = ProxyHttpClientOptions.Equals(null, null);
+
+            // Assert
+            Assert.True(equals);
+        }
     }
 }

--- a/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/QuotaOptionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/QuotaOptionsTests.cs
@@ -31,5 +31,97 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
             Assert.Equal(sut.Average,clone.Average);
             Assert.Equal(sut.Burst,clone.Burst);
         }
+
+        [Fact]
+        public void Equals_Same_Value_Returns_True()
+        {
+            // Arrange
+            var options1 = new QuotaOptions
+            {
+                Average = 10,
+                Burst = 100,
+            };
+
+            var options2 = new QuotaOptions
+            {
+                Average = 10,
+                Burst = 100,
+            };
+
+            // Act
+            var equals = QuotaOptions.Equals(options1, options2);
+
+            // Assert
+            Assert.True(equals);
+        }
+
+        [Fact]
+        public void Equals_Different_Value_Returns_False()
+        {
+            // Arrange
+            var options1 = new QuotaOptions
+            {
+                Average = 10,
+                Burst = 100,
+            };
+
+            var options2 = new QuotaOptions
+            {
+                Average = 20,
+                Burst = 200,
+            };
+
+            // Act
+            var equals = QuotaOptions.Equals(options1, options2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_First_Null_Returns_False()
+        {
+            // Arrange
+            var options2 = new QuotaOptions
+            {
+                Average = 20,
+                Burst = 200,
+            };
+
+            // Act
+            var equals = QuotaOptions.Equals(null, options2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_Second_Null_Returns_False()
+        {
+            // Arrange
+            var options1 = new QuotaOptions
+            {
+                Average = 10,
+                Burst = 100,
+            };
+
+            // Act
+            var equals = QuotaOptions.Equals(options1, null);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_Both_Null_Returns_True()
+        {
+            // Arrange
+
+            // Act
+            var equals = QuotaOptions.Equals(null, null);
+
+            // Assert
+            Assert.True(equals);
+        }
     }
 }

--- a/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/SessionAffinityOptionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/SessionAffinityOptionsTests.cs
@@ -1,6 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Xunit;
 
 namespace Microsoft.ReverseProxy.Abstractions.ClusterDiscovery.Contract

--- a/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/SessionAffinityOptionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/SessionAffinityOptionsTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.ReverseProxy.Abstractions.ClusterDiscovery.Contract
+{
+    public class SessionAffinityOptionsTests
+    {
+        [Fact]
+        public void Constructor_Works()
+        {
+            new SessionAffinityOptions();
+        }
+
+        [Fact]
+        public void DeepClone_Works()
+        {
+            // Arrange
+            var sut = new SessionAffinityOptions
+            {
+                Enabled = true,
+                FailurePolicy = "policy1",
+                Mode = "mode1"
+            };
+
+            // Act
+            var clone = sut.DeepClone();
+
+            // Assert
+            Assert.NotSame(sut, clone);
+            Assert.Equal(sut.Enabled, clone.Enabled);
+            Assert.Equal(sut.FailurePolicy, clone.FailurePolicy);
+            Assert.Equal(sut.Mode, clone.Mode);
+        }
+
+        [Fact]
+        public void Equals_Same_Value_Returns_True()
+        {
+            // Arrange
+            var options1 = new SessionAffinityOptions
+            {
+                Enabled = true,
+                FailurePolicy = "policy1",
+                Mode = "mode1"
+            };
+
+            var options2 = new SessionAffinityOptions
+            {
+                Enabled = true,
+                FailurePolicy = "policy1",
+                Mode = "mode1"
+            };
+
+            // Act
+            var equals = SessionAffinityOptions.Equals(options1, options2);
+
+            // Assert
+            Assert.True(equals);
+        }
+
+        [Fact]
+        public void Equals_Different_Value_Returns_False()
+        {
+            // Arrange
+            var options1 = new SessionAffinityOptions
+            {
+                Enabled = true,
+                FailurePolicy = "policy1",
+                Mode = "mode1"
+            };
+
+            var options2 = new SessionAffinityOptions
+            {
+                Enabled = false,
+                FailurePolicy = "policy2",
+                Mode = "mode2"
+            };
+
+            // Act
+            var equals = SessionAffinityOptions.Equals(options1, options2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_First_Null_Returns_False()
+        {
+            // Arrange
+            var options2 = new SessionAffinityOptions
+            {
+                Enabled = false,
+                FailurePolicy = "policy2",
+                Mode = "mode2"
+            };
+
+            // Act
+            var equals = SessionAffinityOptions.Equals(null, options2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_Second_Null_Returns_False()
+        {
+            // Arrange
+            var options1 = new SessionAffinityOptions
+            {
+                Enabled = true,
+                FailurePolicy = "policy1",
+                Mode = "mode1"
+            };
+
+            // Act
+            var equals = SessionAffinityOptions.Equals(options1, null);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_Both_Null_Returns_True()
+        {
+            // Arrange
+
+            // Act
+            var equals = SessionAffinityOptions.Equals(null, null);
+
+            // Assert
+            Assert.True(equals);
+        }
+    }
+}

--- a/test/ReverseProxy.Tests/Middleware/AffinityMiddlewareTestBase.cs
+++ b/test/ReverseProxy.Tests/Middleware/AffinityMiddlewareTestBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using Microsoft.AspNetCore.Http;
+using Microsoft.ReverseProxy.Abstractions;
 using Microsoft.ReverseProxy.RuntimeModel;
 using Microsoft.ReverseProxy.Service.Management;
 using Microsoft.ReverseProxy.Service.Proxy.Infrastructure;
@@ -19,7 +20,7 @@ namespace Microsoft.ReverseProxy.Middleware
     {
         protected const string AffinitizedDestinationName = "dest-B";
         protected readonly IReadOnlyList<DestinationInfo> Destinations = new[] { new DestinationInfo("dest-A"), new DestinationInfo(AffinitizedDestinationName), new DestinationInfo("dest-C") };
-        protected readonly ClusterConfig ClusterConfig = new ClusterConfig(default, default, new ClusterConfig.ClusterSessionAffinityOptions(true, "Mode-B", "Policy-1", null),
+        protected readonly ClusterConfig ClusterConfig = new ClusterConfig(default, default, default, new ClusterConfig.ClusterSessionAffinityOptions(true, "Mode-B", "Policy-1", null),
             new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object), default, new Dictionary<string, string>());
 
         internal ClusterInfo GetCluster()
@@ -91,7 +92,8 @@ namespace Microsoft.ReverseProxy.Middleware
         internal Endpoint GetEndpoint(ClusterInfo cluster)
         {
             var endpoints = new List<Endpoint>(1);
-            var routeConfig = new RouteConfig(new RouteInfo("route-1"), 47, null, cluster, endpoints.AsReadOnly(), Transforms.Empty);
+            var proxyRoute = new ProxyRoute();
+            var routeConfig = new RouteConfig(new RouteInfo("route-1"), proxyRoute, cluster, endpoints.AsReadOnly(), Transforms.Empty);
             var endpoint = new Endpoint(default, new EndpointMetadataCollection(routeConfig), string.Empty);
             endpoints.Add(endpoint);
             return endpoint;

--- a/test/ReverseProxy.Tests/Middleware/DestinationInitializerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/DestinationInitializerMiddlewareTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
+using Microsoft.ReverseProxy.Abstractions;
 using Microsoft.ReverseProxy.RuntimeModel;
 using Microsoft.ReverseProxy.Service.Management;
 using Microsoft.ReverseProxy.Service.Proxy.Infrastructure;
@@ -30,7 +31,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
         {
             Create<DestinationInitializerMiddleware>();
         }
-        
+
         [Fact]
         public async Task Invoke_SetsFeatures()
         {
@@ -38,7 +39,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
             var cluster1 = new ClusterInfo(
                 clusterId: "cluster1",
                 destinationManager: new DestinationManager());
-            cluster1.Config.Value = new ClusterConfig(default, default, default, httpClient, default, new Dictionary<string, string>());
+            cluster1.Config.Value = new ClusterConfig(default, default, default, default, httpClient, default, new Dictionary<string, string>());
             var destination1 = cluster1.DestinationManager.GetOrCreateItem(
                 "destination1",
                 destination =>
@@ -50,8 +51,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
             var aspNetCoreEndpoints = new List<Endpoint>();
             var routeConfig = new RouteConfig(
                 new RouteInfo("route1"),
-                configHash: 0,
-                order: null,
+                proxyRoute: new ProxyRoute(),
                 cluster1,
                 aspNetCoreEndpoints.AsReadOnly(),
                 transforms: null);
@@ -82,6 +82,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
                 clusterId: "cluster1",
                 destinationManager: new DestinationManager());
             cluster1.Config.Value = new ClusterConfig(
+                new Cluster(),
                 new ClusterConfig.ClusterHealthCheckOptions(enabled: true, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan, 0, ""),
                 new ClusterConfig.ClusterLoadBalancingOptions(),
                 new ClusterConfig.ClusterSessionAffinityOptions(),
@@ -98,8 +99,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
             var aspNetCoreEndpoints = new List<Endpoint>();
             var routeConfig = new RouteConfig(
                 route: new RouteInfo("route1"),
-                configHash: 0,
-                order: null,
+                proxyRoute: new ProxyRoute(),
                 cluster: cluster1,
                 aspNetCoreEndpoints: aspNetCoreEndpoints.AsReadOnly(),
                 transforms: null);

--- a/test/ReverseProxy.Tests/Middleware/LoadBalancerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/LoadBalancerMiddlewareTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
             var cluster1 = new ClusterInfo(
                 clusterId: "cluster1",
                 destinationManager: new DestinationManager());
-            cluster1.Config.Value = new ClusterConfig(default, new ClusterConfig.ClusterLoadBalancingOptions(LoadBalancingMode.RoundRobin), default, httpClient, default, new Dictionary<string, string>());
+            cluster1.Config.Value = new ClusterConfig(default, default, new ClusterConfig.ClusterLoadBalancingOptions(LoadBalancingMode.RoundRobin), default, httpClient, default, new Dictionary<string, string>());
             var destination1 = cluster1.DestinationManager.GetOrCreateItem(
                 "destination1",
                 destination =>
@@ -59,8 +59,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
             var aspNetCoreEndpoints = new List<Endpoint>();
             var routeConfig = new RouteConfig(
                 route: new RouteInfo("route1"),
-                configHash: 0,
-                order: null,
+                proxyRoute: new ProxyRoute(),
                 cluster: cluster1,
                 aspNetCoreEndpoints: aspNetCoreEndpoints.AsReadOnly(),
                 transforms: null);
@@ -98,7 +97,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
             var cluster1 = new ClusterInfo(
                 clusterId: "cluster1",
                 destinationManager: new DestinationManager());
-            cluster1.Config.Value = new ClusterConfig(default, new ClusterConfig.ClusterLoadBalancingOptions(LoadBalancingMode.RoundRobin), default, httpClient, default, new Dictionary<string, string>());
+            cluster1.Config.Value = new ClusterConfig(default, default, new ClusterConfig.ClusterLoadBalancingOptions(LoadBalancingMode.RoundRobin), default, httpClient, default, new Dictionary<string, string>());
             var destination1 = cluster1.DestinationManager.GetOrCreateItem(
                 "destination1",
                 destination =>
@@ -117,8 +116,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
             var aspNetCoreEndpoints = new List<Endpoint>();
             var routeConfig = new RouteConfig(
                 route: new RouteInfo("route1"),
-                configHash: 0,
-                order: null,
+                proxyRoute: new ProxyRoute(),
                 cluster: cluster1,
                 aspNetCoreEndpoints: aspNetCoreEndpoints.AsReadOnly(),
                 transforms: null);

--- a/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
@@ -127,7 +127,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
             var cluster1 = new ClusterInfo(
                 clusterId: "cluster1",
                 destinationManager: new DestinationManager());
-            var clusterConfig = new ClusterConfig(default, default, default, httpClient, default, new Dictionary<string, string>());
+            var clusterConfig = new ClusterConfig(default, default, default, default, httpClient, default, new Dictionary<string, string>());
             httpContext.Features.Set<IReverseProxyFeature>(
                 new ReverseProxyFeature() { AvailableDestinations = Array.Empty<DestinationInfo>(), ClusterConfig = clusterConfig });
             httpContext.Features.Set(cluster1);
@@ -135,8 +135,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
             var aspNetCoreEndpoints = new List<Endpoint>();
             var routeConfig = new RouteConfig(
                 route: new RouteInfo("route1"),
-                configHash: 0,
-                order: null,
+                proxyRoute: new ProxyRoute(),
                 cluster: cluster1,
                 aspNetCoreEndpoints: aspNetCoreEndpoints.AsReadOnly(),
                 transforms: null);

--- a/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
+using Microsoft.ReverseProxy.Abstractions;
 using Microsoft.ReverseProxy.Abstractions.Telemetry;
 using Microsoft.ReverseProxy.RuntimeModel;
 using Microsoft.ReverseProxy.Service.Management;
@@ -50,7 +51,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
             var cluster1 = new ClusterInfo(
                 clusterId: "cluster1",
                 destinationManager: new DestinationManager());
-            var clusterConfig = new ClusterConfig(default, default, default, httpClient, default, new Dictionary<string, string>());
+            var clusterConfig = new ClusterConfig(default, default, default, default, httpClient, default, new Dictionary<string, string>());
             var destination1 = cluster1.DestinationManager.GetOrCreateItem(
                 "destination1",
                 destination =>
@@ -65,8 +66,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
             var aspNetCoreEndpoints = new List<Endpoint>();
             var routeConfig = new RouteConfig(
                 route: new RouteInfo("route1"),
-                configHash: 0,
-                order: null,
+                proxyRoute: new ProxyRoute(),
                 cluster: cluster1,
                 aspNetCoreEndpoints: aspNetCoreEndpoints.AsReadOnly(),
                 transforms: null);

--- a/test/ReverseProxy.Tests/Service/Config/RuntimeRouteBuilderTests.cs
+++ b/test/ReverseProxy.Tests/Service/Config/RuntimeRouteBuilderTests.cs
@@ -63,13 +63,13 @@ namespace Microsoft.ReverseProxy.Service.Tests
 
             Assert.Same(cluster, config.Cluster);
             Assert.Equal(12, config.Order);
-            Assert.Equal(route.GetConfigHash(), config.ConfigHash);
             Assert.Single(config.Endpoints);
             var routeEndpoint = config.Endpoints[0] as AspNetCore.Routing.RouteEndpoint;
             Assert.Equal("route1", routeEndpoint.DisplayName);
             Assert.Same(config, routeEndpoint.Metadata.GetMetadata<RouteConfig>());
             Assert.Equal("/a", routeEndpoint.RoutePattern.RawText);
             Assert.Equal(12, routeEndpoint.Order);
+            Assert.False(config.HasConfigChanged(route, cluster));
 
             var hostMetadata = routeEndpoint.Metadata.GetMetadata<AspNetCore.Routing.HostAttribute>();
             Assert.NotNull(hostMetadata);
@@ -100,13 +100,13 @@ namespace Microsoft.ReverseProxy.Service.Tests
 
             Assert.Same(cluster, config.Cluster);
             Assert.Equal(12, config.Order);
-            Assert.Equal(route.GetConfigHash(), config.ConfigHash);
             Assert.Single(config.Endpoints);
             var routeEndpoint = config.Endpoints[0] as AspNetCore.Routing.RouteEndpoint;
             Assert.Equal("route1", routeEndpoint.DisplayName);
             Assert.Same(config, routeEndpoint.Metadata.GetMetadata<RouteConfig>());
             Assert.Equal("/{**catchall}", routeEndpoint.RoutePattern.RawText);
             Assert.Equal(12, routeEndpoint.Order);
+            Assert.False(config.HasConfigChanged(route, cluster));
 
             var hostMetadata = routeEndpoint.Metadata.GetMetadata<AspNetCore.Routing.HostAttribute>();
             Assert.NotNull(hostMetadata);
@@ -137,13 +137,13 @@ namespace Microsoft.ReverseProxy.Service.Tests
 
             Assert.Same(cluster, config.Cluster);
             Assert.Equal(12, config.Order);
-            Assert.Equal(route.GetConfigHash(), config.ConfigHash);
             Assert.Single(config.Endpoints);
             var routeEndpoint = config.Endpoints[0] as AspNetCore.Routing.RouteEndpoint;
             Assert.Equal("route1", routeEndpoint.DisplayName);
             Assert.Same(config, routeEndpoint.Metadata.GetMetadata<RouteConfig>());
             Assert.Equal("/{**catchall}", routeEndpoint.RoutePattern.RawText);
             Assert.Equal(12, routeEndpoint.Order);
+            Assert.False(config.HasConfigChanged(route, cluster));
 
             var hostMetadata = routeEndpoint.Metadata.GetMetadata<AspNetCore.Routing.HostAttribute>();
             Assert.NotNull(hostMetadata);
@@ -174,13 +174,13 @@ namespace Microsoft.ReverseProxy.Service.Tests
 
             Assert.Same(cluster, config.Cluster);
             Assert.Equal(12, config.Order);
-            Assert.Equal(route.GetConfigHash(), config.ConfigHash);
             Assert.Single(config.Endpoints);
             var routeEndpoint = config.Endpoints[0] as AspNetCore.Routing.RouteEndpoint;
             Assert.Equal("route1", routeEndpoint.DisplayName);
             Assert.Same(config, routeEndpoint.Metadata.GetMetadata<RouteConfig>());
             Assert.Equal("/a", routeEndpoint.RoutePattern.RawText);
             Assert.Equal(12, routeEndpoint.Order);
+            Assert.False(config.HasConfigChanged(route, cluster));
 
             var hostMetadata = routeEndpoint.Metadata.GetMetadata<AspNetCore.Routing.HostAttribute>();
             Assert.Null(hostMetadata);
@@ -205,13 +205,13 @@ namespace Microsoft.ReverseProxy.Service.Tests
 
             Assert.Same(cluster, config.Cluster);
             Assert.Equal(12, config.Order);
-            Assert.NotEqual(0, config.ConfigHash);
             Assert.Single(config.Endpoints);
             var routeEndpoint = config.Endpoints[0] as AspNetCore.Routing.RouteEndpoint;
             Assert.Equal("route1", routeEndpoint.DisplayName);
             Assert.Same(config, routeEndpoint.Metadata.GetMetadata<RouteConfig>());
             Assert.Equal("/{**catchall}", routeEndpoint.RoutePattern.RawText);
             Assert.Equal(12, routeEndpoint.Order);
+            Assert.False(config.HasConfigChanged(route, cluster));
 
             var hostMetadata = routeEndpoint.Metadata.GetMetadata<AspNetCore.Routing.HostAttribute>();
             Assert.Null(hostMetadata);

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/ClusterInfoTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/ClusterInfoTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using Microsoft.ReverseProxy.Abstractions;
 using Microsoft.ReverseProxy.Service.Management;
 using Microsoft.ReverseProxy.Service.Proxy.Infrastructure;
 using Moq;
@@ -78,7 +79,7 @@ namespace Microsoft.ReverseProxy.RuntimeModel.Tests
             Assert.NotNull(state1);
             Assert.Empty(state1.AllDestinations);
 
-            cluster.Config.Value = new ClusterConfig(healthCheckOptions: default, loadBalancingOptions: default, sessionAffinityOptions: default,
+            cluster.Config.Value = new ClusterConfig(cluster: default, healthCheckOptions: default, loadBalancingOptions: default, sessionAffinityOptions: default,
                 httpClient: new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object), httpClientOptions: default, metadata: new Dictionary<string, string>());
             Assert.NotSame(state1, cluster.DynamicState.Value);
             Assert.Empty(cluster.DynamicState.Value.AllDestinations);
@@ -142,6 +143,7 @@ namespace Microsoft.ReverseProxy.RuntimeModel.Tests
         {
             // Pretend that health checks are enabled so that destination health states are honored
             cluster.Config.Value = new ClusterConfig(
+                new Cluster(),
                 healthCheckOptions: new ClusterConfig.ClusterHealthCheckOptions(
                     enabled: true,
                     interval: TimeSpan.FromSeconds(5),

--- a/test/ReverseProxy.Tests/Utilities/CaseInsensitiveEqualHelperTests.cs
+++ b/test/ReverseProxy.Tests/Utilities/CaseInsensitiveEqualHelperTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.ReverseProxy.Utilities
+{
+    public class CaseInsensitiveEqualHelperTests
+    {
+        [Fact]
+        public void Equals_Same_Instance_Returns_True()
+        {
+            // Arrange
+            var list1 = new string[] { "item1", "item2" };
+
+            // Act
+            var equals = CaseInsensitiveEqualHelper.Equals(list1, list1);
+
+            // Assert
+            Assert.True(equals);
+        }
+
+        [Fact]
+        public void Equals_Empty_List_Returns_True()
+        {
+            // Arrange
+            var list1 = new string[] { };
+
+            var list2 = new string[] { };
+
+            // Act
+            var equals = CaseInsensitiveEqualHelper.Equals(list1, list2);
+
+            // Assert
+            Assert.True(equals);
+        }
+
+        [Fact]
+        public void Equals_List_Same_Value_Returns_True()
+        {
+            // Arrange
+            var list1 = new string[] { "item1", "item2" };
+
+            var list2 = new string[] { "item1", "item2" };
+
+            // Act
+            var equals = CaseInsensitiveEqualHelper.Equals(list1, list2);
+
+            // Assert
+            Assert.True(equals);
+        }
+
+        [Fact]
+        public void Equals_List_Different_Value_Returns_False()
+        {
+            // Arrange
+            var list1 = new string[] { "item1", "item2" };
+
+            var list2 = new string[] { "item3", "item4" };
+
+            // Act
+            var equals = CaseInsensitiveEqualHelper.Equals(list1, list2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_First_List_Null_Returns_False()
+        {
+            // Arrange
+            var list2 = new string[] { "item1", "item2" };
+
+            // Act
+            var equals = CaseInsensitiveEqualHelper.Equals(null, list2);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_Second_List_Null_Returns_False()
+        {
+            // Arrange
+            var list1 = new string[] { "item1", "item2" };
+
+            // Act
+            var equals = CaseInsensitiveEqualHelper.Equals(list1, null);
+
+            // Assert
+            Assert.False(equals);
+        }
+
+        [Fact]
+        public void Equals_Null_List_Returns_True()
+        {
+            // Arrange
+
+            // Act
+            var equals = CaseInsensitiveEqualHelper.Equals(list1: null, list2: null);
+
+            // Assert
+            Assert.True(equals);
+        }
+    }
+}

--- a/test/ReverseProxy.Tests/Utilities/CaseInsensitiveEqualHelperTests.cs
+++ b/test/ReverseProxy.Tests/Utilities/CaseInsensitiveEqualHelperTests.cs
@@ -1,6 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Xunit;
 
 namespace Microsoft.ReverseProxy.Utilities


### PR DESCRIPTION
Fixes https://github.com/microsoft/reverse-proxy/issues/359
Fixes https://github.com/microsoft/reverse-proxy/issues/373

Since `ParsedRoute` type is removed by https://github.com/microsoft/reverse-proxy/pull/357, I create a branch of the PR in order to prevent future merge conflicts. So this could be merged after https://github.com/microsoft/reverse-proxy/pull/357.