### PR TITLE
Expose immutable Metadata from RouteConfig

### DIFF
--- a/src/ReverseProxy/Service/RuntimeModel/RouteConfig.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/RouteConfig.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.ReverseProxy.Abstractions;
 using Microsoft.ReverseProxy.Service.RuntimeModel.Transforms;
 
@@ -36,6 +37,7 @@ namespace Microsoft.ReverseProxy.RuntimeModel
             Order = proxyRoute.Order;
             Cluster = cluster;
             Transforms = transforms;
+            Metadata = proxyRoute.Metadata.ToImmutableDictionary();
         }
 
         public RouteInfo Route { get; }
@@ -48,6 +50,8 @@ namespace Microsoft.ReverseProxy.RuntimeModel
         public IReadOnlyList<AspNetCore.Http.Endpoint> Endpoints { get; }
 
         public Transforms Transforms { get; }
+
+        public IReadOnlyDictionary<string, string> Metadata { get; }
 
         public bool HasConfigChanged(ProxyRoute newConfig, ClusterInfo cluster)
         {

--- a/src/ReverseProxy/Service/RuntimeModel/RouteConfig.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/RouteConfig.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ReverseProxy.RuntimeModel
             Order = proxyRoute.Order;
             Cluster = cluster;
             Transforms = transforms;
-            Metadata = proxyRoute.Metadata.ToImmutableDictionary();
+            Metadata = proxyRoute.Metadata?.ToImmutableDictionary();
         }
 
         public RouteInfo Route { get; }


### PR DESCRIPTION
Since extensibility of the yarp is work in progress yet I use Metadata to add some additional information that I can later use to run my own middelware. Without Metadata being accessible through Endpoint->Metadata->RouteConfig->Metadata I need to build my own store for metadata which is unfortunate because I already have everything.