### PR TITLE
Implement header based routing 

### DIFF
--- a/docs/docfx/articles/configfiles.md
+++ b/docs/docfx/articles/configfiles.md
@@ -75,7 +75,7 @@ The routes section is an ordered list of route matches and their associated conf
 - ClusterId - Refers to the name of an entry in the clusters section.
 - Match containing either a Hosts array or a Path pattern string.
 
-[Authorization](authn-authz.md), [CORS](cors.md), and other route based policies can be configured on each route entry. For additional fields see [ProxyRoute](xref:Microsoft.ReverseProxy.Configuration.Contract.ProxyRouteData).
+[Headers](header-routing.md), [Authorization](authn-authz.md), [CORS](cors.md), and other route based policies can be configured on each route entry. For additional fields see [ProxyRoute](xref:Microsoft.ReverseProxy.Configuration.Contract.ProxyRouteData).
 
 The proxy will apply the given matching criteria and policies, and then pass off the request to the specified cluster.
 

--- a/docs/docfx/articles/configproviders.md
+++ b/docs/docfx/articles/configproviders.md
@@ -14,7 +14,7 @@ The routes section is an ordered list of route matches and their associated conf
 - ClusterId - Refers to the name of an entry in the clusters section.
 - Match containing either a Hosts array or a Path pattern string.
 
-[Authorization](authn-authz.md), [CORS](cors.md), and other route based policies can be configured on each route entry. For additional fields see [ProxyRoute](xref:Microsoft.ReverseProxy.Abstractions.ProxyRoute).
+[Headers](header-routing.md), [Authorization](authn-authz.md), [CORS](cors.md), and other route based policies can be configured on each route entry. For additional fields see [ProxyRoute](xref:Microsoft.ReverseProxy.Abstractions.ProxyRoute).
 
 The proxy will apply the given matching criteria and policies, and then pass off the request to the specified cluster.
 

--- a/docs/docfx/articles/header-routing.md
+++ b/docs/docfx/articles/header-routing.md
@@ -1,0 +1,283 @@
+---
+uid: header-routing
+title: Header Routing
+---
+
+# Header Based Routing
+
+Proxy routes specified in [config](configfiles.md) or via [code](configproviders.md) must include at least a path or host to match against. In addition to these, a route can also specify one or more headers that must be present on the request.
+
+### Precedence
+
+The default route match precedence order is 1) path, 2) method, 3) host, 4) headers. That means a route which specifies methods and no headers will match before a route which specifies headers and no methods. This can be overridden by setting the `Order` property on a route.
+
+## Configuration
+
+Headers are specified in the `Match` section of a proxy route.
+
+If multiple headers rules are specified on a route then all must match for a route to be taken. OR logic must be implemented either within a header rule or as separate routes.
+
+Configuration:
+```JSON
+    "Routes": [
+      {
+        "RouteId": "route1",
+        "ClusterId": "cluster1",
+        "Match": {
+          "Path": "{**catch-all}",
+          "Headers": [
+            {
+              "Name": "header1",
+              "Values": [ "value1" ],
+              "Mode": "ExactHeader"
+            }
+          ]
+        }
+      },
+      {
+        "RouteId": "route2",
+        "ClusterId": "cluster1",
+        "Match": {
+          "Path": "{**catch-all}",
+          "Headers": [
+            {
+              "Name": "header2",
+              "Values": [ "1prefix", "2prefix" ],
+              "Mode": "HeaderPrefix"
+            }
+          ]
+        }
+      },
+      {
+        "RouteId": "route3",
+        "ClusterId": "cluster1",
+        "Match": {
+          "Path": "{**catch-all}",
+          "Headers": [
+            {
+              "Name": "header3",
+              "Mode": "Exists"
+            }
+          ]
+        }
+      },
+      {
+        "RouteId": "route4",
+        "ClusterId": "cluster1",
+        "Match": {
+          "Path": "{**catch-all}",
+          "Headers": [
+            {
+              "Name": "header4",
+              "Values": [ "value1", "value2" ],
+              "Mode": "ExactHeader"
+            },
+            {
+              "Name": "header5",
+              "Mode": "Exists"
+            }
+          ]
+        }
+      }
+    ]
+```
+
+Code:
+```C#
+    var routes = new[]
+    {
+        new ProxyRoute()
+        {
+            RouteId = "route1",
+            ClusterId = "cluster1",
+            Match =
+            {
+                Path = "{**catch-all}",
+                Headers = new[]
+                {
+                    new RouteHeader()
+                    {
+                        Name = "Header1",
+                        Values = new[] { "value1" },
+                        Mode = HeaderMatchMode.ExactHeader
+                    }
+                }
+            }
+        },
+        new ProxyRoute()
+        {
+            RouteId = "route2",
+            ClusterId = "cluster1",
+            Match =
+            {
+                Path = "{**catch-all}",
+                Headers = new[]
+                {
+                    new RouteHeader()
+                    {
+                        Name = "Header2",
+                        Values = new[] { "1prefix", "2prefix" },
+                        Mode = HeaderMatchMode.HeaderPrefix
+                    }
+                }
+            }
+        },
+        new ProxyRoute()
+        {
+            RouteId = "route3",
+            ClusterId = "cluster1",
+            Match =
+            {
+                Path = "{**catch-all}",
+                Headers = new[]
+                {
+                    new RouteHeader()
+                    {
+                        Name = "Header3",
+                        Mode = HeaderMatchMode.Exists
+                    }
+                }
+            }
+        },
+        new ProxyRoute()
+        {
+            RouteId = "route4",
+            ClusterId = "cluster1",
+            Match =
+            {
+                Path = "{**catch-all}",
+                Headers = new[]
+                {
+                    new RouteHeader()
+                    {
+                        Name = "Header4",
+                        Values = new[] { "value1", "value2" },
+                        Mode = HeaderMatchMode.ExactHeader
+                    },
+                    new RouteHeader()
+                    {
+                        Name = "Header5",
+                        Mode = HeaderMatchMode.Exists
+                    }
+                }
+            }
+        }
+    };
+```
+
+## Contract
+
+[RouteHeaderData](xref:Microsoft.ReverseProxy.Configuration.Contract.RouteHeaderData) defines the configuration contract, where [RouteHeader](xref:Microsoft.ReverseProxy.Abstractions.RouteHeader) defines the code contract. The only difference in these contracts is that RouteHeaderData defines an extra `Value` property for convenience, `Values` is preferred if specified.
+
+### Name
+
+The header name to check for on the request. A non-empty value is required. This field is case-insensitive per the HTTP RFCs.
+
+### Values
+
+A list of possible values to search for. The header must match at least one of these values according to the specified `Mode`. At least one value is required unless `Mode` is set to `Exists`.
+
+### Mode
+
+[HeaderMatchMode](xref:Microsoft.ReverseProxy.Abstractions.HeaderMatchMode) specifies how to match the value(s) against the request header. The default is `ExactHeader`.
+- ExactHeader - The header must match in its entirety, subject to the value of `IsCaseSensitive`. Only single headers are supported. If there are multiple headers with the same name then the match fails.
+- HeaderPrefix - The header must match by prefix, subject to the value of `IsCaseSensitive`. Only single headers are supported. If there are multiple headers with the same name then the match fails.
+- Exists - The header must exist and contain any non-empty value.
+
+### IsCaseSensitive
+
+Indicates if the value match should be performed as case sensitive or insensitive. The default is `false`, insensitive.
+
+## Examples
+
+These examples use the configuration specified above.
+
+### Scenario 1 - Exact Header Match
+
+A request with the following header will match against route1.
+```
+Header1: Value1
+```
+
+A header with multiple values is not currently supported and will _not_ match.
+```
+Header1: Value1, Value2
+```
+
+Multiple headers with the same name are not currently supported and will _not_ match.
+```
+Header1: Value1
+Header1: Value2
+```
+
+### Scenario 2 - Multiple Values
+
+Route2 defined multiple values to search for in a header ("1prefix", "2prefix"), any of the values are acceptable. It also specified the `Mode` as `HeaderPrefix`, so any header that starts with those values is acceptable.
+
+Any of the following headers will match route2.
+```
+Header2: 1prefix
+```
+```
+Header2: 2prefix
+```
+```
+Header2: 1prefix-extra
+```
+```
+Header2: 2prefix-extra
+```
+
+A header with multiple values is not currently supported and will _not_ match.
+```
+Header2: 1prefix, 2prefix
+```
+
+Multiple headers with the same name are not currently supported and will _not_ match.
+```
+Header2: 1prefix
+Header2: 2prefix
+```
+
+### Scenario 3 - Exists
+
+Route3 only requires that the header "Header3" exists with any non-empty value
+
+The following is an example that will match route3.
+```
+Header3: value
+```
+
+An empty header will _not_ match.
+```
+Header3:
+```
+
+This mode does support headers with multiple values and multiple headers with the same name since it does not look at the header contents. The following will match.
+```
+Header3: value1, value2
+```
+```
+Header3: value1
+Header3: value2
+```
+
+### Scenario 4 - Multiple Headers
+
+Route4 requires both `header4` and `header5`, each matching according to their specified `Mode`. The following headers will match route4:
+```
+Header4: value1
+Header5: AnyValue
+```
+```
+Header4: value2
+Header5: AnyValue
+```
+
+These will _not_ match route4 because they are missing one of the required headers:
+```
+Header4: value2
+```
+```
+Header5: AnyValue
+```

--- a/docs/docfx/articles/toc.yml
+++ b/docs/docfx/articles/toc.yml
@@ -8,6 +8,8 @@
   href: configproviders.md
 - name: Proxy HTTP client configuration
   href: proxyhttpclientconfig.md
+- name: Header Routing
+  href: header-routing.md
 - name: Authentication and Authorization
   href: authn-authz.md
 - name: Cross-Origin Requests (CORS)

--- a/global.json
+++ b/global.json
@@ -7,17 +7,17 @@
     "runtimes": {
       "dotnet/x64": [
         "$(MicrosoftNETCoreAppPackageVersion)",
-        "3.1.0"
+        "3.1.8"
       ],
       "dotnet/x86": [
         "$(MicrosoftNETCoreAppPackageVersion)",
-        "3.1.0"
+        "3.1.8"
       ],
       "aspnetcore/x64": [
-        "3.1.0"
+        "3.1.8"
       ],
       "aspnetcore/x86": [
-        "3.1.0"
+        "3.1.8"
       ]
     }
   },

--- a/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/HeaderMatchMode.cs
+++ b/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/HeaderMatchMode.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.ReverseProxy.Service.Routing;
+
 namespace Microsoft.ReverseProxy.Abstractions
 {
     /// <summary>
@@ -9,7 +11,7 @@ namespace Microsoft.ReverseProxy.Abstractions
     public enum HeaderMatchMode
     {
         /// <summary>
-        /// The header must match in its entirety, subject to the value of <see cref="IHeaderMetadata.CaseSensitive"/>.
+        /// The header must match in its entirety, subject to the value of <see cref="IHeaderMetadata.IsCaseSensitive"/>.
         /// Only single headers are supported. If there are multiple headers with the same name then the match fails.
         /// </summary>
         ExactHeader,
@@ -20,7 +22,7 @@ namespace Microsoft.ReverseProxy.Abstractions
         // ValuePrefix,
 
         /// <summary>
-        /// The header must match by prefix, subject to the value of <see cref="IHeaderMetadata.CaseSensitive"/>.
+        /// The header must match by prefix, subject to the value of <see cref="IHeaderMetadata.IsCaseSensitive"/>.
         /// Only single headers are supported. If there are multiple headers with the same name then the match fails.
         /// </summary>
         HeaderPrefix,

--- a/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/HeaderMatchMode.cs
+++ b/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/HeaderMatchMode.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Microsoft.ReverseProxy.Service.Routing
+namespace Microsoft.ReverseProxy.Abstractions
 {
     /// <summary>
     /// How to match header values.

--- a/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/ProxyMatch.cs
+++ b/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/ProxyMatch.cs
@@ -76,12 +76,7 @@ namespace Microsoft.ReverseProxy.Abstractions
                 return true;
             }
 
-            if ((headers1?.Count ?? 0) == 0 && (headers2?.Count ?? 0) == 0)
-            {
-                return true;
-            }
-
-            if (headers1 != null && headers2 == null || headers1 == null && headers2 != null)
+            if (headers1 == null || headers2 == null)
             {
                 return false;
             }

--- a/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/ProxyMatch.cs
+++ b/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/ProxyMatch.cs
@@ -34,11 +34,10 @@ namespace Microsoft.ReverseProxy.Abstractions
         /// </summary>
         // public ICollection<KeyValuePair<string, string>> QueryParameters { get; set; }
 
-        // TODO:
         /// <summary>
-        /// Only match requests that contain all of these request headers.
+        /// Only match requests that contain all of these headers.
         /// </summary>
-        // public ICollection<KeyValuePair<string, string>> Headers { get; set; }
+        public IReadOnlyList<RouteHeader> Headers { get; set; }
 
         ProxyMatch IDeepCloneable<ProxyMatch>.DeepClone()
         {
@@ -47,7 +46,7 @@ namespace Microsoft.ReverseProxy.Abstractions
                 Methods = Methods?.ToArray(),
                 Hosts = Hosts?.ToArray(),
                 Path = Path,
-                // Headers = Headers.DeepClone(); // TODO:
+                Headers = Headers?.DeepCloneList(),
             };
         }
 
@@ -65,7 +64,42 @@ namespace Microsoft.ReverseProxy.Abstractions
 
             return string.Equals(proxyMatch1.Path, proxyMatch2.Path, StringComparison.OrdinalIgnoreCase)
                 && CaseInsensitiveEqualHelper.Equals(proxyMatch1.Hosts, proxyMatch2.Hosts)
-                && CaseInsensitiveEqualHelper.Equals(proxyMatch1.Methods, proxyMatch2.Methods);
+                && CaseInsensitiveEqualHelper.Equals(proxyMatch1.Methods, proxyMatch2.Methods)
+                && HeadersEqual(proxyMatch1.Headers, proxyMatch2.Headers);
+        }
+
+        // Order sensitive to reduce complexity
+        private static bool HeadersEqual(IReadOnlyList<RouteHeader> headers1, IReadOnlyList<RouteHeader> headers2)
+        {
+            if (ReferenceEquals(headers1, headers2))
+            {
+                return true;
+            }
+
+            if ((headers1?.Count ?? 0) == 0 && (headers2?.Count ?? 0) == 0)
+            {
+                return true;
+            }
+
+            if (headers1 != null && headers2 == null || headers1 == null && headers2 != null)
+            {
+                return false;
+            }
+
+            if (headers1.Count != headers2.Count)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < headers1.Count; i++)
+            {
+                if (!RouteHeader.Equals(headers1[i], headers2[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/RouteHeader.cs
+++ b/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/RouteHeader.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.ReverseProxy.Service.Routing;
 using Microsoft.ReverseProxy.Utilities;
 
 namespace Microsoft.ReverseProxy.Abstractions
@@ -17,13 +16,13 @@ namespace Microsoft.ReverseProxy.Abstractions
         /// <summary>
         /// Name of the header to look for.
         /// </summary>
-        public string HeaderName { get; set; }
+        public string Name { get; set; }
 
         /// <summary>
-        /// A collection of acceptable header values used during routing.
-        /// The list must not be empty.
+        /// A collection of acceptable header values used during routing. Only one value must match.
+        /// The list must not be empty unless using <see cref="HeaderMatchMode.Exists"/>.
         /// </summary>
-        public IReadOnlyList<string> HeaderValues { get; set; }
+        public IReadOnlyList<string> Values { get; set; }
 
         /// <summary>
         /// Specifies how header values should be compared (e.g. exact matches Vs. by prefix).
@@ -37,16 +36,16 @@ namespace Microsoft.ReverseProxy.Abstractions
         /// When <c>false</c>, <see cref="StringComparison.OrdinalIgnoreCase" /> is used.
         /// Defaults to <c>false</c>.
         /// </summary>
-        public bool CaseSensitive { get; set; }
+        public bool IsCaseSensitive { get; set; }
 
         RouteHeader IDeepCloneable<RouteHeader>.DeepClone()
         {
             return new RouteHeader()
             {
-                HeaderName = HeaderName,
-                HeaderValues = HeaderValues?.ToArray(),
+                Name = Name,
+                Values = Values?.ToArray(),
                 Mode = Mode,
-                CaseSensitive = CaseSensitive,
+                IsCaseSensitive = IsCaseSensitive,
             };
         }
 
@@ -62,12 +61,12 @@ namespace Microsoft.ReverseProxy.Abstractions
                 return false;
             }
 
-            return string.Equals(header1.HeaderName, header1.HeaderName, StringComparison.OrdinalIgnoreCase)
+            return string.Equals(header1.Name, header1.Name, StringComparison.OrdinalIgnoreCase)
                 && header1.Mode == header2.Mode
-                && header1.CaseSensitive == header2.CaseSensitive
-                && header1.CaseSensitive
-                    ? CaseSensitiveEqualHelper.Equals(header1.HeaderValues, header2.HeaderValues)
-                    : CaseInsensitiveEqualHelper.Equals(header1.HeaderValues, header2.HeaderValues);
+                && header1.IsCaseSensitive == header2.IsCaseSensitive
+                && header1.IsCaseSensitive
+                    ? CaseSensitiveEqualHelper.Equals(header1.Values, header2.Values)
+                    : CaseInsensitiveEqualHelper.Equals(header1.Values, header2.Values);
         }
     }
 }

