### PR TITLE
Move to the preview.8 SDK

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,10 +48,10 @@ stages:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCorePublic-Pool
-            queue: BuildPool.Windows.VS2019.Pre.Scouting.Open
+            queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: NetCoreInternal-Pool
-            queue: BuildPool.Server.Amd64.VS2019
+            queue: BuildPool.Windows.10.Amd64.VS2019.Pre
         variables:
           
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ stages:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCorePublic-Pool
-            queue: BuildPool.Server.Amd64.VS2019.Open
+            queue: BuildPool.Windows.VS2019.Scouting.Open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: NetCoreInternal-Pool
             queue: BuildPool.Server.Amd64.VS2019

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ stages:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCorePublic-Pool
-            queue: BuildPool.Windows.VS2019.Scouting.Open
+            queue: BuildPool.Windows.VS2019.Pre.Scouting.Open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: NetCoreInternal-Pool
             queue: BuildPool.Server.Amd64.VS2019

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "5.0.100-preview.6.20310.4"
+    "version": "5.0.100-preview.8.20417.9"
   },
   "tools": {
-    "dotnet": "5.0.100-preview.6.20310.4",
+    "dotnet": "5.0.100-preview.8.20417.9",
     "runtimes": {
       "dotnet/x64": [
         "$(MicrosoftNETCoreAppPackageVersion)",


### PR DESCRIPTION
Fixes #377 - Dlls get a bunch of new metadata from the compiler
Unblocks #330 @Kahbazi - I think there was a bug in the preview 6 SDK about the Pipes library on 3.1. Can you rebase after this is merged and try again?

Blocked: We need the CI agents to be updated to VS 16.8.0 Preview 2 to unblock the build.