### PR TITLE
programatically -> programmatically

### DIFF
--- a/docs/docfx/articles/configproviders.md
+++ b/docs/docfx/articles/configproviders.md
@@ -3,7 +3,7 @@
 Introduced: preview4
 
 ## Introduction
-Proxy configuration can be loaded programatically from the source of your choosing by implementing an [IProxyConfigProvider](xref:Microsoft.ReverseProxy.Service.IProxyConfigProvider).
+Proxy configuration can be loaded programmatically from the source of your choosing by implementing an [IProxyConfigProvider](xref:Microsoft.ReverseProxy.Service.IProxyConfigProvider).
 
 ## Structure
 [IProxyConfigProvider](xref:Microsoft.ReverseProxy.Service.IProxyConfigProvider) has a single method `GetConfig()` that returns an [IProxyConfig](xref:Microsoft.ReverseProxy.Service.IProxyConfig) instance. The IProxyConfig has lists of the current routes and clusters, as well as an `IChangeToken` to notify the proxy when this information is out of date and should be reloaded by calling `GetConfig()` again.

--- a/docs/docfx/articles/getting_started.md
+++ b/docs/docfx/articles/getting_started.md
@@ -80,7 +80,7 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 
 The configuration for YARP is defined in the appsettings.json file. See [Configuration Files](configfiles.md) for details.
 
-The configuration can also be provided programatically. See [Configuration Providers](configproviders.md) for details.
+The configuration can also be provided programmatically. See [Configuration Providers](configproviders.md) for details.
 
 You can find out more about the available configuration options by looking at [ProxyRoute](xref:Microsoft.ReverseProxy.Abstractions.ProxyRoute) and [Cluster](xref:Microsoft.ReverseProxy.Abstractions.Cluster).
  


### PR DESCRIPTION
Probably should have double checked the spelling before merging #436 instead of immediately after 😆 