--- a/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/RouteHeader.cs
+++ b/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/RouteHeader.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ReverseProxy.Abstractions
 
         /// <summary>
         /// Specifies how header values should be compared (e.g. exact matches Vs. by prefix).
-        /// Defaults to <see cref="HeaderMatchMode.Exact"/>.
+        /// Defaults to <see cref="HeaderMatchMode.ExactHeader"/>.
         /// </summary>
         public HeaderMatchMode Mode { get; set; }
 

--- a/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/RouteHeader.cs
+++ b/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/RouteHeader.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.ReverseProxy.Service.Routing;
+using Microsoft.ReverseProxy.Utilities;
+
+namespace Microsoft.ReverseProxy.Abstractions
+{
+    /// <summary>
+    /// Route criteria for a header that must be present on the incoming request.
+    /// </summary>
+    public class RouteHeader : IDeepCloneable<RouteHeader>
+    {
+        /// <summary>
+        /// Name of the header to look for.
+        /// </summary>
+        public string HeaderName { get; set; }
+
+        /// <summary>
+        /// A collection of acceptable header values used during routing.
+        /// The list must not be empty.
+        /// </summary>
+        public IReadOnlyList<string> HeaderValues { get; set; }
+
+        /// <summary>
+        /// Specifies how header values should be compared (e.g. exact matches Vs. by prefix).
+        /// Defaults to <see cref="HeaderMatchMode.Exact"/>.
+        /// </summary>
+        public HeaderMatchMode Mode { get; set; }
+
+        /// <summary>
+        /// Specifies whether header value comparisons should ignore case.
+        /// When <c>true</c>, <see cref="StringComparison.Ordinal" /> is used.
+        /// When <c>false</c>, <see cref="StringComparison.OrdinalIgnoreCase" /> is used.
+        /// Defaults to <c>false</c>.
+        /// </summary>
+        public bool CaseSensitive { get; set; }
+
+        RouteHeader IDeepCloneable<RouteHeader>.DeepClone()
+        {
+            return new RouteHeader()
+            {
+                HeaderName = HeaderName,
+                HeaderValues = HeaderValues?.ToArray(),
+                Mode = Mode,
+                CaseSensitive = CaseSensitive,
+            };
+        }
+
+        internal static bool Equals(RouteHeader header1, RouteHeader header2)
+        {
+            if (header1 == null && header2 == null)
+            {
+                return true;
+            }
+
+            if (header1 == null || header2 == null)
+            {
+                return false;
+            }
+
+            return string.Equals(header1.HeaderName, header1.HeaderName, StringComparison.OrdinalIgnoreCase)
+                && header1.Mode == header2.Mode
+                && header1.CaseSensitive == header2.CaseSensitive
+                && header1.CaseSensitive
+                    ? CaseSensitiveEqualHelper.Equals(header1.HeaderValues, header2.HeaderValues)
+                    : CaseInsensitiveEqualHelper.Equals(header1.HeaderValues, header2.HeaderValues);
+        }
+    }
+}

--- a/src/ReverseProxy/Configuration/ConfigurationConfigProvider.cs
+++ b/src/ReverseProxy/Configuration/ConfigurationConfigProvider.cs
@@ -156,7 +156,7 @@ namespace Microsoft.ReverseProxy.Configuration
             return cluster;
         }
 
-        private ProxyRoute Convert(ProxyRouteData data)
+        private static ProxyRoute Convert(ProxyRouteData data)
         {
             var route = new ProxyRoute
             {
@@ -172,7 +172,7 @@ namespace Microsoft.ReverseProxy.Configuration
             return route;
         }
 
-        private void Convert(ProxyMatch proxyMatch, ProxyMatchData data)
+        private static void Convert(ProxyMatch proxyMatch, ProxyMatchData data)
         {
             if (data == null)
             {
@@ -182,9 +182,28 @@ namespace Microsoft.ReverseProxy.Configuration
             proxyMatch.Methods = data.Methods?.ToArray();
             proxyMatch.Hosts = data.Hosts?.ToArray();
             proxyMatch.Path = data.Path;
+            proxyMatch.Headers = Convert(data.Headers);
         }
 
-        private CircuitBreakerOptions Convert(CircuitBreakerData data)
+        private static IReadOnlyList<RouteHeader> Convert(IReadOnlyList<RouteHeaderData> headers)
+        {
+            return headers?.Select(data => Convert(data)).ToArray();
+        }
+
+        private static RouteHeader Convert(RouteHeaderData data)
+        {
+            var routeHeader = new RouteHeader()
+            {
+                Name = data.Name,
+                Values = data.Values,
+                Mode = data.Mode,
+                IsCaseSensitive = data.IsCaseSensitive,
+            };
+
+            return routeHeader;
+        }
+
+        private static CircuitBreakerOptions Convert(CircuitBreakerData data)
         {
             if(data == null)
             {
@@ -198,7 +217,7 @@ namespace Microsoft.ReverseProxy.Configuration
             };
         }
 
-        private QuotaOptions Convert(QuotaData data)
+        private static QuotaOptions Convert(QuotaData data)
         {
             if (data == null)
             {
@@ -212,7 +231,7 @@ namespace Microsoft.ReverseProxy.Configuration
             };
         }
 
-        private ClusterPartitioningOptions Convert(ClusterPartitioningData data)
+        private static ClusterPartitioningOptions Convert(ClusterPartitioningData data)
         {
             if (data == null)
             {
@@ -227,7 +246,7 @@ namespace Microsoft.ReverseProxy.Configuration
             };
         }
 
-        private LoadBalancingOptions Convert(LoadBalancingData data)
+        private static LoadBalancingOptions Convert(LoadBalancingData data)
         {
             if (data == null)
             {
@@ -240,7 +259,7 @@ namespace Microsoft.ReverseProxy.Configuration
             };
         }
 
-        private SessionAffinityOptions Convert(SessionAffinityData data)
+        private static SessionAffinityOptions Convert(SessionAffinityData data)
         {
             if (data == null)
             {
@@ -256,7 +275,7 @@ namespace Microsoft.ReverseProxy.Configuration
             };
         }
 
-        private HealthCheckOptions Convert(HealthCheckData data)
+        private static HealthCheckOptions Convert(HealthCheckData data)
         {
             if (data == null)
             {
@@ -305,7 +324,7 @@ namespace Microsoft.ReverseProxy.Configuration
             };
         }
 
-        private Destination Convert(DestinationData data)
+        private static Destination Convert(DestinationData data)
         {
             if (data == null)
             {

--- a/src/ReverseProxy/Configuration/Contract/ProxyMatchData.cs
+++ b/src/ReverseProxy/Configuration/Contract/ProxyMatchData.cs
@@ -31,10 +31,9 @@ namespace Microsoft.ReverseProxy.Configuration.Contract
         /// </summary>
         // public ICollection<KeyValuePair<string, string>> QueryParameters { get; set; }
 
-        // TODO:
         /// <summary>
-        /// Only match requests that contain all of these request headers.
+        /// Only match requests that contain all of these headers.
         /// </summary>
-        // public ICollection<KeyValuePair<string, string>> Headers { get; set; }
+        public IReadOnlyList<RouteHeaderData> Headers { get; set; }
     }
 }

--- a/src/ReverseProxy/Configuration/Contract/RouteHeaderData.cs
+++ b/src/ReverseProxy/Configuration/Contract/RouteHeaderData.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.ReverseProxy.Abstractions;
+
+namespace Microsoft.ReverseProxy.Configuration.Contract
+{
+    /// <summary>
+    /// Describes the matching criteria for a route.
+    /// </summary>
+    public class RouteHeaderData
+    {
+        /// <summary>
+        /// Name of the header to look for.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// A collection of acceptable header values used during routing. Only one value must match.
+        /// The list must not be empty unless using <see cref="HeaderMatchMode.Exists"/>.
+        /// </summary>
+        public IReadOnlyList<string> Values { get; set; }
+
+        /// <summary>
+        /// Specifies how header values should be compared (e.g. exact matches Vs. by prefix).
+        /// Defaults to <see cref="HeaderMatchMode.ExactHeader"/>.
+        /// </summary>
+        public HeaderMatchMode Mode { get; set; }
+
+        /// <summary>
+        /// Specifies whether header value comparisons should ignore case.
+        /// When <c>true</c>, <see cref="StringComparison.Ordinal" /> is used.
+        /// When <c>false</c>, <see cref="StringComparison.OrdinalIgnoreCase" /> is used.
+        /// Defaults to <c>false</c>.
+        /// </summary>
+        public bool IsCaseSensitive { get; set; }
+    }
+}

--- a/src/ReverseProxy/Configuration/DependencyInjection/BuilderExtensions/IReverseProxyBuilderExtensions.cs
+++ b/src/ReverseProxy/Configuration/DependencyInjection/BuilderExtensions/IReverseProxyBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.ReverseProxy.Abstractions.Telemetry;
@@ -11,6 +12,7 @@ using Microsoft.ReverseProxy.Service.Management;
 using Microsoft.ReverseProxy.Service.Metrics;
 using Microsoft.ReverseProxy.Service.Proxy;
 using Microsoft.ReverseProxy.Service.Proxy.Infrastructure;
+using Microsoft.ReverseProxy.Service.Routing;
 using Microsoft.ReverseProxy.Service.SessionAffinity;
 using Microsoft.ReverseProxy.Telemetry;
 using Microsoft.ReverseProxy.Utilities;
@@ -37,6 +39,7 @@ namespace Microsoft.ReverseProxy.Configuration.DependencyInjection
         {
             builder.Services.TryAddSingleton<IConfigValidator, ConfigValidator>();
             builder.Services.TryAddSingleton<IRuntimeRouteBuilder, RuntimeRouteBuilder>();
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<MatcherPolicy, HeaderMatcherPolicy>());
             return builder;
         }
 

--- a/src/ReverseProxy/Configuration/DependencyInjection/ReverseProxyServiceCollectionExtensions.cs
+++ b/src/ReverseProxy/Configuration/DependencyInjection/ReverseProxyServiceCollectionExtensions.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddDataProtection();
             services.AddAuthorization();
             services.AddCors();
+            services.AddRouting();
 
             return builder;
         }

--- a/src/ReverseProxy/Service/Config/RuntimeRouteBuilder.cs
+++ b/src/ReverseProxy/Service/Config/RuntimeRouteBuilder.cs
@@ -11,7 +11,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.ReverseProxy.Abstractions;
 using Microsoft.ReverseProxy.Abstractions.RouteDiscovery.Contract;
 using Microsoft.ReverseProxy.RuntimeModel;
-using Microsoft.ReverseProxy.Service.Config;
+using Microsoft.ReverseProxy.Service.Routing;
 using CorsConstants = Microsoft.ReverseProxy.Abstractions.RouteDiscovery.Contract.CorsConstants;
 
 namespace Microsoft.ReverseProxy.Service
@@ -74,6 +74,17 @@ namespace Microsoft.ReverseProxy.Service
             if (source.Match.Hosts != null && source.Match.Hosts.Count != 0)
             {
                 endpointBuilder.Metadata.Add(new AspNetCore.Routing.HostAttribute(source.Match.Hosts.ToArray()));
+            }
+
+            if (source.Match.Headers != null && source.Match.Headers.Count > 0)
+            {
+                var matchers = new List<HeaderMatcher>(source.Match.Headers.Count);
+                foreach (var header in source.Match.Headers)
+                {
+                    matchers.Add(new HeaderMatcher(header.Name, header.Values, header.Mode, header.IsCaseSensitive));
+                }
+
+                endpointBuilder.Metadata.Add(new HeaderMetadata(matchers));
             }
 
             bool acceptCorsPreflight;

--- a/src/ReverseProxy/Service/Routing/HeaderMatchMode.cs
+++ b/src/ReverseProxy/Service/Routing/HeaderMatchMode.cs
@@ -14,6 +14,11 @@ namespace Microsoft.ReverseProxy.Service.Routing
         Exact,
 
         /// <summary>
+        /// The header must exist, but any non-empty value is allowed.
+        /// </summary>
+        Exists,
+
+        /// <summary>
         /// Header value must match by prefix, subject to the value of <see cref="IHeaderMetadata.CaseSensitive"/>.
         /// </summary>
         Prefix,

--- a/src/ReverseProxy/Service/Routing/HeaderMatchMode.cs
+++ b/src/ReverseProxy/Service/Routing/HeaderMatchMode.cs
@@ -4,23 +4,30 @@
 namespace Microsoft.ReverseProxy.Service.Routing
 {
     /// <summary>
-    /// How to compare header values.
+    /// How to match header values.
     /// </summary>
     public enum HeaderMatchMode
     {
         /// <summary>
-        /// Header value must match in its entirety, subject to the value of <see cref="IHeaderMetadata.CaseSensitive"/>.
+        /// The header must match in its entirety, subject to the value of <see cref="IHeaderMetadata.CaseSensitive"/>.
+        /// Only single headers are supported. If there are multiple headers with the same name then the match fails.
         /// </summary>
-        Exact,
+        ExactHeader,
+
+        // TODO: Matches individual values from multi-value headers (split by coma, or semicolon for cookies).
+        // Also supports multiple headers of the same name.
+        // ExactValue,
+        // ValuePrefix,
 
         /// <summary>
-        /// The header must exist, but any non-empty value is allowed.
+        /// The header must match by prefix, subject to the value of <see cref="IHeaderMetadata.CaseSensitive"/>.
+        /// Only single headers are supported. If there are multiple headers with the same name then the match fails.
+        /// </summary>
+        HeaderPrefix,
+
+        /// <summary>
+        /// The header must exist and contain any non-empty value.
         /// </summary>
         Exists,
-
-        /// <summary>
-        /// Header value must match by prefix, subject to the value of <see cref="IHeaderMetadata.CaseSensitive"/>.
-        /// </summary>
-        Prefix,
     }
 }

--- a/src/ReverseProxy/Service/Routing/HeaderMatchMode.cs
+++ b/src/ReverseProxy/Service/Routing/HeaderMatchMode.cs
@@ -6,7 +6,7 @@ namespace Microsoft.ReverseProxy.Service.Routing
     /// <summary>
     /// How to compare header values.
     /// </summary>
-    public enum HeaderValueMatchMode
+    public enum HeaderMatchMode
     {
         /// <summary>
         /// Header value must match in its entirety, subject to the value of <see cref="IHeaderMetadata.CaseSensitive"/>.

--- a/src/ReverseProxy/Service/Routing/HeaderMatcher.cs
+++ b/src/ReverseProxy/Service/Routing/HeaderMatcher.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.ReverseProxy.Abstractions;
+
+namespace Microsoft.ReverseProxy.Service.Routing
+{
+    /// <summary>
+    /// A request header matcher used during routing.
+    /// </summary>
+    internal class HeaderMatcher
+    {
+        /// <summary>
+        /// Creates a new instance.
+        /// </summary>
+        public HeaderMatcher(string name, IReadOnlyList<string> values, HeaderMatchMode mode, bool isCaseSensitive)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("A header name is required.", nameof(name));
+            }
+            if (mode != HeaderMatchMode.Exists
+                && (values == null || values.Count == 0))
+            {
+                throw new ArgumentException("Header values must have at least one value.", nameof(values));
+            }
+            if (mode == HeaderMatchMode.Exists && values?.Count > 0)
+            {
+                throw new ArgumentException($"Header values must not be specified when using '{nameof(HeaderMatchMode.Exists)}'.", nameof(values));
+            }
+
+            Name = name;
+            Values = values;
+            Mode = mode;
+            IsCaseSensitive = isCaseSensitive;
+        }
+
+        /// <summary>
+        /// Name of the header to look for.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Returns a read-only collection of acceptable header values used during routing.
+        /// At least one value is required unless <see cref="Mode"/> is set to <see cref="HeaderMatchMode.Exists"/>.
+        /// </summary>
+        public IReadOnlyList<string> Values { get; }
+
+        /// <summary>
+        /// Specifies how header values should be compared (e.g. exact matches Vs. by prefix).
+        /// Defaults to <see cref="HeaderMatchMode.ExactHeader"/>.
+        /// </summary>
+        public HeaderMatchMode Mode { get; }
+
+        /// <summary>
+        /// Specifies whether header value comparisons should ignore case.
+        /// When <c>true</c>, <see cref="StringComparison.Ordinal" /> is used.
+        /// When <c>false</c>, <see cref="StringComparison.OrdinalIgnoreCase" /> is used.
+        /// Defaults to <c>false</c>.
+        /// </summary>
+        public bool IsCaseSensitive { get; }
+    }
+}

