### PR TITLE
Update to the 5.0.0 RTM SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "5.0.100-rc.2.20479.15"
+    "version": "5.0.100-rtm.20515.8"
   },
   "tools": {
-    "dotnet": "5.0.100-rc.2.20479.15",
+    "dotnet": "5.0.100-rtm.20515.8",
     "runtimes": {
       "dotnet/x64": [
         "$(MicrosoftNETCoreAppPackageVersion)",

--- a/test/ReverseProxy.Tests/Microsoft.ReverseProxy.Tests.csproj
+++ b/test/ReverseProxy.Tests/Microsoft.ReverseProxy.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
@@ -19,7 +19,6 @@
     <PackageReference Include="coverlet.collector" Version="1.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="System.IO.Pipelines" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
And remove a pipelines test dependency that was there as a workaround.