### PR TITLE
Change the doc publishing to track a release branch

### DIFF
--- a/.github/workflows/docfx_build.yml
+++ b/.github/workflows/docfx_build.yml
@@ -2,7 +2,7 @@ name: DocFX Build
 on:
   push:
     branches:
-      - master
+      - release/docs
 jobs:
   build:
     name: Build
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: source
+          ref: release/docs
       # Run a build
       - name: Build docs
         run: "& ./eng/common/build.ps1 -restore -build -projects ./docs/docfx/docfx.csproj"

--- a/docs/docfx/readme.md
+++ b/docs/docfx/readme.md
@@ -12,4 +12,8 @@ The build will produce a series of HTML files in the `_site` directory. Many of 
 
 ## Publishing the docs
 
-The docs are automatically built and published by a [GitHub Action](https://github.com/microsoft/reverse-proxy/blob/master/.github/workflows/docfx_build.yml) on every push to `master`. The built `_site` directory is pushed to the `gh-pages` branch and served by [https://microsoft.github.io/reverse-proxy/](https://microsoft.github.io/reverse-proxy/).
+The docs are automatically built and published by a [GitHub Action](https://github.com/microsoft/reverse-proxy/blob/master/.github/workflows/docfx_build.yml) on every push to `release/docs`. The built `_site` directory is pushed to the `gh-pages` branch and served by [https://microsoft.github.io/reverse-proxy/](https://microsoft.github.io/reverse-proxy/). Maintaining a seperate branch for the released docs allows us to choose when to publish them and with what content, and without modifying the build scripts each release.
+
+Doc edits for the current public release should go into that release's branch (e.g. `release/1.0.0-preview3`) and merged forward into `master`. Then `release/docs` should be reset to that release branch's position.
+
+When publishing a new product version (e.g. `relese/1.0.0-preview4`) `release/docs` should be reset to that position after the docs have been updated.


### PR DESCRIPTION
Fixes #344 Our docs live in the repo and get updated live with commits to master. However, when we make breaking changes the published docs get out of sync with the last release (e.g. preview4) causing confusion for some users.

I've changed the doc publishing process to explicitly track a release/docs branch. See the updated readme.