--- a/src/ReverseProxy/Service/Routing/HeaderMatcherPolicy.cs
+++ b/src/ReverseProxy/Service/Routing/HeaderMatcherPolicy.cs
@@ -70,7 +70,7 @@ namespace Microsoft.ReverseProxy.Service.Routing
                     {
                         var requestHeaderValue = requestHeaderValues.ToString();
                         var comparisonFunc = GetComparisonFunc(metadata.ValueMatchMode);
-                        var stringComparison = metadata.ValueIgnoresCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+                        var stringComparison = metadata.CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
                         for (var j = 0; j < metadataHeaderValues.Count; j++)
                         {
                             if (comparisonFunc(requestHeaderValue, metadataHeaderValues[j], stringComparison))
@@ -169,15 +169,15 @@ namespace Microsoft.ReverseProxy.Service.Routing
                 }
 
                 // 4. Then, by case sensitivity
-                if (x.ValueIgnoresCase && !y.ValueIgnoresCase)
-                {
-                    // y is more specific, as *only it* is case sensitive
-                    return 1;
-                }
-                else if (!x.ValueIgnoresCase && y.ValueIgnoresCase)
+                if (x.CaseSensitive && !y.CaseSensitive)
                 {
                     // x is more specific, as *only it* is case sensitive
                     return -1;
+                }
+                else if (!x.CaseSensitive && y.CaseSensitive)
+                {
+                    // y is more specific, as *only it* is case sensitive
+                    return 1;
                 }
 
                 // They have equal specificity

--- a/src/ReverseProxy/Service/Routing/HeaderMatcherPolicy.cs
+++ b/src/ReverseProxy/Service/Routing/HeaderMatcherPolicy.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Matching;
+
+namespace Microsoft.ReverseProxy.Service.Routing
+{
+    internal sealed class HeaderMatcherPolicy : MatcherPolicy, IEndpointComparerPolicy, IEndpointSelectorPolicy
+    {
+        /// <inheritdoc/>
+        // Run after HttpMethodMatcherPolicy (-1000) and HostMatcherPolicy (-100), but before default (0)
+        public override int Order => -50;
+
+        /// <inheritdoc/>
+        public IComparer<Endpoint> Comparer => new HeaderMetadataEndpointComparer();
+
+        /// <inheritdoc/>
+        bool IEndpointSelectorPolicy.AppliesToEndpoints(IReadOnlyList<Endpoint> endpoints)
+        {
+            _ = endpoints ?? throw new ArgumentNullException(nameof(endpoints));
+
+            // When the node contains dynamic endpoints we can't make any assumptions.
+            if (ContainsDynamicEndpoints(endpoints))
+            {
+                return true;
+            }
+
+            return AppliesToEndpointsCore(endpoints);
+        }
+
+        /// <inheritdoc/>
+        public Task ApplyAsync(HttpContext httpContext, CandidateSet candidates)
+        {
+            _ = httpContext ?? throw new ArgumentNullException(nameof(httpContext));
+            _ = candidates ?? throw new ArgumentNullException(nameof(candidates));
+
+            for (var i = 0; i < candidates.Count; i++)
+            {
+                if (!candidates.IsValidCandidate(i))
+                {
+                    continue;
+                }
+
+                var metadata = candidates[i].Endpoint.Metadata.GetMetadata<IHeaderMetadata>();
+                var metadataHeaderName = metadata?.HeaderName;
+                if (string.IsNullOrEmpty(metadataHeaderName))
+                {
+                    // Can match any request
+                    continue;
+                }
+
+                var metadataHeaderValues = metadata.HeaderValues;
+                var maxValuesToInspect = metadata.MaximumValuesToInspect;
+
+                var matched = false;
+                if (httpContext.Request.Headers.TryGetValue(metadataHeaderName, out var requestHeaderValues))
+                {
+                    if (metadataHeaderValues?.Count == 0)
+                    {
+                        // We were asked to match as long as the header exists, and it *does* exist
+                        matched = true;
+                    }
+                    else
+                    {
+                        var comparisonFunc = GetComparisonFunc(metadata.ValueMatchMode);
+                        var stringComparison = metadata.ValueIgnoresCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+                        for (var j = 0; j < metadataHeaderValues.Count; j++)
+                        {
+                            for (var k = 0; k < requestHeaderValues.Count && k < maxValuesToInspect; k++)
+                            {
+                                if (comparisonFunc(requestHeaderValues[k], metadataHeaderValues[j], stringComparison))
+                                {
+                                    matched = true;
+                                    break;
+                                }
+                            }
+
+                            if (matched)
+                            {
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                if (!matched)
+                {
+                    candidates.SetValidity(i, false);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private static Func<string, string, StringComparison, bool> GetComparisonFunc(HeaderValueMatchMode matchMode)
+        {
+            return matchMode switch
+            {
+                HeaderValueMatchMode.Prefix => Prefix,
+                _ => Exact,
+            };
+
+            static bool Exact(string a, string b, StringComparison comparison) => string.Equals(a, b, comparison);
+            static bool Prefix(string a, string b, StringComparison comparison) => a != null && b != null && a.StartsWith(b, comparison);
+        }
+
+        private static bool AppliesToEndpointsCore(IReadOnlyList<Endpoint> endpoints)
+        {
+            return endpoints.Any(e =>
+            {
+                var metadata = e.Metadata.GetMetadata<IHeaderMetadata>();
+                return !string.IsNullOrEmpty(metadata?.HeaderName);
+            });
+        }
+
+        private class HeaderMetadataEndpointComparer : EndpointMetadataComparer<IHeaderMetadata>
+        {
+            protected override int CompareMetadata(IHeaderMetadata x, IHeaderMetadata y)
+            {
+                var xPresent = !string.IsNullOrEmpty(x?.HeaderName);
+                var yPresent = !string.IsNullOrEmpty(y?.HeaderName);
+
+                // 1. First, sort by presence of metadata
+                if (!xPresent && yPresent)
+                {
+                    // y is more specific
+                    return 1;
+                }
+                else if (xPresent && !yPresent)
+                {
+                    // x is more specific
+                    return -1;
+                }
+                else if (!xPresent && !yPresent)
+                {
+                    // None of the policies have any effect, so they have same specificity.
+                    return 0;
+                }
+
+                // 2. Then, by whether we seek specific header values or just header presence
+                var xCount = x.HeaderValues?.Count ?? 0;
+                var yCount = y.HeaderValues?.Count ?? 0;
+
+                if (xCount == 0 && yCount > 0)
+                {
+                    // y is more specific, as *only it* looks for specific header values
+                    return 1;
+                }
+                else if (xCount > 0 && yCount == 0)
+                {
+                    // x is more specific, as *only it* looks for specific header values
+                    return -1;
+                }
+                else if (xCount == 0 && yCount == 0)
+                {
+                    // Same specificity, they both only check eader presence
+                    return 0;
+                }
+
+                // 3. Then, by value match mode (Exact Vs. Prefix)
+                if (x.ValueMatchMode != HeaderValueMatchMode.Exact && y.ValueMatchMode == HeaderValueMatchMode.Exact)
+                {
+                    // y is more specific, as *only it* does exact match
+                    return 1;
+                }
+                else if (x.ValueMatchMode == HeaderValueMatchMode.Exact && y.ValueMatchMode != HeaderValueMatchMode.Exact)
+                {
+                    // x is more specific, as *only it* does exact match
+                    return -1;
+                }
+
+                // 4. Then, by case sensitivity
+                if (x.ValueIgnoresCase && !y.ValueIgnoresCase)
+                {
+                    // y is more specific, as *only it* is case sensitive
+                    return 1;
+                }
+                else if (!x.ValueIgnoresCase && y.ValueIgnoresCase)
+                {
+                    // x is more specific, as *only it* is case sensitive
+                    return -1;
+                }
+
+                // 5. then, by how many headers are inspected
+                if (x.MaximumValuesToInspect > y.MaximumValuesToInspect)
+                {
+                    // y is more specific, as it needs a match among a smaller number of incoming headers.
+                    return 1;
+                }
+                else if (x.MaximumValuesToInspect < y.MaximumValuesToInspect)
+                {
+                    // x is more specific, as it needs a match among a smaller number of incoming headers.
+                    return -1;
+                }
+
+                // They have equal specificity
+                return 0;
+            }
+        }
+    }
+}

--- a/src/ReverseProxy/Service/Routing/HeaderMatcherPolicy.cs
+++ b/src/ReverseProxy/Service/Routing/HeaderMatcherPolicy.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.Extensions.Primitives;
+using Microsoft.ReverseProxy.Abstractions;
 
 namespace Microsoft.ReverseProxy.Service.Routing
 {

--- a/src/ReverseProxy/Service/Routing/HeaderMetadata.cs
+++ b/src/ReverseProxy/Service/Routing/HeaderMetadata.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.ReverseProxy.Abstractions;
 
 namespace Microsoft.ReverseProxy.Service.Routing
 {
@@ -12,47 +11,12 @@ namespace Microsoft.ReverseProxy.Service.Routing
     /// </summary>
     internal class HeaderMetadata : IHeaderMetadata
     {
-        public HeaderMetadata(string headerName, IReadOnlyList<string> headerValues, HeaderMatchMode mode, bool caseSensitive)
+        public HeaderMetadata(IReadOnlyList<HeaderMatcher> matchers)
         {
-            if (string.IsNullOrEmpty(headerName))
-            {
-                throw new ArgumentException("A header name is required.", nameof(headerName));
-            }
-            if (mode != HeaderMatchMode.Exists
-                && (headerValues == null || headerValues.Count == 0))
-            {
-                throw new ArgumentException("Header values must have at least one value.", nameof(headerValues));
-            }
-
-            HeaderName = headerName;
-            HeaderValues = headerValues;
-            Mode = mode;
-            CaseSensitive = caseSensitive;
+            Matchers = matchers ?? throw new ArgumentNullException(nameof(matchers));
         }
 
-        /// <summary>
-        /// Name of the header to look for.
-        /// </summary>
-        public string HeaderName { get; }
-
-        /// <summary>
-        /// Returns a read-only collection of acceptable header values used during routing.
-        /// An empty collection means any header value will be accepted, as long as the header is present.
-        /// </summary>
-        public IReadOnlyList<string> HeaderValues { get; }
-
-        /// <summary>
-        /// Specifies how header values should be compared (e.g. exact matches Vs. by prefix).
-        /// Defaults to <see cref="HeaderMatchMode.ExactHeader"/>.
-        /// </summary>
-        public HeaderMatchMode Mode { get; }
-
-        /// <summary>
-        /// Specifies whether header value comparisons should ignore case.
-        /// When <c>true</c>, <see cref="StringComparison.Ordinal" /> is used.
-        /// When <c>false</c>, <see cref="StringComparison.OrdinalIgnoreCase" /> is used.
-        /// Defaults to <c>false</c>.
-        /// </summary>
-        public bool CaseSensitive { get; }
+        /// <inheritdoc/>
+        public IReadOnlyList<HeaderMatcher> Matchers { get; }
     }
 }

--- a/src/ReverseProxy/Service/Routing/HeaderMetadata.cs
+++ b/src/ReverseProxy/Service/Routing/HeaderMetadata.cs
@@ -13,6 +13,16 @@ namespace Microsoft.ReverseProxy.Service.Routing
     {
         public HeaderMetadata(string headerName, IReadOnlyList<string> headerValues, HeaderMatchMode mode, bool caseSensitive)
         {
+            if (string.IsNullOrEmpty(headerName))
+            {
+                throw new ArgumentException("A header name is required.", nameof(headerName));
+            }
+            if (mode != HeaderMatchMode.Exists
+                && (headerValues == null || headerValues.Count == 0))
+            {
+                throw new ArgumentException("Header values must have at least one value.", nameof(headerValues));
+            }
+
             HeaderName = headerName;
             HeaderValues = headerValues;
             Mode = mode;
@@ -32,7 +42,7 @@ namespace Microsoft.ReverseProxy.Service.Routing
 
         /// <summary>
         /// Specifies how header values should be compared (e.g. exact matches Vs. by prefix).
-        /// Defaults to <see cref="HeaderMatchMode.Exact"/>.
+        /// Defaults to <see cref="HeaderMatchMode.ExactHeader"/>.
         /// </summary>
         public HeaderMatchMode Mode { get; }
 

--- a/src/ReverseProxy/Service/Routing/HeaderMetadata.cs
+++ b/src/ReverseProxy/Service/Routing/HeaderMetadata.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.ReverseProxy.Abstractions;
 
 namespace Microsoft.ReverseProxy.Service.Routing
 {

--- a/src/ReverseProxy/Service/Routing/HeaderMetadata.cs
+++ b/src/ReverseProxy/Service/Routing/HeaderMetadata.cs
@@ -9,24 +9,32 @@ namespace Microsoft.ReverseProxy.Service.Routing
     /// <summary>
     /// Represents request header metadata used during routing.
     /// </summary>
-    internal interface IHeaderMetadata
+    internal class HeaderMetadata : IHeaderMetadata
     {
+        public HeaderMetadata(string headerName, IReadOnlyList<string> headerValues, HeaderMatchMode mode, bool caseSensitive)
+        {
+            HeaderName = headerName;
+            HeaderValues = headerValues;
+            Mode = mode;
+            CaseSensitive = caseSensitive;
+        }
+
         /// <summary>
         /// Name of the header to look for.
         /// </summary>
-        string HeaderName { get; }
+        public string HeaderName { get; }
 
         /// <summary>
         /// Returns a read-only collection of acceptable header values used during routing.
         /// An empty collection means any header value will be accepted, as long as the header is present.
         /// </summary>
-        IReadOnlyList<string> HeaderValues { get; }
+        public IReadOnlyList<string> HeaderValues { get; }
 
         /// <summary>
         /// Specifies how header values should be compared (e.g. exact matches Vs. by prefix).
         /// Defaults to <see cref="HeaderMatchMode.Exact"/>.
         /// </summary>
-        HeaderMatchMode Mode { get; }
+        public HeaderMatchMode Mode { get; }
 
         /// <summary>
         /// Specifies whether header value comparisons should ignore case.
@@ -34,6 +42,6 @@ namespace Microsoft.ReverseProxy.Service.Routing
         /// When <c>false</c>, <see cref="StringComparison.OrdinalIgnoreCase" /> is used.
         /// Defaults to <c>false</c>.
         /// </summary>
-        bool CaseSensitive { get; }
+        public bool CaseSensitive { get; }
     }
 }

--- a/src/ReverseProxy/Service/Routing/HeaderValueMatchMode.cs
+++ b/src/ReverseProxy/Service/Routing/HeaderValueMatchMode.cs
@@ -9,12 +9,12 @@ namespace Microsoft.ReverseProxy.Service.Routing
     public enum HeaderValueMatchMode
     {
         /// <summary>
-        /// Header value must match in its entirety, subject to the value of <see cref="IHeaderMetadata.ValueIgnoresCase"/>.
+        /// Header value must match in its entirety, subject to the value of <see cref="IHeaderMetadata.CaseSensitive"/>.
         /// </summary>
         Exact,
 
         /// <summary>
-        /// Header value must match by prefix, subject to the value of <see cref="IHeaderMetadata.ValueIgnoresCase"/>.
+        /// Header value must match by prefix, subject to the value of <see cref="IHeaderMetadata.CaseSensitive"/>.
         /// </summary>
         Prefix,
     }

--- a/src/ReverseProxy/Service/Routing/HeaderValueMatchMode.cs
+++ b/src/ReverseProxy/Service/Routing/HeaderValueMatchMode.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.ReverseProxy.Service.Routing
+{
+    /// <summary>
+    /// How to compare header values.
+    /// </summary>
+    public enum HeaderValueMatchMode
+    {
+        /// <summary>
+        /// Header value must match in its entirety, subject to the value of <see cref="IHeaderMetadata.ValueIgnoresCase"/>.
+        /// </summary>
+        Exact,
+
+        /// <summary>
+        /// Header value must match by prefix, subject to the value of <see cref="IHeaderMetadata.ValueIgnoresCase"/>.
+        /// </summary>
+        Prefix,
+    }
+}

--- a/src/ReverseProxy/Service/Routing/IHeaderMetadata.cs
+++ b/src/ReverseProxy/Service/Routing/IHeaderMetadata.cs
@@ -28,6 +28,14 @@ namespace Microsoft.ReverseProxy.Service.Routing
         /// </summary>
         HeaderMatchMode Mode { get; }
 
+        // Not implemented:
+        // A request header may have multiple values, either as multiple headers,
+        // a comma separated header, or some combination of the two.
+        // Also don't forget cookies that are semi-colon separated.
+        // The current implementation doesn't attempt to match individual header values,
+        // it only supports matching a single full header.
+        // bool AllowMultiValueHeaders { get; }
+
         /// <summary>
         /// Specifies whether header value comparisons should ignore case.
         /// When <c>true</c>, <see cref="StringComparison.Ordinal" /> is used.

--- a/src/ReverseProxy/Service/Routing/IHeaderMetadata.cs
+++ b/src/ReverseProxy/Service/Routing/IHeaderMetadata.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.ReverseProxy.Service.Routing
+{
+    /// <summary>
+    /// Represents request header metadata used during routing.
+    /// </summary>
+    public interface IHeaderMetadata
+    {
+        /// <summary>
+        /// Name of the header to look for.
+        /// </summary>
+        string HeaderName { get; }
+
+        /// <summary>
+        /// Returns a read-only collection of acceptable header values used during routing.
+        /// An empty collection means any header value will be accepted, as long as the header is present.
+        /// </summary>
+        IReadOnlyList<string> HeaderValues { get; }
+
+        /// <summary>
+        /// Specifies how header values should be compared (e.g. exact matches Vs. by prefix).
+        /// Defaults to <see cref="HeaderValueMatchMode.Exact"/>.
+        /// </summary>
+        HeaderValueMatchMode ValueMatchMode { get; }
+
+        /// <summary>
+        /// Specifies whether header value comparisons should ignore case.
+        /// When <c>false</c>, <see cref="StringComparison.Ordinal" /> is used.
+        /// When <c>true</c>, <see cref="StringComparison.OrdinalIgnoreCase" /> is used.
+        /// Defaults to <c>false</c>.
+        /// </summary>
+        bool ValueIgnoresCase { get; }
+
+        /// <summary>
+        /// Specifies the maximum number of incoming header values to inspect when evaluating each <see cref="HeaderValues"/>.
+        /// </summary>
+        /// <remarks>
+        /// Since header-based routing is commonly used in scenarios where a single header value is expected,
+        /// this helps us bail out early for unexpected requests.
+        /// </remarks>
+        int MaximumValuesToInspect { get; }
+    }
+}

--- a/src/ReverseProxy/Service/Routing/IHeaderMetadata.cs
+++ b/src/ReverseProxy/Service/Routing/IHeaderMetadata.cs
@@ -30,10 +30,10 @@ namespace Microsoft.ReverseProxy.Service.Routing
 
         /// <summary>
         /// Specifies whether header value comparisons should ignore case.
-        /// When <c>false</c>, <see cref="StringComparison.Ordinal" /> is used.
-        /// When <c>true</c>, <see cref="StringComparison.OrdinalIgnoreCase" /> is used.
+        /// When <c>true</c>, <see cref="StringComparison.Ordinal" /> is used.
+        /// When <c>false</c>, <see cref="StringComparison.OrdinalIgnoreCase" /> is used.
         /// Defaults to <c>false</c>.
         /// </summary>
-        bool ValueIgnoresCase { get; }
+        bool CaseSensitive { get; }
     }
 }

--- a/src/ReverseProxy/Service/Routing/IHeaderMetadata.cs
+++ b/src/ReverseProxy/Service/Routing/IHeaderMetadata.cs
@@ -18,7 +18,7 @@ namespace Microsoft.ReverseProxy.Service.Routing
 
         /// <summary>
         /// Returns a read-only collection of acceptable header values used during routing.
-        /// An empty collection means any header value will be accepted, as long as the header is present.
+        /// The list must not be empty.
         /// </summary>
         IReadOnlyList<string> HeaderValues { get; }
 

--- a/src/ReverseProxy/Service/Routing/IHeaderMetadata.cs
+++ b/src/ReverseProxy/Service/Routing/IHeaderMetadata.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ReverseProxy.Service.Routing
 
         /// <summary>
         /// Specifies how header values should be compared (e.g. exact matches Vs. by prefix).
-        /// Defaults to <see cref="HeaderMatchMode.Exact"/>.
+        /// Defaults to <see cref="HeaderMatchMode.ExactHeader"/>.
         /// </summary>
         HeaderMatchMode Mode { get; }
 

--- a/src/ReverseProxy/Service/Routing/IHeaderMetadata.cs
+++ b/src/ReverseProxy/Service/Routing/IHeaderMetadata.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.ReverseProxy.Abstractions;
 
 namespace Microsoft.ReverseProxy.Service.Routing
 {

--- a/src/ReverseProxy/Service/Routing/IHeaderMetadata.cs
+++ b/src/ReverseProxy/Service/Routing/IHeaderMetadata.cs
@@ -35,14 +35,5 @@ namespace Microsoft.ReverseProxy.Service.Routing
         /// Defaults to <c>false</c>.
         /// </summary>
         bool ValueIgnoresCase { get; }
-
-        /// <summary>
-        /// Specifies the maximum number of incoming header values to inspect when evaluating each <see cref="HeaderValues"/>.
-        /// </summary>
-        /// <remarks>
-        /// Since header-based routing is commonly used in scenarios where a single header value is expected,
-        /// this helps us bail out early for unexpected requests.
-        /// </remarks>
-        int MaximumValuesToInspect { get; }
     }
 }

--- a/src/ReverseProxy/Service/Routing/IHeaderMetadata.cs
+++ b/src/ReverseProxy/Service/Routing/IHeaderMetadata.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
-using Microsoft.ReverseProxy.Abstractions;
 
 namespace Microsoft.ReverseProxy.Service.Routing
 {
@@ -13,36 +11,8 @@ namespace Microsoft.ReverseProxy.Service.Routing
     internal interface IHeaderMetadata
     {
         /// <summary>
-        /// Name of the header to look for.
+        /// One or more matchers to apply to the request headers.
         /// </summary>
-        string HeaderName { get; }
-
-        /// <summary>
-        /// Returns a read-only collection of acceptable header values used during routing.
-        /// The list must not be empty.
-        /// </summary>
-        IReadOnlyList<string> HeaderValues { get; }
-
-        /// <summary>
-        /// Specifies how header values should be compared (e.g. exact matches Vs. by prefix).
-        /// Defaults to <see cref="HeaderMatchMode.ExactHeader"/>.
-        /// </summary>
-        HeaderMatchMode Mode { get; }
-
-        // Not implemented:
-        // A request header may have multiple values, either as multiple headers,
-        // a comma separated header, or some combination of the two.
-        // Also don't forget cookies that are semi-colon separated.
-        // The current implementation doesn't attempt to match individual header values,
-        // it only supports matching a single full header.
-        // bool AllowMultiValueHeaders { get; }
-
-        /// <summary>
-        /// Specifies whether header value comparisons should ignore case.
-        /// When <c>true</c>, <see cref="StringComparison.Ordinal" /> is used.
-        /// When <c>false</c>, <see cref="StringComparison.OrdinalIgnoreCase" /> is used.
-        /// Defaults to <c>false</c>.
-        /// </summary>
-        bool CaseSensitive { get; }
+        IReadOnlyList<HeaderMatcher> Matchers { get; }
     }
 }

--- a/src/ReverseProxy/Utilities/CaseInsensitiveEqualHelper.cs
+++ b/src/ReverseProxy/Utilities/CaseInsensitiveEqualHelper.cs
@@ -15,12 +15,7 @@ namespace Microsoft.ReverseProxy.Utilities
                 return true;
             }
 
-            if ((list1?.Count ?? 0) == 0 && (list2?.Count ?? 0) == 0)
-            {
-                return true;
-            }
-
-            if (list1 != null && list2 == null || list1 == null && list2 != null)
+            if (list1 == null || list2 == null)
             {
                 return false;
             }
@@ -48,12 +43,7 @@ namespace Microsoft.ReverseProxy.Utilities
                 return true;
             }
 
-            if ((dictionaryList1?.Count ?? 0) == 0 && (dictionaryList2?.Count ?? 0) == 0)
-            {
-                return true;
-            }
-
-            if (dictionaryList1 != null && dictionaryList2 == null || dictionaryList1 == null && dictionaryList2 != null)
+            if (dictionaryList1 == null || dictionaryList2 == null)
             {
                 return false;
             }
@@ -91,12 +81,7 @@ namespace Microsoft.ReverseProxy.Utilities
                 return true;
             }
 
-            if ((dictionary1?.Count ?? 0) == 0 && (dictionary2?.Count ?? 0) == 0)
-            {
-                return true;
-            }
-
-            if (dictionary1 != null && dictionary2 == null || dictionary1 == null && dictionary2 != null)
+            if (dictionary1 == null || dictionary2 == null)
             {
                 return false;
             }
@@ -104,6 +89,11 @@ namespace Microsoft.ReverseProxy.Utilities
             if (dictionary1.Count != dictionary2.Count)
             {
                 return false;
+            }
+
+            if (dictionary1.Count == 0)
+            {
+                return true;
             }
 
             foreach (var (key, value1) in dictionary1)

--- a/src/ReverseProxy/Utilities/CaseInsensitiveEqualHelper.cs
+++ b/src/ReverseProxy/Utilities/CaseInsensitiveEqualHelper.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.ReverseProxy.Utilities
 {
-    internal class CaseInsensitiveEqualHelper
+    internal static class CaseInsensitiveEqualHelper
     {
         internal static bool Equals(IReadOnlyList<string> list1, IReadOnlyList<string> list2)
         {

--- a/src/ReverseProxy/Utilities/CaseSensitiveEqualHelper.cs
+++ b/src/ReverseProxy/Utilities/CaseSensitiveEqualHelper.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.ReverseProxy.Utilities
+{
+    internal static class CaseSensitiveEqualHelper
+    {
+        internal static bool Equals(IReadOnlyList<string> list1, IReadOnlyList<string> list2)
+        {
+            if (ReferenceEquals(list1, list2))
+            {
+                return true;
+            }
+
+            if ((list1?.Count ?? 0) == 0 && (list2?.Count ?? 0) == 0)
+            {
+                return true;
+            }
+
+            if (list1 != null && list2 == null || list1 == null && list2 != null)
+            {
+                return false;
+            }
+
+            if (list1.Count != list2.Count)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < list1.Count; i++)
+            {
+                if (!string.Equals(list1[i], list2[i], StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/ReverseProxy/Utilities/CaseSensitiveEqualHelper.cs
+++ b/src/ReverseProxy/Utilities/CaseSensitiveEqualHelper.cs
@@ -15,12 +15,7 @@ namespace Microsoft.ReverseProxy.Utilities
                 return true;
             }
 
-            if ((list1?.Count ?? 0) == 0 && (list2?.Count ?? 0) == 0)
-            {
-                return true;
-            }
-
-            if (list1 != null && list2 == null || list1 == null && list2 != null)
+            if (list1 == null && list2 == null)
             {
                 return false;
             }

--- a/src/ReverseProxy/Utilities/DeepCloneableExtensions.cs
+++ b/src/ReverseProxy/Utilities/DeepCloneableExtensions.cs
@@ -14,10 +14,10 @@ namespace Microsoft.ReverseProxy
             return item.DeepClone();
         }
 
-        public static IList<T> DeepClone<T>(this IList<T> list)
+        public static IReadOnlyList<T> DeepCloneList<T>(this IReadOnlyList<T> list)
             where T : IDeepCloneable<T>
         {
-            return list.Select(entry => entry.DeepClone()).ToList();
+            return list.Select(entry => entry.DeepClone()).ToArray();
         }
 
         public static List<T> CloneList<T>(this IList<T> list)

--- a/test/ReverseProxy.FunctionalTests/WebSocketTests.cs
+++ b/test/ReverseProxy.FunctionalTests/WebSocketTests.cs
@@ -168,8 +168,6 @@ namespace Microsoft.ReverseProxy
         {
             return CreateHost(services =>
             {
-                services.AddRouting();
-
                 var proxyRoute = new ProxyRoute
                 {
                     RouteId = "route1",

--- a/test/ReverseProxy.Tests/Abstractions/RouteDiscovery/Contract/ProxyRouteTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/RouteDiscovery/Contract/ProxyRouteTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using Microsoft.ReverseProxy.Service.Routing;
 using Xunit;
 
 namespace Microsoft.ReverseProxy.Abstractions.Tests
@@ -26,6 +27,16 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
                     Methods = new[] { "GET", "POST" },
                     Hosts = new[] { "example.com" },
                     Path = "/",
+                    Headers = new[]
+                    {
+                        new RouteHeader()
+                        {
+                            HeaderName = "header1",
+                            HeaderValues = new[] { "value1", "value2" },
+                            Mode = HeaderMatchMode.Prefix,
+                            CaseSensitive = true,
+                        }
+                    },
                 },
                 Order = 2,
                 ClusterId = "cluster1",
@@ -45,8 +56,11 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
             Assert.Equal(sut.RouteId, clone.RouteId);
             Assert.NotSame(sut.Match, clone.Match);
             Assert.NotSame(sut.Match.Methods, clone.Match.Methods);
+            Assert.NotSame(sut.Match.Hosts, clone.Match.Hosts);
+            Assert.NotSame(sut.Match.Headers, clone.Match.Headers);
             Assert.Equal(sut.Match.Methods, clone.Match.Methods);
             Assert.Equal(sut.Match.Hosts, clone.Match.Hosts);
+            Assert.Equal(sut.Match.Headers.Count, clone.Match.Headers.Count); // These types don't implement the standard Object.Equals
             Assert.Equal(sut.Match.Path, clone.Match.Path);
             Assert.Equal(sut.Order, clone.Order);
             Assert.Equal(sut.ClusterId, clone.ClusterId);
@@ -71,6 +85,7 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
             Assert.Null(clone.RouteId);
             Assert.Null(clone.Match.Methods);
             Assert.Null(clone.Match.Hosts);
+            Assert.Null(clone.Match.Headers);
             Assert.Null(clone.Match.Path);
             Assert.Null(clone.Order);
             Assert.Null(clone.ClusterId);

--- a/test/ReverseProxy.Tests/Abstractions/RouteDiscovery/Contract/ProxyRouteTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/RouteDiscovery/Contract/ProxyRouteTests.cs
@@ -31,10 +31,10 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
                     {
                         new RouteHeader()
                         {
-                            HeaderName = "header1",
-                            HeaderValues = new[] { "value1", "value2" },
+                            Name = "header1",
+                            Values = new[] { "value1", "value2" },
                             Mode = HeaderMatchMode.HeaderPrefix,
-                            CaseSensitive = true,
+                            IsCaseSensitive = true,
                         }
                     },
                 },

--- a/test/ReverseProxy.Tests/Abstractions/RouteDiscovery/Contract/ProxyRouteTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/RouteDiscovery/Contract/ProxyRouteTests.cs
@@ -69,18 +69,17 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
             Assert.NotNull(clone.Metadata);
             Assert.NotSame(sut.Metadata, clone.Metadata);
             Assert.Equal("value", clone.Metadata["key"]);
+
+            Assert.True(ProxyRoute.Equals(sut, clone));
         }
 
         [Fact]
         public void DeepClone_Nulls_Works()
         {
-            // Arrange
             var sut = new ProxyRoute();
 
-            // Act
             var clone = sut.DeepClone();
 
-            // Assert
             Assert.NotSame(sut, clone);
             Assert.Null(clone.RouteId);
             Assert.Null(clone.Match.Methods);
@@ -92,6 +91,8 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
             Assert.Null(clone.AuthorizationPolicy);
             Assert.Null(clone.CorsPolicy);
             Assert.Null(clone.Metadata);
+
+            Assert.True(ProxyRoute.Equals(sut, clone));
         }
     }
 }

--- a/test/ReverseProxy.Tests/Abstractions/RouteDiscovery/Contract/ProxyRouteTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/RouteDiscovery/Contract/ProxyRouteTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
                         {
                             HeaderName = "header1",
                             HeaderValues = new[] { "value1", "value2" },
-                            Mode = HeaderMatchMode.Prefix,
+                            Mode = HeaderMatchMode.HeaderPrefix,
                             CaseSensitive = true,
                         }
                     },

--- a/test/ReverseProxy.Tests/Abstractions/RouteDiscovery/Contract/RouteHeaderTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/RouteDiscovery/Contract/RouteHeaderTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
             {
                 HeaderName = "header1",
                 HeaderValues = new[] { "value1", "value2" },
-                Mode = HeaderMatchMode.Prefix,
+                Mode = HeaderMatchMode.HeaderPrefix,
                 CaseSensitive = true,
             };
 
@@ -46,7 +46,7 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
             Assert.NotSame(sut, clone);
             Assert.Null(clone.HeaderName);
             Assert.Null(clone.HeaderValues);
-            Assert.Equal(HeaderMatchMode.Exact, clone.Mode);
+            Assert.Equal(HeaderMatchMode.ExactHeader, clone.Mode);
             Assert.False(clone.CaseSensitive);
 
             Assert.True(RouteHeader.Equals(sut, clone));

--- a/test/ReverseProxy.Tests/Abstractions/RouteDiscovery/Contract/RouteHeaderTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/RouteDiscovery/Contract/RouteHeaderTests.cs
@@ -19,20 +19,20 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
         {
             var sut = new RouteHeader
             {
-                HeaderName = "header1",
-                HeaderValues = new[] { "value1", "value2" },
+                Name = "header1",
+                Values = new[] { "value1", "value2" },
                 Mode = HeaderMatchMode.HeaderPrefix,
-                CaseSensitive = true,
+                IsCaseSensitive = true,
             };
 
             var clone = sut.DeepClone();
 
             Assert.NotSame(sut, clone);
-            Assert.Equal(sut.HeaderName, clone.HeaderName);
-            Assert.NotSame(sut.HeaderValues, clone.HeaderValues);
-            Assert.Equal(sut.HeaderValues, clone.HeaderValues);
+            Assert.Equal(sut.Name, clone.Name);
+            Assert.NotSame(sut.Values, clone.Values);
+            Assert.Equal(sut.Values, clone.Values);
             Assert.Equal(sut.Mode, clone.Mode);
-            Assert.Equal(sut.CaseSensitive, clone.CaseSensitive);
+            Assert.Equal(sut.IsCaseSensitive, clone.IsCaseSensitive);
 
             Assert.True(RouteHeader.Equals(sut, clone));
         }
@@ -44,10 +44,10 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
             var clone = sut.DeepClone();
 
             Assert.NotSame(sut, clone);
-            Assert.Null(clone.HeaderName);
-            Assert.Null(clone.HeaderValues);
+            Assert.Null(clone.Name);
+            Assert.Null(clone.Values);
             Assert.Equal(HeaderMatchMode.ExactHeader, clone.Mode);
-            Assert.False(clone.CaseSensitive);
+            Assert.False(clone.IsCaseSensitive);
 
             Assert.True(RouteHeader.Equals(sut, clone));
         }

--- a/test/ReverseProxy.Tests/Abstractions/RouteDiscovery/Contract/RouteHeaderTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/RouteDiscovery/Contract/RouteHeaderTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.ReverseProxy.Service.Routing;
+using Xunit;
+
+namespace Microsoft.ReverseProxy.Abstractions.Tests
+{
+    public class RouteHeaderTests
+    {
+        [Fact]
+        public void Constructor_Works()
+        {
+            new RouteHeader();
+        }
+
+        [Fact]
+        public void DeepClone_Works()
+        {
+            var sut = new RouteHeader
+            {
+                HeaderName = "header1",
+                HeaderValues = new[] { "value1", "value2" },
+                Mode = HeaderMatchMode.Prefix,
+                CaseSensitive = true,
+            };
+
+            var clone = sut.DeepClone();
+
+            Assert.NotSame(sut, clone);
+            Assert.Equal(sut.HeaderName, clone.HeaderName);
+            Assert.NotSame(sut.HeaderValues, clone.HeaderValues);
+            Assert.Equal(sut.HeaderValues, clone.HeaderValues);
+            Assert.Equal(sut.Mode, clone.Mode);
+            Assert.Equal(sut.CaseSensitive, clone.CaseSensitive);
+
+            Assert.True(RouteHeader.Equals(sut, clone));
+        }
+
+        [Fact]
+        public void DeepClone_Nulls_Works()
+        {
+            var sut = new RouteHeader();
+            var clone = sut.DeepClone();
+
+            Assert.NotSame(sut, clone);
+            Assert.Null(clone.HeaderName);
+            Assert.Null(clone.HeaderValues);
+            Assert.Equal(HeaderMatchMode.Exact, clone.Mode);
+            Assert.False(clone.CaseSensitive);
+
+            Assert.True(RouteHeader.Equals(sut, clone));
+        }
+    }
+}

--- a/test/ReverseProxy.Tests/IntegrationTests/RoutingTests.cs
+++ b/test/ReverseProxy.Tests/IntegrationTests/RoutingTests.cs
@@ -1,0 +1,364 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.ReverseProxy.Abstractions;
+using Xunit;
+
+namespace Microsoft.ReverseProxy.IntegrationTests
+{
+    public class RoutingTests
+    {
+        [Fact]
+        public async Task PathRouting_Works()
+        {
+            var routes = new[]
+            {
+                new ProxyRoute()
+                {
+                    RouteId = "route1",
+                    ClusterId = "cluster1",
+                    Match = { Path = "/api/{**catchall}" }
+                }
+            };
+
+            using var host = await CreateHostAsync(routes);
+            var client = host.GetTestClient();
+
+            // Positive
+            var response = await client.GetAsync("/api/extra");
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("route1", response.Headers.GetValues("route").SingleOrDefault());
+
+            // Negative
+            response = await client.GetAsync("/");
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task HostRouting_Works()
+        {
+            var routes = new[]
+            {
+                new ProxyRoute()
+                {
+                    RouteId = "route1",
+                    ClusterId = "cluster1",
+                    Match = { Hosts = new[] { "*.example.com" } }
+                }
+            };
+
+            using var host = await CreateHostAsync(routes);
+            var client = host.GetTestClient();
+
+            // Positive
+            var response = await client.GetAsync("http://foo.example.com/");
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("route1", response.Headers.GetValues("route").SingleOrDefault());
+
+            // Negative
+            response = await client.GetAsync("http://example.com");
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task HeaderRouting_OneHeader_Works()
+        {
+            var routes = new[]
+            {
+                new ProxyRoute()
+                {
+                    RouteId = "route1",
+                    ClusterId = "cluster1",
+                    Match =
+                    {
+                        Path = "/{**catchall}",
+                        Headers = new[]
+                        {
+                            new RouteHeader()
+                            {
+                                Name = "header1",
+                                Values = new[] { "value1" },
+                            }
+                        }
+                    }
+                }
+            };
+
+            using var host = await CreateHostAsync(routes);
+            var client = host.GetTestClient();
+
+            // Positive
+            var request = new HttpRequestMessage();
+            request.Headers.Add("header1", "value1");
+            var response = await client.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("route1", response.Headers.GetValues("route").SingleOrDefault());
+
+            // Negative
+            response = await client.GetAsync("/");
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+            request = new HttpRequestMessage();
+            request.Headers.Add("header2", "value1");
+            response = await client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+            request = new HttpRequestMessage();
+            request.Headers.Add("header1", "v");
+            response = await client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+            request = new HttpRequestMessage();
+            request.Headers.Add("header1", (string)null);
+            response = await client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task HeaderRouting_MultipleHeaders_Works()
+        {
+            var routes = new[]
+            {
+                new ProxyRoute()
+                {
+                    RouteId = "route1",
+                    ClusterId = "cluster1",
+                    Match =
+                    {
+                        Path = "/{**catchall}",
+                        Headers = new[]
+                        {
+                            new RouteHeader()
+                            {
+                                Name = "header1",
+                                Values = new[] { "value1" },
+                            }
+                        }
+                    }
+                },
+                new ProxyRoute()
+                {
+                    RouteId = "route2",
+                    ClusterId = "cluster1",
+                    Match =
+                    {
+                        Path = "/{**catchall}",
+                        Headers = new[]
+                        {
+                            new RouteHeader()
+                            {
+                                Name = "header2",
+                                Values = new[] { "value2" },
+                            }
+                        }
+                    }
+                },
+                new ProxyRoute()
+                {
+                    RouteId = "route3",
+                    ClusterId = "cluster1",
+                    Match =
+                    {
+                        Path = "/{**catchall}",
+                        Headers = new[]
+                        {
+                            new RouteHeader()
+                            {
+                                Name = "header1",
+                                Values = new[] { "value1" },
+                            },
+                            new RouteHeader()
+                            {
+                                Name = "header2",
+                                Values = new[] { "value2" },
+                            }
+                        }
+                    }
+                }
+            };
+
+            using var host = await CreateHostAsync(routes);
+            var client = host.GetTestClient();
+
+            // Check for the most specific match
+            var request = new HttpRequestMessage();
+            request.Headers.Add("header1", "value1");
+            var response = await client.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("route1", response.Headers.GetValues("route").SingleOrDefault());
+
+            request = new HttpRequestMessage();
+            request.Headers.Add("header1", "value1");
+            request.Headers.Add("header2", "value3");
+            response = await client.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("route1", response.Headers.GetValues("route").SingleOrDefault());
+
+            request = new HttpRequestMessage();
+            request.Headers.Add("header2", "value2");
+            response = await client.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("route2", response.Headers.GetValues("route").SingleOrDefault());
+
+            request = new HttpRequestMessage();
+            request.Headers.Add("header1", "value3");
+            request.Headers.Add("header2", "value2");
+            response = await client.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("route2", response.Headers.GetValues("route").SingleOrDefault());
+
+            request = new HttpRequestMessage();
+            request.Headers.Add("header1", "value1");
+            request.Headers.Add("header2", "value2");
+            response = await client.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("route3", response.Headers.GetValues("route").SingleOrDefault());
+
+            // Negative
+            response = await client.GetAsync("/");
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+            request = new HttpRequestMessage();
+            request.Headers.Add("header1", "value2");
+            request.Headers.Add("header2", "value1");
+            response = await client.SendAsync(request);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task Precedence_PathMethodHostHeaders()
+        {
+            var routes = new[]
+            {
+                new ProxyRoute()
+                {
+                    RouteId = "route1",
+                    ClusterId = "cluster1",
+                    Match = { Path = "/route1" }
+                },
+                new ProxyRoute()
+                {
+                    RouteId = "route2",
+                    ClusterId = "cluster1",
+                    Match =
+                    {
+                        Path = "/{**catchall}",
+                        Methods = new[] { "GET" },
+                    }
+                },
+                new ProxyRoute()
+                {
+                    RouteId = "route3",
+                    ClusterId = "cluster1",
+                    Match =
+                    {
+                        Hosts = new[] { "localhost" }
+                    }
+                },
+                new ProxyRoute()
+                {
+                    RouteId = "route4",
+                    ClusterId = "cluster1",
+                    Match =
+                    {
+                        Path = "/{**catchall}",
+                        Headers = new[]
+                        {
+                            new RouteHeader()
+                            {
+                                Name = "header1",
+                                Values = new[] { "value1" },
+                            },
+                        }
+                    }
+                }
+            };
+
+            using var host = await CreateHostAsync(routes);
+            var client = host.GetTestClient();
+
+            // Check for the highest priority match
+
+            // Path
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/route1");
+            request.Headers.Add("header1", "value1");
+            var response = await client.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("route1", response.Headers.GetValues("route").SingleOrDefault());
+
+            // Method
+            request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/");
+            request.Headers.Add("header1", "value1");
+            response = await client.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("route2", response.Headers.GetValues("route").SingleOrDefault());
+
+            // Host
+            request = new HttpRequestMessage(HttpMethod.Post, "http://localhost/");
+            request.Headers.Add("header1", "value1");
+            response = await client.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("route3", response.Headers.GetValues("route").SingleOrDefault());
+
+            // Header
+            request = new HttpRequestMessage(HttpMethod.Post, "http://example/");
+            request.Headers.Add("header1", "value1");
+            response = await client.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("route4", response.Headers.GetValues("route").SingleOrDefault());
+        }
+
+        public static Task<IHost> CreateHostAsync(IReadOnlyList<ProxyRoute> routes)
+        {
+            var clusters = new[]
+            {
+                new Cluster()
+                {
+                    Id = "cluster1",
+                    Destinations =
+                    {
+                        { "d1", new Destination() { Address = "http://localhost/" }  }
+                    }
+                }
+            };
+
+            return new HostBuilder()
+                .ConfigureWebHost(webHost =>
+                {
+                    webHost.UseTestServer();
+                    webHost.ConfigureServices(services =>
+                    {
+                        services.AddReverseProxy()
+                            .LoadFromMemory(routes, clusters);
+                    });
+                    webHost.Configure(appBuilder =>
+                    {
+                        appBuilder.UseRouting();
+                        appBuilder.UseEndpoints(endpoints =>
+                        {
+                            endpoints.MapReverseProxy(proxyApp =>
+                            {
+                                proxyApp.Run(context =>
+                                {
+                                    var endpoint = context.GetEndpoint();
+                                    context.Response.Headers["route"] = endpoint.DisplayName;
+                                    return Task.CompletedTask;
+                                });
+                            });
+                        });
+                    });
+                }).StartAsync();
+        }
+    }
+}

--- a/test/ReverseProxy.Tests/Microsoft.ReverseProxy.Tests.csproj
+++ b/test/ReverseProxy.Tests/Microsoft.ReverseProxy.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
@@ -17,6 +17,7 @@
     <PackageReference Include="Autofac" Version="4.9.4" />
     <PackageReference Include="Autofac.Extras.Moq" Version="4.3.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="System.IO.Pipelines" Version="4.7.2" />
   </ItemGroup>

--- a/test/ReverseProxy.Tests/Service/Config/RuntimeRouteBuilderTests.cs
+++ b/test/ReverseProxy.Tests/Service/Config/RuntimeRouteBuilderTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
@@ -11,6 +12,7 @@ using Microsoft.ReverseProxy.Abstractions;
 using Microsoft.ReverseProxy.RuntimeModel;
 using Microsoft.ReverseProxy.Service.Config;
 using Microsoft.ReverseProxy.Service.Management;
+using Microsoft.ReverseProxy.Service.Routing;
 using Microsoft.ReverseProxy.Utilities;
 using Xunit;
 
@@ -236,6 +238,112 @@ namespace Microsoft.ReverseProxy.Service.Tests
             Action action = () => builder.Build(route, cluster, routeInfo);
 
             Assert.Throws<AspNetCore.Routing.Patterns.RoutePatternException>(action);
+        }
+
+        [Fact]
+        public void BuildEndpoints_Header_Works()
+        {
+            var services = CreateServices();
+            var builder = services.GetRequiredService<IRuntimeRouteBuilder>();
+            builder.SetProxyPipeline(context => Task.CompletedTask);
+
+            var route = new ProxyRoute
+            {
+                RouteId = "route1",
+                Match =
+                {
+                    Path = "/",
+                    Headers = new[]
+                    {
+                        new RouteHeader()
+                        {
+                            Name = "header1",
+                            Values = new[] { "value1" },
+                            Mode = HeaderMatchMode.HeaderPrefix,
+                            IsCaseSensitive = true,
+                        }
+                    }
+                },
+            };
+            var cluster = new ClusterInfo("cluster1", new DestinationManager());
+            var routeInfo = new RouteInfo("route1");
+
+            var config = builder.Build(route, cluster, routeInfo);
+
+            Assert.Same(cluster, config.Cluster);
+            Assert.Single(config.Endpoints);
+            var routeEndpoint = config.Endpoints[0] as AspNetCore.Routing.RouteEndpoint;
+            Assert.Equal("route1", routeEndpoint.DisplayName);
+            var headerMetadata = routeEndpoint.Metadata.GetMetadata<IHeaderMetadata>();
+            Assert.NotNull(headerMetadata);
+            var matchers = headerMetadata.Matchers;
+            Assert.Single(matchers);
+            var matcher = matchers.Single();
+            Assert.Equal("header1", matcher.Name);
+            Assert.Equal(new[] { "value1" }, matcher.Values);
+            Assert.Equal(HeaderMatchMode.HeaderPrefix, matcher.Mode);
+            Assert.True(matcher.IsCaseSensitive);
+
+            Assert.False(config.HasConfigChanged(route, cluster));
+        }
+
+        [Fact]
+        public void BuildEndpoints_Headers_Works()
+        {
+            var services = CreateServices();
+            var builder = services.GetRequiredService<IRuntimeRouteBuilder>();
+            builder.SetProxyPipeline(context => Task.CompletedTask);
+
+            var route = new ProxyRoute
+            {
+                RouteId = "route1",
+                Match =
+                {
+                    Path = "/",
+                    Headers = new[]
+                    {
+                        new RouteHeader()
+                        {
+                            Name = "header1",
+                            Values = new[] { "value1" },
+                            Mode = HeaderMatchMode.HeaderPrefix,
+                            IsCaseSensitive = true,
+                        },
+                        new RouteHeader()
+                        {
+                            Name = "header2",
+                            Mode = HeaderMatchMode.Exists,
+                        }
+                    }
+                },
+            };
+            var cluster = new ClusterInfo("cluster1", new DestinationManager());
+            var routeInfo = new RouteInfo("route1");
+
+            var config = builder.Build(route, cluster, routeInfo);
+
+            Assert.Same(cluster, config.Cluster);
+            Assert.Single(config.Endpoints);
+            var routeEndpoint = config.Endpoints[0] as AspNetCore.Routing.RouteEndpoint;
+            Assert.Equal("route1", routeEndpoint.DisplayName);
+            var metadata = routeEndpoint.Metadata.GetMetadata<IHeaderMetadata>();
+            Assert.Equal(2, metadata.Matchers.Count);
+
+            var firstMetadata = metadata.Matchers.First();
+            Assert.NotNull(firstMetadata);
+            Assert.Equal("header1", firstMetadata.Name);
+            Assert.Equal(new[] { "value1" }, firstMetadata.Values);
+            Assert.Equal(HeaderMatchMode.HeaderPrefix, firstMetadata.Mode);
+            Assert.True(firstMetadata.IsCaseSensitive);
+
+            var secondMetadata = metadata.Matchers.Skip(1).Single();
+            Assert.NotNull(secondMetadata);
+            Assert.Equal("header2", secondMetadata.Name);
+            Assert.Null(secondMetadata.Values);
+            Assert.Equal(HeaderMatchMode.Exists, secondMetadata.Mode);
+            Assert.False(secondMetadata.IsCaseSensitive);
+
+            Assert.False(config.HasConfigChanged(route, cluster));
         }
 
         [Fact]

--- a/test/ReverseProxy.Tests/Service/Routing/HeaderMatcherPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Service/Routing/HeaderMatcherPolicyTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -19,22 +20,22 @@ namespace Microsoft.ReverseProxy.Service.Routing
             // Arrange
             var endpoints = new[]
             {
-                (0, Endpoint("header", new[] { "abc" }, HeaderValueMatchMode.Exact, caseSensitive: true)),
+                (0, Endpoint("header", new[] { "abc" }, HeaderMatchMode.Exact, caseSensitive: true)),
 
-                (1, Endpoint("header", new[] { "abc" }, HeaderValueMatchMode.Exact)),
-                (1, Endpoint("header", new[] { "abc", "def" }, HeaderValueMatchMode.Exact)),
-                (1, Endpoint("header2", new[] { "abc", "def" }, HeaderValueMatchMode.Exact)),
+                (1, Endpoint("header", new[] { "abc" }, HeaderMatchMode.Exact)),
+                (1, Endpoint("header", new[] { "abc", "def" }, HeaderMatchMode.Exact)),
+                (1, Endpoint("header2", new[] { "abc", "def" }, HeaderMatchMode.Exact)),
 
-                (2, Endpoint("header", new[] { "abc" }, HeaderValueMatchMode.Prefix, caseSensitive: true)),
+                (2, Endpoint("header", new[] { "abc" }, HeaderMatchMode.Prefix, caseSensitive: true)),
 
-                (3, Endpoint("header", new[] { "abc" }, HeaderValueMatchMode.Prefix)),
-                (3, Endpoint("header", new[] { "abc", "def" }, HeaderValueMatchMode.Prefix)),
-                (3, Endpoint("header2", new[] { "abc", "def" }, HeaderValueMatchMode.Prefix)),
+                (3, Endpoint("header", new[] { "abc" }, HeaderMatchMode.Prefix)),
+                (3, Endpoint("header", new[] { "abc", "def" }, HeaderMatchMode.Prefix)),
+                (3, Endpoint("header2", new[] { "abc", "def" }, HeaderMatchMode.Prefix)),
 
-                (9, Endpoint("header", new string[0], HeaderValueMatchMode.Exact, caseSensitive: true)),
-                (9, Endpoint("header", new string[0], HeaderValueMatchMode.Exact)),
-                (9, Endpoint("header", new string[0], HeaderValueMatchMode.Prefix, caseSensitive: true)),
-                (9, Endpoint("header", new string[0], HeaderValueMatchMode.Prefix)),
+                (9, Endpoint("header", new string[0], HeaderMatchMode.Exact, caseSensitive: true)),
+                (9, Endpoint("header", new string[0], HeaderMatchMode.Exact)),
+                (9, Endpoint("header", new string[0], HeaderMatchMode.Prefix, caseSensitive: true)),
+                (9, Endpoint("header", new string[0], HeaderMatchMode.Prefix)),
                 (9, Endpoint("header", new string[0])),
 
                 (10, Endpoint(string.Empty, null)),
@@ -89,25 +90,15 @@ namespace Microsoft.ReverseProxy.Service.Routing
         }
 
         [Fact]
-        public void AppliesToEndpoints_DoesNotApplyScenarios()
+        public void AppliesToEndpoints_NoMetadata_DoesNotApply()
         {
-            // Arrange
-            var scenarios = new[]
-            {
-                Endpoint(null, null),
-                Endpoint(string.Empty, null),
-                Endpoint(string.Empty, new string[0]),
-                Endpoint(string.Empty, new[] { "abc" }),
-            };
+            var endpoint = new RouteEndpointBuilder(_ => Task.CompletedTask, RoutePatternFactory.Parse("/"), 0).Build();
+
             var sut = new HeaderMatcherPolicy();
             var endpointSelectorPolicy = (IEndpointSelectorPolicy)sut;
 
-            // Act
-            for (var i = 0; i < scenarios.Length; i++)
-            {
-                var result = endpointSelectorPolicy.AppliesToEndpoints(new[] { scenarios[i] });
-                Assert.False(result, $"scenario {i}");
-            }
+            var result = endpointSelectorPolicy.AppliesToEndpoints(new[] { endpoint });
+            Assert.False(result);
         }
 
         [Theory]
@@ -153,31 +144,31 @@ namespace Microsoft.ReverseProxy.Service.Routing
         }
 
         [Theory]
-        [InlineData("abc", HeaderValueMatchMode.Exact, false, null, false)]
-        [InlineData("abc", HeaderValueMatchMode.Exact, false, "", false)]
-        [InlineData("abc", HeaderValueMatchMode.Exact, false, "abc", true)]
-        [InlineData("abc", HeaderValueMatchMode.Exact, false, "aBC", true)]
-        [InlineData("abc", HeaderValueMatchMode.Exact, false, "abcd", false)]
-        [InlineData("abc", HeaderValueMatchMode.Exact, false, "ab", false)]
-        [InlineData("abc", HeaderValueMatchMode.Exact, true, "", false)]
-        [InlineData("abc", HeaderValueMatchMode.Exact, true, "abc", true)]
-        [InlineData("abc", HeaderValueMatchMode.Exact, true, "aBC", false)]
-        [InlineData("abc", HeaderValueMatchMode.Exact, true, "abcd", false)]
-        [InlineData("abc", HeaderValueMatchMode.Exact, true, "ab", false)]
-        [InlineData("abc", HeaderValueMatchMode.Prefix, false, "", false)]
-        [InlineData("abc", HeaderValueMatchMode.Prefix, false, "abc", true)]
-        [InlineData("abc", HeaderValueMatchMode.Prefix, false, "aBC", true)]
-        [InlineData("abc", HeaderValueMatchMode.Prefix, false, "abcd", true)]
-        [InlineData("abc", HeaderValueMatchMode.Prefix, false, "ab", false)]
-        [InlineData("abc", HeaderValueMatchMode.Prefix, true, "", false)]
-        [InlineData("abc", HeaderValueMatchMode.Prefix, true, "abc", true)]
-        [InlineData("abc", HeaderValueMatchMode.Prefix, true, "aBC", false)]
-        [InlineData("abc", HeaderValueMatchMode.Prefix, true, "abcd", true)]
-        [InlineData("abc", HeaderValueMatchMode.Prefix, true, "aBCd", false)]
-        [InlineData("abc", HeaderValueMatchMode.Prefix, true, "ab", false)]
+        [InlineData("abc", HeaderMatchMode.Exact, false, null, false)]
+        [InlineData("abc", HeaderMatchMode.Exact, false, "", false)]
+        [InlineData("abc", HeaderMatchMode.Exact, false, "abc", true)]
+        [InlineData("abc", HeaderMatchMode.Exact, false, "aBC", true)]
+        [InlineData("abc", HeaderMatchMode.Exact, false, "abcd", false)]
+        [InlineData("abc", HeaderMatchMode.Exact, false, "ab", false)]
+        [InlineData("abc", HeaderMatchMode.Exact, true, "", false)]
+        [InlineData("abc", HeaderMatchMode.Exact, true, "abc", true)]
+        [InlineData("abc", HeaderMatchMode.Exact, true, "aBC", false)]
+        [InlineData("abc", HeaderMatchMode.Exact, true, "abcd", false)]
+        [InlineData("abc", HeaderMatchMode.Exact, true, "ab", false)]
+        [InlineData("abc", HeaderMatchMode.Prefix, false, "", false)]
+        [InlineData("abc", HeaderMatchMode.Prefix, false, "abc", true)]
+        [InlineData("abc", HeaderMatchMode.Prefix, false, "aBC", true)]
+        [InlineData("abc", HeaderMatchMode.Prefix, false, "abcd", true)]
+        [InlineData("abc", HeaderMatchMode.Prefix, false, "ab", false)]
+        [InlineData("abc", HeaderMatchMode.Prefix, true, "", false)]
+        [InlineData("abc", HeaderMatchMode.Prefix, true, "abc", true)]
+        [InlineData("abc", HeaderMatchMode.Prefix, true, "aBC", false)]
+        [InlineData("abc", HeaderMatchMode.Prefix, true, "abcd", true)]
+        [InlineData("abc", HeaderMatchMode.Prefix, true, "aBCd", false)]
+        [InlineData("abc", HeaderMatchMode.Prefix, true, "ab", false)]
         public async Task ApplyAsync_MatchingScenarios_OneHeaderValue(
             string headerValue,
-            HeaderValueMatchMode headerValueMatchMode,
+            HeaderMatchMode headerValueMatchMode,
             bool caseSensitive,
             string incomingHeaderValue,
             bool shouldMatch)
@@ -201,45 +192,45 @@ namespace Microsoft.ReverseProxy.Service.Routing
         }
 
         [Theory]
-        [InlineData("abc", "def", HeaderValueMatchMode.Exact, false, null, false)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Exact, false, "", false)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Exact, false, "abc", true)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Exact, false, "aBc", true)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Exact, false, "abcd", false)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Exact, false, "def", true)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Exact, false, "deF", true)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Exact, false, "defg", false)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Exact, true, null, false)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Exact, true, "", false)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Exact, true, "abc", true)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Exact, true, "aBC", false)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Exact, true, "aBCd", false)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Exact, true, "def", true)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Exact, true, "DEFg", false)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Exact, true, "dEf", false)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, false, null, false)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, false, "", false)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, false, "abc", true)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, false, "aBc", true)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, false, "abcd", true)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, false, "abcD", true)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, false, "def", true)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, false, "deF", true)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, false, "defg", true)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, false, "defG", true)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, false, "aabc", false)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, true, null, false)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, true, "", false)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, true, "abc", true)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, true, "aBC", false)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, true, "aBCd", false)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, true, "def", true)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, true, "DEFg", false)]
-        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, true, "aabc", false)]
+        [InlineData("abc", "def", HeaderMatchMode.Exact, false, null, false)]
+        [InlineData("abc", "def", HeaderMatchMode.Exact, false, "", false)]
+        [InlineData("abc", "def", HeaderMatchMode.Exact, false, "abc", true)]
+        [InlineData("abc", "def", HeaderMatchMode.Exact, false, "aBc", true)]
+        [InlineData("abc", "def", HeaderMatchMode.Exact, false, "abcd", false)]
+        [InlineData("abc", "def", HeaderMatchMode.Exact, false, "def", true)]
+        [InlineData("abc", "def", HeaderMatchMode.Exact, false, "deF", true)]
+        [InlineData("abc", "def", HeaderMatchMode.Exact, false, "defg", false)]
+        [InlineData("abc", "def", HeaderMatchMode.Exact, true, null, false)]
+        [InlineData("abc", "def", HeaderMatchMode.Exact, true, "", false)]
+        [InlineData("abc", "def", HeaderMatchMode.Exact, true, "abc", true)]
+        [InlineData("abc", "def", HeaderMatchMode.Exact, true, "aBC", false)]
+        [InlineData("abc", "def", HeaderMatchMode.Exact, true, "aBCd", false)]
+        [InlineData("abc", "def", HeaderMatchMode.Exact, true, "def", true)]
+        [InlineData("abc", "def", HeaderMatchMode.Exact, true, "DEFg", false)]
+        [InlineData("abc", "def", HeaderMatchMode.Exact, true, "dEf", false)]
+        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, null, false)]
+        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, "", false)]
+        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, "abc", true)]
+        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, "aBc", true)]
+        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, "abcd", true)]
+        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, "abcD", true)]
+        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, "def", true)]
+        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, "deF", true)]
+        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, "defg", true)]
+        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, "defG", true)]
+        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, "aabc", false)]
+        [InlineData("abc", "def", HeaderMatchMode.Prefix, true, null, false)]
+        [InlineData("abc", "def", HeaderMatchMode.Prefix, true, "", false)]
+        [InlineData("abc", "def", HeaderMatchMode.Prefix, true, "abc", true)]
+        [InlineData("abc", "def", HeaderMatchMode.Prefix, true, "aBC", false)]
+        [InlineData("abc", "def", HeaderMatchMode.Prefix, true, "aBCd", false)]
+        [InlineData("abc", "def", HeaderMatchMode.Prefix, true, "def", true)]
+        [InlineData("abc", "def", HeaderMatchMode.Prefix, true, "DEFg", false)]
+        [InlineData("abc", "def", HeaderMatchMode.Prefix, true, "aabc", false)]
         public async Task ApplyAsync_MatchingScenarios_TwoHeaderValues(
             string header1Value,
             string header2Value,
-            HeaderValueMatchMode headerValueMatchMode,
+            HeaderMatchMode headerValueMatchMode,
             bool caseSensitive,
             string incomingHeaderValue,
             bool shouldMatch)
@@ -259,10 +250,42 @@ namespace Microsoft.ReverseProxy.Service.Routing
             Assert.Equal(shouldMatch, candidates.IsValidCandidate(0));
         }
 
+        [Theory]
+        [InlineData(false, false, false)]
+        [InlineData(false, true, false)]
+        [InlineData(true, false, false)]
+        [InlineData(true, true, true)]
+        public async Task ApplyAsync_MultipleRules_RequiresAllHeaders(bool sendHeader1, bool sendHeader2, bool shouldMatch)
+        {
+            var builder = new RouteEndpointBuilder(_ => Task.CompletedTask, RoutePatternFactory.Parse("/"), 0);
+            var metadata1 = new HeaderMetadata("header1", new[] { "value1" }, HeaderMatchMode.Exact, caseSensitive: false);
+            var metadata2 = new HeaderMetadata("header2", new[] { "value2" }, HeaderMatchMode.Exact, caseSensitive: false);
+            builder.Metadata.Add(metadata1);
+            builder.Metadata.Add(metadata2);
+            var endpoint = builder.Build();
+
+            var context = new DefaultHttpContext();
+            if (sendHeader1)
+            {
+                context.Request.Headers.Add("header1", "value1");
+            }
+            if (sendHeader2)
+            {
+                context.Request.Headers.Add("header2", "value2");
+            }
+
+            var candidates = new CandidateSet(new[] { endpoint }, new RouteValueDictionary[1], new int[1]);
+            var sut = new HeaderMatcherPolicy();
+
+            await sut.ApplyAsync(context, candidates);
+
+            Assert.Equal(shouldMatch, candidates.IsValidCandidate(0));
+        }
+
         private static Endpoint Endpoint(
             string headerName,
             string[] headerValues,
-            HeaderValueMatchMode headerValueMatchMode = HeaderValueMatchMode.Exact,
+            HeaderMatchMode headerValueMatchMode = HeaderMatchMode.Exact,
             bool caseSensitive = false,
             bool isDynamic = false)
         {
@@ -270,7 +293,7 @@ namespace Microsoft.ReverseProxy.Service.Routing
             var metadata = new Mock<IHeaderMetadata>();
             metadata.SetupGet(m => m.HeaderName).Returns(headerName);
             metadata.SetupGet(m => m.HeaderValues).Returns(headerValues);
-            metadata.SetupGet(m => m.ValueMatchMode).Returns(headerValueMatchMode);
+            metadata.SetupGet(m => m.Mode).Returns(headerValueMatchMode);
             metadata.SetupGet(m => m.CaseSensitive).Returns(caseSensitive);
 
             builder.Metadata.Add(metadata.Object);

--- a/test/ReverseProxy.Tests/Service/Routing/HeaderMatcherPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Service/Routing/HeaderMatcherPolicyTests.cs
@@ -20,22 +20,22 @@ namespace Microsoft.ReverseProxy.Service.Routing
             // Arrange
             var endpoints = new[]
             {
-                (0, Endpoint("header", new[] { "abc" }, HeaderMatchMode.Exact, caseSensitive: true)),
+                (0, Endpoint("header", new[] { "abc" }, HeaderMatchMode.ExactHeader, caseSensitive: true)),
 
-                (1, Endpoint("header", new[] { "abc" }, HeaderMatchMode.Exact)),
-                (1, Endpoint("header", new[] { "abc", "def" }, HeaderMatchMode.Exact)),
-                (1, Endpoint("header2", new[] { "abc", "def" }, HeaderMatchMode.Exact)),
+                (1, Endpoint("header", new[] { "abc" }, HeaderMatchMode.ExactHeader)),
+                (1, Endpoint("header", new[] { "abc", "def" }, HeaderMatchMode.ExactHeader)),
+                (1, Endpoint("header2", new[] { "abc", "def" }, HeaderMatchMode.ExactHeader)),
 
-                (2, Endpoint("header", new[] { "abc" }, HeaderMatchMode.Prefix, caseSensitive: true)),
+                (2, Endpoint("header", new[] { "abc" }, HeaderMatchMode.HeaderPrefix, caseSensitive: true)),
 
-                (3, Endpoint("header", new[] { "abc" }, HeaderMatchMode.Prefix)),
-                (3, Endpoint("header", new[] { "abc", "def" }, HeaderMatchMode.Prefix)),
-                (3, Endpoint("header2", new[] { "abc", "def" }, HeaderMatchMode.Prefix)),
+                (3, Endpoint("header", new[] { "abc" }, HeaderMatchMode.HeaderPrefix)),
+                (3, Endpoint("header", new[] { "abc", "def" }, HeaderMatchMode.HeaderPrefix)),
+                (3, Endpoint("header2", new[] { "abc", "def" }, HeaderMatchMode.HeaderPrefix)),
 
-                (9, Endpoint("header", new string[0], HeaderMatchMode.Exact, caseSensitive: true)),
-                (9, Endpoint("header", new string[0], HeaderMatchMode.Exact)),
-                (9, Endpoint("header", new string[0], HeaderMatchMode.Prefix, caseSensitive: true)),
-                (9, Endpoint("header", new string[0], HeaderMatchMode.Prefix)),
+                (9, Endpoint("header", new string[0], HeaderMatchMode.ExactHeader, caseSensitive: true)),
+                (9, Endpoint("header", new string[0], HeaderMatchMode.ExactHeader)),
+                (9, Endpoint("header", new string[0], HeaderMatchMode.HeaderPrefix, caseSensitive: true)),
+                (9, Endpoint("header", new string[0], HeaderMatchMode.HeaderPrefix)),
                 (9, Endpoint("header", new string[0])),
 
                 (10, Endpoint(string.Empty, null)),
@@ -144,28 +144,28 @@ namespace Microsoft.ReverseProxy.Service.Routing
         }
 
         [Theory]
-        [InlineData("abc", HeaderMatchMode.Exact, false, null, false)]
-        [InlineData("abc", HeaderMatchMode.Exact, false, "", false)]
-        [InlineData("abc", HeaderMatchMode.Exact, false, "abc", true)]
-        [InlineData("abc", HeaderMatchMode.Exact, false, "aBC", true)]
-        [InlineData("abc", HeaderMatchMode.Exact, false, "abcd", false)]
-        [InlineData("abc", HeaderMatchMode.Exact, false, "ab", false)]
-        [InlineData("abc", HeaderMatchMode.Exact, true, "", false)]
-        [InlineData("abc", HeaderMatchMode.Exact, true, "abc", true)]
-        [InlineData("abc", HeaderMatchMode.Exact, true, "aBC", false)]
-        [InlineData("abc", HeaderMatchMode.Exact, true, "abcd", false)]
-        [InlineData("abc", HeaderMatchMode.Exact, true, "ab", false)]
-        [InlineData("abc", HeaderMatchMode.Prefix, false, "", false)]
-        [InlineData("abc", HeaderMatchMode.Prefix, false, "abc", true)]
-        [InlineData("abc", HeaderMatchMode.Prefix, false, "aBC", true)]
-        [InlineData("abc", HeaderMatchMode.Prefix, false, "abcd", true)]
-        [InlineData("abc", HeaderMatchMode.Prefix, false, "ab", false)]
-        [InlineData("abc", HeaderMatchMode.Prefix, true, "", false)]
-        [InlineData("abc", HeaderMatchMode.Prefix, true, "abc", true)]
-        [InlineData("abc", HeaderMatchMode.Prefix, true, "aBC", false)]
-        [InlineData("abc", HeaderMatchMode.Prefix, true, "abcd", true)]
-        [InlineData("abc", HeaderMatchMode.Prefix, true, "aBCd", false)]
-        [InlineData("abc", HeaderMatchMode.Prefix, true, "ab", false)]
+        [InlineData("abc", HeaderMatchMode.ExactHeader, false, null, false)]
+        [InlineData("abc", HeaderMatchMode.ExactHeader, false, "", false)]
+        [InlineData("abc", HeaderMatchMode.ExactHeader, false, "abc", true)]
+        [InlineData("abc", HeaderMatchMode.ExactHeader, false, "aBC", true)]
+        [InlineData("abc", HeaderMatchMode.ExactHeader, false, "abcd", false)]
+        [InlineData("abc", HeaderMatchMode.ExactHeader, false, "ab", false)]
+        [InlineData("abc", HeaderMatchMode.ExactHeader, true, "", false)]
+        [InlineData("abc", HeaderMatchMode.ExactHeader, true, "abc", true)]
+        [InlineData("abc", HeaderMatchMode.ExactHeader, true, "aBC", false)]
+        [InlineData("abc", HeaderMatchMode.ExactHeader, true, "abcd", false)]
+        [InlineData("abc", HeaderMatchMode.ExactHeader, true, "ab", false)]
+        [InlineData("abc", HeaderMatchMode.HeaderPrefix, false, "", false)]
+        [InlineData("abc", HeaderMatchMode.HeaderPrefix, false, "abc", true)]
+        [InlineData("abc", HeaderMatchMode.HeaderPrefix, false, "aBC", true)]
+        [InlineData("abc", HeaderMatchMode.HeaderPrefix, false, "abcd", true)]
+        [InlineData("abc", HeaderMatchMode.HeaderPrefix, false, "ab", false)]
+        [InlineData("abc", HeaderMatchMode.HeaderPrefix, true, "", false)]
+        [InlineData("abc", HeaderMatchMode.HeaderPrefix, true, "abc", true)]
+        [InlineData("abc", HeaderMatchMode.HeaderPrefix, true, "aBC", false)]
+        [InlineData("abc", HeaderMatchMode.HeaderPrefix, true, "abcd", true)]
+        [InlineData("abc", HeaderMatchMode.HeaderPrefix, true, "aBCd", false)]
+        [InlineData("abc", HeaderMatchMode.HeaderPrefix, true, "ab", false)]
         public async Task ApplyAsync_MatchingScenarios_OneHeaderValue(
             string headerValue,
             HeaderMatchMode headerValueMatchMode,
@@ -192,41 +192,41 @@ namespace Microsoft.ReverseProxy.Service.Routing
         }
 
         [Theory]
-        [InlineData("abc", "def", HeaderMatchMode.Exact, false, null, false)]
-        [InlineData("abc", "def", HeaderMatchMode.Exact, false, "", false)]
-        [InlineData("abc", "def", HeaderMatchMode.Exact, false, "abc", true)]
-        [InlineData("abc", "def", HeaderMatchMode.Exact, false, "aBc", true)]
-        [InlineData("abc", "def", HeaderMatchMode.Exact, false, "abcd", false)]
-        [InlineData("abc", "def", HeaderMatchMode.Exact, false, "def", true)]
-        [InlineData("abc", "def", HeaderMatchMode.Exact, false, "deF", true)]
-        [InlineData("abc", "def", HeaderMatchMode.Exact, false, "defg", false)]
-        [InlineData("abc", "def", HeaderMatchMode.Exact, true, null, false)]
-        [InlineData("abc", "def", HeaderMatchMode.Exact, true, "", false)]
-        [InlineData("abc", "def", HeaderMatchMode.Exact, true, "abc", true)]
-        [InlineData("abc", "def", HeaderMatchMode.Exact, true, "aBC", false)]
-        [InlineData("abc", "def", HeaderMatchMode.Exact, true, "aBCd", false)]
-        [InlineData("abc", "def", HeaderMatchMode.Exact, true, "def", true)]
-        [InlineData("abc", "def", HeaderMatchMode.Exact, true, "DEFg", false)]
-        [InlineData("abc", "def", HeaderMatchMode.Exact, true, "dEf", false)]
-        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, null, false)]
-        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, "", false)]
-        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, "abc", true)]
-        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, "aBc", true)]
-        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, "abcd", true)]
-        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, "abcD", true)]
-        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, "def", true)]
-        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, "deF", true)]
-        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, "defg", true)]
-        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, "defG", true)]
-        [InlineData("abc", "def", HeaderMatchMode.Prefix, false, "aabc", false)]
-        [InlineData("abc", "def", HeaderMatchMode.Prefix, true, null, false)]
-        [InlineData("abc", "def", HeaderMatchMode.Prefix, true, "", false)]
-        [InlineData("abc", "def", HeaderMatchMode.Prefix, true, "abc", true)]
-        [InlineData("abc", "def", HeaderMatchMode.Prefix, true, "aBC", false)]
-        [InlineData("abc", "def", HeaderMatchMode.Prefix, true, "aBCd", false)]
-        [InlineData("abc", "def", HeaderMatchMode.Prefix, true, "def", true)]
-        [InlineData("abc", "def", HeaderMatchMode.Prefix, true, "DEFg", false)]
-        [InlineData("abc", "def", HeaderMatchMode.Prefix, true, "aabc", false)]
+        [InlineData("abc", "def", HeaderMatchMode.ExactHeader, false, null, false)]
+        [InlineData("abc", "def", HeaderMatchMode.ExactHeader, false, "", false)]
+        [InlineData("abc", "def", HeaderMatchMode.ExactHeader, false, "abc", true)]
+        [InlineData("abc", "def", HeaderMatchMode.ExactHeader, false, "aBc", true)]
+        [InlineData("abc", "def", HeaderMatchMode.ExactHeader, false, "abcd", false)]
+        [InlineData("abc", "def", HeaderMatchMode.ExactHeader, false, "def", true)]
+        [InlineData("abc", "def", HeaderMatchMode.ExactHeader, false, "deF", true)]
+        [InlineData("abc", "def", HeaderMatchMode.ExactHeader, false, "defg", false)]
+        [InlineData("abc", "def", HeaderMatchMode.ExactHeader, true, null, false)]
+        [InlineData("abc", "def", HeaderMatchMode.ExactHeader, true, "", false)]
+        [InlineData("abc", "def", HeaderMatchMode.ExactHeader, true, "abc", true)]
+        [InlineData("abc", "def", HeaderMatchMode.ExactHeader, true, "aBC", false)]
+        [InlineData("abc", "def", HeaderMatchMode.ExactHeader, true, "aBCd", false)]
+        [InlineData("abc", "def", HeaderMatchMode.ExactHeader, true, "def", true)]
+        [InlineData("abc", "def", HeaderMatchMode.ExactHeader, true, "DEFg", false)]
+        [InlineData("abc", "def", HeaderMatchMode.ExactHeader, true, "dEf", false)]
+        [InlineData("abc", "def", HeaderMatchMode.HeaderPrefix, false, null, false)]
+        [InlineData("abc", "def", HeaderMatchMode.HeaderPrefix, false, "", false)]
+        [InlineData("abc", "def", HeaderMatchMode.HeaderPrefix, false, "abc", true)]
+        [InlineData("abc", "def", HeaderMatchMode.HeaderPrefix, false, "aBc", true)]
+        [InlineData("abc", "def", HeaderMatchMode.HeaderPrefix, false, "abcd", true)]
+        [InlineData("abc", "def", HeaderMatchMode.HeaderPrefix, false, "abcD", true)]
+        [InlineData("abc", "def", HeaderMatchMode.HeaderPrefix, false, "def", true)]
+        [InlineData("abc", "def", HeaderMatchMode.HeaderPrefix, false, "deF", true)]
+        [InlineData("abc", "def", HeaderMatchMode.HeaderPrefix, false, "defg", true)]
+        [InlineData("abc", "def", HeaderMatchMode.HeaderPrefix, false, "defG", true)]
+        [InlineData("abc", "def", HeaderMatchMode.HeaderPrefix, false, "aabc", false)]
+        [InlineData("abc", "def", HeaderMatchMode.HeaderPrefix, true, null, false)]
+        [InlineData("abc", "def", HeaderMatchMode.HeaderPrefix, true, "", false)]
+        [InlineData("abc", "def", HeaderMatchMode.HeaderPrefix, true, "abc", true)]
+        [InlineData("abc", "def", HeaderMatchMode.HeaderPrefix, true, "aBC", false)]
+        [InlineData("abc", "def", HeaderMatchMode.HeaderPrefix, true, "aBCd", false)]
+        [InlineData("abc", "def", HeaderMatchMode.HeaderPrefix, true, "def", true)]
+        [InlineData("abc", "def", HeaderMatchMode.HeaderPrefix, true, "DEFg", false)]
+        [InlineData("abc", "def", HeaderMatchMode.HeaderPrefix, true, "aabc", false)]
         public async Task ApplyAsync_MatchingScenarios_TwoHeaderValues(
             string header1Value,
             string header2Value,
@@ -258,8 +258,8 @@ namespace Microsoft.ReverseProxy.Service.Routing
         public async Task ApplyAsync_MultipleRules_RequiresAllHeaders(bool sendHeader1, bool sendHeader2, bool shouldMatch)
         {
             var builder = new RouteEndpointBuilder(_ => Task.CompletedTask, RoutePatternFactory.Parse("/"), 0);
-            var metadata1 = new HeaderMetadata("header1", new[] { "value1" }, HeaderMatchMode.Exact, caseSensitive: false);
-            var metadata2 = new HeaderMetadata("header2", new[] { "value2" }, HeaderMatchMode.Exact, caseSensitive: false);
+            var metadata1 = new HeaderMetadata("header1", new[] { "value1" }, HeaderMatchMode.ExactHeader, caseSensitive: false);
+            var metadata2 = new HeaderMetadata("header2", new[] { "value2" }, HeaderMatchMode.ExactHeader, caseSensitive: false);
             builder.Metadata.Add(metadata1);
             builder.Metadata.Add(metadata2);
             var endpoint = builder.Build();
@@ -285,7 +285,7 @@ namespace Microsoft.ReverseProxy.Service.Routing
         private static Endpoint Endpoint(
             string headerName,
             string[] headerValues,
-            HeaderMatchMode headerValueMatchMode = HeaderMatchMode.Exact,
+            HeaderMatchMode headerValueMatchMode = HeaderMatchMode.ExactHeader,
             bool caseSensitive = false,
             bool isDynamic = false)
         {

--- a/test/ReverseProxy.Tests/Service/Routing/HeaderMatcherPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Service/Routing/HeaderMatcherPolicyTests.cs
@@ -1,0 +1,301 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Matching;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Moq;
+using Xunit;
+
+namespace Microsoft.ReverseProxy.Service.Routing
+{
+    public class HeaderMatcherPolicyTests
+    {
+        [Fact]
+        public void Comparer_SortOrder()
+        {
+            // Arrange
+            var endpoints = new[]
+            {
+                (0, Endpoint("header", new[] { "abc" }, HeaderValueMatchMode.Exact)),
+                (0, Endpoint("header", new[] { "abc", "def" }, HeaderValueMatchMode.Exact)),
+                (0, Endpoint("header2", new[] { "abc", "def" }, HeaderValueMatchMode.Exact)),
+
+                (1, Endpoint("header", new[] { "abc" }, HeaderValueMatchMode.Exact, maxValuesToInspect: 2)),
+
+                (2, Endpoint("header", new[] { "abc" }, HeaderValueMatchMode.Exact, maxValuesToInspect: 3)),
+
+                (3, Endpoint("header", new[] { "abc" }, HeaderValueMatchMode.Exact, valueIgnoresCase: true)),
+
+                (4, Endpoint("header", new[] { "abc" }, HeaderValueMatchMode.Exact, valueIgnoresCase: true, maxValuesToInspect: 2)),
+
+                (5, Endpoint("header", new[] { "abc" }, HeaderValueMatchMode.Prefix)),
+                (5, Endpoint("header", new[] { "abc", "def" }, HeaderValueMatchMode.Prefix)),
+                (5, Endpoint("header2", new[] { "abc", "def" }, HeaderValueMatchMode.Prefix)),
+
+                (6, Endpoint("header", new[] { "abc" }, HeaderValueMatchMode.Prefix, maxValuesToInspect: 2)),
+
+                (7, Endpoint("header", new[] { "abc" }, HeaderValueMatchMode.Prefix, valueIgnoresCase: true)),
+
+                (8, Endpoint("header", new[] { "abc" }, HeaderValueMatchMode.Prefix, valueIgnoresCase: true, maxValuesToInspect: 2)),
+
+                (9, Endpoint("header", new string[0], HeaderValueMatchMode.Exact)),
+                (9, Endpoint("header", new string[0], HeaderValueMatchMode.Exact, valueIgnoresCase: true)),
+                (9, Endpoint("header", new string[0], HeaderValueMatchMode.Prefix)),
+                (9, Endpoint("header", new string[0], HeaderValueMatchMode.Prefix, valueIgnoresCase: true)),
+                (9, Endpoint("header", new string[0], maxValuesToInspect: 2)),
+
+                (10, Endpoint(string.Empty, null)),
+                (10, Endpoint(null, null)),
+            };
+            var sut = new HeaderMatcherPolicy();
+
+            // Act
+            for (var i = 0; i < endpoints.Length; i++)
+            {
+                for (var j = 0; j < endpoints.Length; j++)
+                {
+                    var a = endpoints[i];
+                    var b = endpoints[j];
+
+                    var actual = sut.Comparer.Compare(a.Item2, b.Item2);
+                    var expected =
+                        a.Item1 < b.Item1 ? -1 :
+                        a.Item1 > b.Item1 ? 1 : 0;
+                    if (actual != expected)
+                    {
+                        Assert.True(false, $"Error comparing [{i}] to [{j}], expected {expected}, found {actual}.");
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void AppliesToEndpoints_AppliesScenarios()
+        {
+            // Arrange
+            var scenarios = new[]
+            {
+                Endpoint("org-id", new string[0]),
+                Endpoint("org-id", new[] { "abc" }),
+                Endpoint("org-id", new[] { "abc", "def" }),
+                Endpoint(null, null, isDynamic: true),
+                Endpoint(string.Empty, null, isDynamic: true),
+                Endpoint("org-id", new string[0], isDynamic: true),
+                Endpoint("org-id", new[] { "abc" }, isDynamic: true),
+                Endpoint(null, null, isDynamic: true),
+            };
+            var sut = new HeaderMatcherPolicy();
+            var endpointSelectorPolicy = (IEndpointSelectorPolicy)sut;
+
+            // Act
+            for (var i = 0; i < scenarios.Length; i++)
+            {
+                var result = endpointSelectorPolicy.AppliesToEndpoints(new[] { scenarios[i] });
+                Assert.True(result, $"scenario {i}");
+            }
+        }
+
+        [Fact]
+        public void AppliesToEndpoints_DoesNotApplyScenarios()
+        {
+            // Arrange
+            var scenarios = new[]
+            {
+                Endpoint(null, null),
+                Endpoint(string.Empty, null),
+                Endpoint(string.Empty, new string[0]),
+                Endpoint(string.Empty, new[] { "abc" }),
+            };
+            var sut = new HeaderMatcherPolicy();
+            var endpointSelectorPolicy = (IEndpointSelectorPolicy)sut;
+
+            // Act
+            for (var i = 0; i < scenarios.Length; i++)
+            {
+                var result = endpointSelectorPolicy.AppliesToEndpoints(new[] { scenarios[i] });
+                Assert.False(result, $"scenario {i}");
+            }
+        }
+
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData("", true)]
+        [InlineData("abc", true)]
+        public async Task ApplyAsync_MatchingScenarios_AnyHeaderValue(string incomingHeaderValue, bool shouldMatch)
+        {
+            // Arrange
+            var context = new DefaultHttpContext();
+            if (incomingHeaderValue != null)
+            {
+                context.Request.Headers.Add("org-id", incomingHeaderValue);
+            }
+
+            var endpoint = Endpoint("org-id", new string[0]);
+            var candidates = new CandidateSet(new[] { endpoint }, new RouteValueDictionary[1], new int[1]);
+            var sut = new HeaderMatcherPolicy();
+
+            // Act
+            await sut.ApplyAsync(context, candidates);
+
+            // Assert
+            Assert.Equal(shouldMatch, candidates.IsValidCandidate(0));
+        }
+
+        [Theory]
+        [InlineData("abc", HeaderValueMatchMode.Exact, false, null, false)]
+        [InlineData("abc", HeaderValueMatchMode.Exact, false, "", false)]
+        [InlineData("abc", HeaderValueMatchMode.Exact, false, "abc", true)]
+        [InlineData("abc", HeaderValueMatchMode.Exact, false, "aBC", false)]
+        [InlineData("abc", HeaderValueMatchMode.Exact, false, "abcd", false)]
+        [InlineData("abc", HeaderValueMatchMode.Exact, false, "ab", false)]
+        [InlineData("abc", HeaderValueMatchMode.Exact, true, "", false)]
+        [InlineData("abc", HeaderValueMatchMode.Exact, true, "abc", true)]
+        [InlineData("abc", HeaderValueMatchMode.Exact, true, "aBC", true)]
+        [InlineData("abc", HeaderValueMatchMode.Exact, true, "abcd", false)]
+        [InlineData("abc", HeaderValueMatchMode.Exact, true, "ab", false)]
+        [InlineData("abc", HeaderValueMatchMode.Prefix, false, "", false)]
+        [InlineData("abc", HeaderValueMatchMode.Prefix, false, "abc", true)]
+        [InlineData("abc", HeaderValueMatchMode.Prefix, false, "aBC", false)]
+        [InlineData("abc", HeaderValueMatchMode.Prefix, false, "abcd", true)]
+        [InlineData("abc", HeaderValueMatchMode.Prefix, false, "ab", false)]
+        [InlineData("abc", HeaderValueMatchMode.Prefix, true, "", false)]
+        [InlineData("abc", HeaderValueMatchMode.Prefix, true, "abc", true)]
+        [InlineData("abc", HeaderValueMatchMode.Prefix, true, "aBC", true)]
+        [InlineData("abc", HeaderValueMatchMode.Prefix, true, "abcd", true)]
+        [InlineData("abc", HeaderValueMatchMode.Prefix, true, "aBCd", true)]
+        [InlineData("abc", HeaderValueMatchMode.Prefix, true, "ab", false)]
+        public async Task ApplyAsync_MatchingScenarios_OneHeaderValue(
+            string headerValue,
+            HeaderValueMatchMode headerValueMatchMode,
+            bool valueIgnoresCase,
+            string incomingHeaderValue,
+            bool shouldMatch)
+        {
+            // Arrange
+            var context = new DefaultHttpContext();
+            if (incomingHeaderValue != null)
+            {
+                context.Request.Headers.Add("org-id", incomingHeaderValue);
+            }
+
+            var endpoint = Endpoint("org-id", new[] { headerValue }, headerValueMatchMode, valueIgnoresCase);
+            var candidates = new CandidateSet(new[] { endpoint }, new RouteValueDictionary[1], new int[1]);
+            var sut = new HeaderMatcherPolicy();
+
+            // Act
+            await sut.ApplyAsync(context, candidates);
+
+            // Assert
+            Assert.Equal(shouldMatch, candidates.IsValidCandidate(0));
+        }
+
+        [Theory]
+        [InlineData("abc", "def", HeaderValueMatchMode.Exact, false, null, false)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Exact, false, "", false)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Exact, false, "abc", true)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Exact, false, "abcd", false)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Exact, false, "def", true)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Exact, false, "defg", false)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Exact, true, null, false)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Exact, true, "", false)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Exact, true, "abc", true)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Exact, true, "aBC", true)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Exact, true, "aBCd", false)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Exact, true, "def", true)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Exact, true, "DEFg", false)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, false, null, false)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, false, "", false)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, false, "abc", true)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, false, "abcd", true)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, false, "def", true)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, false, "defg", true)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, false, "aabc", false)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, true, null, false)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, true, "", false)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, true, "abc", true)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, true, "aBC", true)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, true, "aBCd", true)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, true, "def", true)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, true, "DEFg", true)]
+        [InlineData("abc", "def", HeaderValueMatchMode.Prefix, true, "aabc", false)]
+        public async Task ApplyAsync_MatchingScenarios_TwoHeaderValues(
+            string header1Value,
+            string header2Value,
+            HeaderValueMatchMode headerValueMatchMode,
+            bool valueIgnoresCase,
+            string incomingHeaderValue,
+            bool shouldMatch)
+        {
+            // Arrange
+            var context = new DefaultHttpContext();
+            context.Request.Headers.Add("org-id", incomingHeaderValue);
+            var endpoint = Endpoint("org-id", new[] { header1Value, header2Value }, headerValueMatchMode, valueIgnoresCase);
+
+            var candidates = new CandidateSet(new[] { endpoint }, new RouteValueDictionary[1], new int[1]);
+            var sut = new HeaderMatcherPolicy();
+
+            // Act
+            await sut.ApplyAsync(context, candidates);
+
+            // Assert
+            Assert.Equal(shouldMatch, candidates.IsValidCandidate(0));
+        }
+
+        [Fact]
+        public async Task ApplyAsync_RespectsMaxHeadersToInspect()
+        {
+            // Arrange
+            var context = new DefaultHttpContext();
+            context.Request.Headers.Add("org-id", new[] { "abc1", "abc2", "abc3" });
+            var endpoint1 = Endpoint("org-id", new[] { "abc1" }, maxValuesToInspect: 2);
+            var endpoint2 = Endpoint("org-id", new[] { "abc2" }, maxValuesToInspect: 2);
+            var endpoint3 = Endpoint("org-id", new[] { "abc3" }, maxValuesToInspect: 2);
+            var endpoint4 = Endpoint("org-id", new[] { "abc3" }, maxValuesToInspect: 3);
+
+            var candidates = new CandidateSet(new[] { endpoint1, endpoint2, endpoint3, endpoint4 }, new RouteValueDictionary[4], new int[4]);
+            var sut = new HeaderMatcherPolicy();
+
+            // Act
+            await sut.ApplyAsync(context, candidates);
+
+            // Assert
+            Assert.True(candidates.IsValidCandidate(0));
+            Assert.True(candidates.IsValidCandidate(1));
+            Assert.False(candidates.IsValidCandidate(2));
+            Assert.True(candidates.IsValidCandidate(3));
+        }
+
+        private static Endpoint Endpoint(
+            string headerName,
+            string[] headerValues,
+            HeaderValueMatchMode headerValueMatchMode = HeaderValueMatchMode.Exact,
+            bool valueIgnoresCase = false,
+            int maxValuesToInspect = 1,
+            bool isDynamic = false)
+        {
+            var builder = new RouteEndpointBuilder(_ => Task.CompletedTask, RoutePatternFactory.Parse("/"), 0);
+            var metadata = new Mock<IHeaderMetadata>();
+            metadata.SetupGet(m => m.HeaderName).Returns(headerName);
+            metadata.SetupGet(m => m.HeaderValues).Returns(headerValues);
+            metadata.SetupGet(m => m.ValueMatchMode).Returns(headerValueMatchMode);
+            metadata.SetupGet(m => m.ValueIgnoresCase).Returns(valueIgnoresCase);
+            metadata.SetupGet(m => m.MaximumValuesToInspect).Returns(maxValuesToInspect);
+
+            builder.Metadata.Add(metadata.Object);
+            if (isDynamic)
+            {
+                builder.Metadata.Add(new DynamicEndpointMetadata());
+            }
+
+            return builder.Build();
+        }
+
+        private class DynamicEndpointMetadata : IDynamicEndpointMetadata
+        {
+            public bool IsDynamic => true;
+        }
+    }
+}

--- a/test/ReverseProxy.Tests/Service/Routing/HeaderMatcherPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Service/Routing/HeaderMatcherPolicyTests.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.AspNetCore.Routing.Patterns;
-using Microsoft.Extensions.Options;
+using Microsoft.ReverseProxy.Abstractions;
 using Moq;
 using Xunit;
 

--- a/test/ReverseProxy.Tests/Service/Routing/HeaderMatcherPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Service/Routing/HeaderMatcherPolicyTests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.ReverseProxy.Service.Routing
 
         [Theory]
         [InlineData(null, false)]
-        [InlineData("", true)]
+        [InlineData("", false)]
         [InlineData("abc", true)]
         public async Task ApplyAsync_MatchingScenarios_AnyHeaderValue(string incomingHeaderValue, bool shouldMatch)
         {
@@ -114,7 +114,7 @@ namespace Microsoft.ReverseProxy.Service.Routing
                 context.Request.Headers.Add("org-id", incomingHeaderValue);
             }
 
-            var endpoint = Endpoint("org-id", new string[0]);
+            var endpoint = Endpoint("org-id", new[] { string.Empty }, HeaderMatchMode.Exists);
             var candidates = new CandidateSet(new[] { endpoint }, new RouteValueDictionary[1], new int[1]);
             var sut = new HeaderMatcherPolicy();
 


### PR DESCRIPTION
Fixes #448

Design points:
- The ability to specify one or more header and value(s) that must be present on a request in order to route.
- Exposed from both code and config.
  - Should we allow you to specify a route using only a header? Today routes must have a path or host.
  - In config I've included both a Value and Values properties for convivence in the common single value scenario. Values takes priority if set. We may also want to do this with Host and Hosts, Header and Headers.
- Headers are lower priority matches than paths, methods, and hosts. One unanticipated side effect of this I saw was if one route specifies methods and another specifies headers, the methods route will always win as more specific. The headers check only comes into play if the higher priority checks are equal.
- Comparisons are case-insensitive by default to match the rest of routing, but you can opt-into case-sensitive checks.
  - Headers do not have consistent semantics like other parts of the request. Casing shouldn't matter in the average scenario, but there are some data types such as base64 encoded values where casing significantly changes the interpretation.
  - The case sensitivity option is implemented separately from match modes. When I included some of the match modes we may add in the future, and tried merging them with the case in/sensitive option it got very verbose and redundant. E.g. ExactHeaderCaseSensitive, ExactHeaderCaseInsensitive, ExactValueCaseSensitive, ExactValueCaseInsensitive, etc.. Even regexes have an optional, separate case sensitivity flag.
- Only a limited set of header matching rules have been implemented, scoped to the customer requirements. See the docs for details.
  - Multi-header and multi-value headers are not supported.
  - Complex matching such as regex patterns are not supported.
  - The matching rules are specified separately from the values because there's no well-defined pattern syntax for header formats short of a full regex. The customer requirements so far only call for basic value matching.
- Routing has some advanced performance features like INodeBuilderPolicy that we are not implementing in this first pass. They add significant complexity and it's not clear yet if they're needed for our scenarios.

Other oddities:
- Bumped the 3.1 dependencies to 3.1.8 to pick up a fix in routing.