### PR TITLE
Some cleanup

### DIFF
--- a/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/SessionAffinityConstants.cs
+++ b/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/SessionAffinityConstants.cs
@@ -10,16 +10,16 @@ namespace Microsoft.ReverseProxy.Abstractions.ClusterDiscovery.Contract
     {
         public static class Modes
         {
-            public static string Cookie => "Cookie";
+            public static string Cookie => nameof(Cookie);
 
-            public static string CustomHeader => "CustomHeader";
+            public static string CustomHeader => nameof(CustomHeader);
         }
 
         public static class AffinityFailurePolicies
         {
-            public static string Redistribute => "Redistribute";
+            public static string Redistribute => nameof(Redistribute);
 
-            public static string Return503Error => "Return503Error";
+            public static string Return503Error => nameof(Return503Error);
         }
     }
 }

--- a/src/ReverseProxy/Middleware/AffinitizeRequestMiddleware.cs
+++ b/src/ReverseProxy/Middleware/AffinitizeRequestMiddleware.cs
@@ -67,7 +67,7 @@ namespace Microsoft.ReverseProxy.Middleware
             return _next(context);
         }
 
-        private void AffinitizeRequest(HttpContext context, ClusterConfig.ClusterSessionAffinityOptions options, DestinationInfo destination)
+        private void AffinitizeRequest(HttpContext context, ClusterSessionAffinityOptions options, DestinationInfo destination)
         {
             var currentProvider = _sessionAffinityProviders.GetRequiredServiceById(options.Mode, SessionAffinityConstants.Modes.Cookie);
             currentProvider.AffinitizeRequest(context, options, destination);

--- a/src/ReverseProxy/Middleware/AffinitizedDestinationLookupMiddleware.cs
+++ b/src/ReverseProxy/Middleware/AffinitizedDestinationLookupMiddleware.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ReverseProxy.Middleware
             return InvokeInternal(context, proxyFeature, options, cluster.ClusterId);
         }
 
-        private async Task InvokeInternal(HttpContext context, IReverseProxyFeature proxyFeature, ClusterConfig.ClusterSessionAffinityOptions options, string clusterId)
+        private async Task InvokeInternal(HttpContext context, IReverseProxyFeature proxyFeature, ClusterSessionAffinityOptions options, string clusterId)
         {
             var destinations = proxyFeature.AvailableDestinations;
 

--- a/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
@@ -287,15 +287,15 @@ namespace Microsoft.ReverseProxy.Service.Management
 
                         var newClusterConfig = new ClusterConfig(
                                 newCluster,
-                                new ClusterConfig.ClusterHealthCheckOptions(
+                                new ClusterHealthCheckOptions(
                                     enabled: newCluster.HealthCheck?.Enabled ?? false,
                                     interval: newCluster.HealthCheck?.Interval ?? TimeSpan.FromSeconds(0),
                                     timeout: newCluster.HealthCheck?.Timeout ?? TimeSpan.FromSeconds(0),
                                     port: newCluster.HealthCheck?.Port ?? 0,
                                     path: newCluster.HealthCheck?.Path ?? string.Empty),
-                                new ClusterConfig.ClusterLoadBalancingOptions(
+                                new ClusterLoadBalancingOptions(
                                     mode: newCluster.LoadBalancing?.Mode ?? default),
-                                new ClusterConfig.ClusterSessionAffinityOptions(
+                                new ClusterSessionAffinityOptions(
                                     enabled: newCluster.SessionAffinity?.Enabled ?? false,
                                     mode: newCluster.SessionAffinity?.Mode,
                                     failurePolicy: newCluster.SessionAffinity?.FailurePolicy,
@@ -481,14 +481,14 @@ namespace Microsoft.ReverseProxy.Service.Management
             }
         }
 
-        private ClusterConfig.ClusterProxyHttpClientOptions ConvertProxyHttpClientOptions(ProxyHttpClientOptions httpClientOptions)
+        private ClusterProxyHttpClientOptions ConvertProxyHttpClientOptions(ProxyHttpClientOptions httpClientOptions)
         {
             if (httpClientOptions == null)
             {
-                return new ClusterConfig.ClusterProxyHttpClientOptions();
+                return new ClusterProxyHttpClientOptions();
             }
 
-            return new ClusterConfig.ClusterProxyHttpClientOptions(
+            return new ClusterProxyHttpClientOptions(
                 httpClientOptions.SslProtocols,
                 httpClientOptions.DangerousAcceptAnyServerCertificate,
                 httpClientOptions.ClientCertificate,

--- a/src/ReverseProxy/Service/Proxy/ILoadBalancer.cs
+++ b/src/ReverseProxy/Service/Proxy/ILoadBalancer.cs
@@ -18,6 +18,6 @@ namespace Microsoft.ReverseProxy.Service.Proxy
         // TODO: How to ensure retries pick a different destination when available?
         DestinationInfo PickDestination(
             IReadOnlyList<DestinationInfo> availableDestinations,
-            in ClusterConfig.ClusterLoadBalancingOptions loadBalancingOptions);
+            in ClusterLoadBalancingOptions loadBalancingOptions);
     }
 }

--- a/src/ReverseProxy/Service/Proxy/Infrastructure/ProxyHttpClientContext.cs
+++ b/src/ReverseProxy/Service/Proxy/Infrastructure/ProxyHttpClientContext.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Infrastructure
         /// from which the <see cref="OldClient"/> was created.
         /// Can be null if a client is getting constructed for the first time.
         /// </summary>
-        public ClusterConfig.ClusterProxyHttpClientOptions OldOptions { get; set; }
+        public ClusterProxyHttpClientOptions OldOptions { get; set; }
 
         /// <summary>
         /// Old metadata instance from which the <see cref="OldClient"/> was created.
@@ -41,7 +41,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Infrastructure
         /// specifying the settings for a new client.
         /// CANNOT be null.
         /// </summary>
-        public ClusterConfig.ClusterProxyHttpClientOptions NewOptions { get; set; }
+        public ClusterProxyHttpClientOptions NewOptions { get; set; }
 
         /// <summary>
         /// New metadata instance used for a new client construction.

--- a/src/ReverseProxy/Service/Proxy/LoadBalancer.cs
+++ b/src/ReverseProxy/Service/Proxy/LoadBalancer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy
 
         public DestinationInfo PickDestination(
             IReadOnlyList<DestinationInfo> endpoints,
-            in ClusterConfig.ClusterLoadBalancingOptions loadBalancingOptions)
+            in ClusterLoadBalancingOptions loadBalancingOptions)
         {
             var endpointCount = endpoints.Count;
             if (endpointCount == 0)

--- a/src/ReverseProxy/Service/RuntimeModel/ClusterConfig.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/ClusterConfig.cs
@@ -4,11 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Net.Security;
-using System.Security.Authentication;
-using System.Security.Cryptography.X509Certificates;
 using Microsoft.ReverseProxy.Abstractions;
-using Microsoft.ReverseProxy.Utilities;
 
 namespace Microsoft.ReverseProxy.RuntimeModel
 {
@@ -65,137 +61,6 @@ namespace Microsoft.ReverseProxy.RuntimeModel
         internal bool HasConfigChanged(ClusterConfig newClusterConfig)
         {
             return !Cluster.Equals(_cluster, newClusterConfig._cluster);
-        }
-
-        /// <summary>
-        /// Active health probing options for a cluster.
-        /// </summary>
-        /// <remarks>
-        /// Struct used only to keep things organized as we add more configuration options inside of `ClusterConfig`.
-        /// Each "feature" can have its own struct.
-        /// </remarks>
-        public readonly struct ClusterHealthCheckOptions
-        {
-            public ClusterHealthCheckOptions(bool enabled, TimeSpan interval, TimeSpan timeout, int port, string path)
-            {
-                Enabled = enabled;
-                Interval = interval;
-                Timeout = timeout;
-                Port = port;
-                Path = path;
-            }
-
-            /// <summary>
-            /// Whether health probes are enabled.
-            /// </summary>
-            public bool Enabled { get; }
-
-            /// <summary>
-            /// Interval between health probes.
-            /// </summary>
-            public TimeSpan Interval { get; }
-
-            /// <summary>
-            /// Health probe timeout, after which the targeted endpoint is considered unhealthy.
-            /// </summary>
-            public TimeSpan Timeout { get; }
-
-            /// <summary>
-            /// Port number.
-            /// </summary>
-            public int Port { get; }
-
-            /// <summary>
-            /// Http path.
-            /// </summary>
-            public string Path { get; }
-        }
-
-        public readonly struct ClusterLoadBalancingOptions
-        {
-            public ClusterLoadBalancingOptions(LoadBalancingMode mode)
-            {
-                Mode = mode;
-                // Increment returns the new value and we want the first return value to be 0.
-                RoundRobinState = new AtomicCounter() { Value = -1 };
-            }
-
-            public LoadBalancingMode Mode { get; }
-
-            internal AtomicCounter RoundRobinState { get; }
-        }
-
-        public readonly struct ClusterSessionAffinityOptions
-        {
-            public ClusterSessionAffinityOptions(bool enabled, string mode, string failurePolicy, IReadOnlyDictionary<string, string> settings)
-            {
-                Mode = mode;
-                FailurePolicy = failurePolicy;
-                Settings = settings;
-                Enabled = enabled;
-            }
-
-            public bool Enabled { get; }
-
-            public string Mode { get; }
-
-            public string FailurePolicy { get; }
-
-            public IReadOnlyDictionary<string, string> Settings { get; }
-        }
-
-        public readonly struct ClusterProxyHttpClientOptions : IEquatable<ClusterProxyHttpClientOptions>
-        {
-            public ClusterProxyHttpClientOptions(
-                SslProtocols? sslProtocols,
-                bool acceptAnyServerCertificate,
-                X509Certificate2 clientCertificate,
-                int? maxConnectionsPerServer)
-            {
-                SslProtocols = sslProtocols;
-                DangerousAcceptAnyServerCertificate = acceptAnyServerCertificate;
-                ClientCertificate = clientCertificate;
-                MaxConnectionsPerServer = maxConnectionsPerServer;
-            }
-
-            public SslProtocols? SslProtocols { get; }
-
-            public bool DangerousAcceptAnyServerCertificate { get; }
-
-            public X509Certificate2 ClientCertificate { get; }
-
-            public int? MaxConnectionsPerServer { get; }
-
-            // TODO: Add this property once we have migrated to SDK version that supports it.
-            //public bool? EnableMultipleHttp2Connections { get; }
-
-            public override bool Equals(object obj)
-            {
-                return obj is ClusterProxyHttpClientOptions options && Equals(options);
-            }
-
-            public bool Equals(ClusterProxyHttpClientOptions other)
-            {
-                return SslProtocols == other.SslProtocols &&
-                       DangerousAcceptAnyServerCertificate == other.DangerousAcceptAnyServerCertificate &&
-                       EqualityComparer<X509Certificate2>.Default.Equals(ClientCertificate, other.ClientCertificate) &&
-                       MaxConnectionsPerServer == other.MaxConnectionsPerServer;
-            }
-
-            public override int GetHashCode()
-            {
-                return HashCode.Combine(SslProtocols, DangerousAcceptAnyServerCertificate, ClientCertificate, MaxConnectionsPerServer);
-            }
-
-            public static bool operator ==(ClusterProxyHttpClientOptions left, ClusterProxyHttpClientOptions right)
-            {
-                return left.Equals(right);
-            }
-
-            public static bool operator !=(ClusterProxyHttpClientOptions left, ClusterProxyHttpClientOptions right)
-            {
-                return !(left == right);
-            }
         }
     }
 }

--- a/src/ReverseProxy/Service/RuntimeModel/ClusterHealthCheckOptions.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/ClusterHealthCheckOptions.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.ReverseProxy.RuntimeModel
+{
+    /// <summary>
+    /// Active health probing options for a cluster.
+    /// </summary>
+    /// <remarks>
+    /// Struct used only to keep things organized as we add more configuration options inside of `ClusterConfig`.
+    /// Each "feature" can have its own struct.
+    /// </remarks>
+    public readonly struct ClusterHealthCheckOptions
+    {
+        public ClusterHealthCheckOptions(bool enabled, TimeSpan interval, TimeSpan timeout, int port, string path)
+        {
+            Enabled = enabled;
+            Interval = interval;
+            Timeout = timeout;
+            Port = port;
+            Path = path;
+        }
+
+        /// <summary>
+        /// Whether health probes are enabled.
+        /// </summary>
+        public bool Enabled { get; }
+
+        /// <summary>
+        /// Interval between health probes.
+        /// </summary>
+        public TimeSpan Interval { get; }
+
+        /// <summary>
+        /// Health probe timeout, after which the targeted endpoint is considered unhealthy.
+        /// </summary>
+        public TimeSpan Timeout { get; }
+
+        /// <summary>
+        /// Port number.
+        /// </summary>
+        public int Port { get; }
+
+        /// <summary>
+        /// Http path.
+        /// </summary>
+        public string Path { get; }
+    }
+}

--- a/src/ReverseProxy/Service/RuntimeModel/ClusterLoadBalancingOptions.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/ClusterLoadBalancingOptions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.ReverseProxy.Abstractions;
+using Microsoft.ReverseProxy.Utilities;
+
+namespace Microsoft.ReverseProxy.RuntimeModel
+{
+    public readonly struct ClusterLoadBalancingOptions
+    {
+        public ClusterLoadBalancingOptions(LoadBalancingMode mode)
+        {
+            Mode = mode;
+            // Increment returns the new value and we want the first return value to be 0.
+            RoundRobinState = new AtomicCounter() { Value = -1 };
+        }
+
+        public LoadBalancingMode Mode { get; }
+
+        internal AtomicCounter RoundRobinState { get; }
+    }
+}

--- a/src/ReverseProxy/Service/RuntimeModel/ClusterProxyHttpClientOptions.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/ClusterProxyHttpClientOptions.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Microsoft.ReverseProxy.RuntimeModel
+{
+    public readonly struct ClusterProxyHttpClientOptions : IEquatable<ClusterProxyHttpClientOptions>
+    {
+        public ClusterProxyHttpClientOptions(
+            SslProtocols? sslProtocols,
+            bool acceptAnyServerCertificate,
+            X509Certificate2 clientCertificate,
+            int? maxConnectionsPerServer)
+        {
+            SslProtocols = sslProtocols;
+            DangerousAcceptAnyServerCertificate = acceptAnyServerCertificate;
+            ClientCertificate = clientCertificate;
+            MaxConnectionsPerServer = maxConnectionsPerServer;
+        }
+
+        public SslProtocols? SslProtocols { get; }
+
+        public bool DangerousAcceptAnyServerCertificate { get; }
+
+        public X509Certificate2 ClientCertificate { get; }
+
+        public int? MaxConnectionsPerServer { get; }
+
+        // TODO: Add this property once we have migrated to SDK version that supports it.
+        //public bool? EnableMultipleHttp2Connections { get; }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ClusterProxyHttpClientOptions options && Equals(options);
+        }
+
+        public bool Equals(ClusterProxyHttpClientOptions other)
+        {
+            return SslProtocols == other.SslProtocols &&
+                   DangerousAcceptAnyServerCertificate == other.DangerousAcceptAnyServerCertificate &&
+                   EqualityComparer<X509Certificate2>.Default.Equals(ClientCertificate, other.ClientCertificate) &&
+                   MaxConnectionsPerServer == other.MaxConnectionsPerServer;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(SslProtocols, DangerousAcceptAnyServerCertificate, ClientCertificate, MaxConnectionsPerServer);
+        }
+
+        public static bool operator ==(ClusterProxyHttpClientOptions left, ClusterProxyHttpClientOptions right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(ClusterProxyHttpClientOptions left, ClusterProxyHttpClientOptions right)
+        {
+            return !(left == right);
+        }
+    }
+}

--- a/src/ReverseProxy/Service/RuntimeModel/ClusterSessionAffinityOptions.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/ClusterSessionAffinityOptions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace Microsoft.ReverseProxy.RuntimeModel
+{
+    public readonly struct ClusterSessionAffinityOptions
+    {
+        public ClusterSessionAffinityOptions(bool enabled, string mode, string failurePolicy, IReadOnlyDictionary<string, string> settings)
+        {
+            Mode = mode;
+            FailurePolicy = failurePolicy;
+            Settings = settings;
+            Enabled = enabled;
+        }
+
+        public bool Enabled { get; }
+
+        public string Mode { get; }
+
+        public string FailurePolicy { get; }
+
+        public IReadOnlyDictionary<string, string> Settings { get; }
+    }
+}

--- a/src/ReverseProxy/Service/SessionAffinity/BaseSessionAffinityProvider.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/BaseSessionAffinityProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
 
         public abstract string Mode { get; }
 
-        public virtual void AffinitizeRequest(HttpContext context, in ClusterConfig.ClusterSessionAffinityOptions options, DestinationInfo destination)
+        public virtual void AffinitizeRequest(HttpContext context, in ClusterSessionAffinityOptions options, DestinationInfo destination)
         {
             if (!options.Enabled)
             {
@@ -40,7 +40,7 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
             }
         }
 
-        public virtual AffinityResult FindAffinitizedDestinations(HttpContext context, IReadOnlyList<DestinationInfo> destinations, string clusterId, in ClusterConfig.ClusterSessionAffinityOptions options)
+        public virtual AffinityResult FindAffinitizedDestinations(HttpContext context, IReadOnlyList<DestinationInfo> destinations, string clusterId, in ClusterSessionAffinityOptions options)
         {
             if (!options.Enabled)
             {
@@ -85,7 +85,7 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
             return new AffinityResult(matchingDestinations, AffinityStatus.OK);
         }
 
-        protected virtual string GetSettingValue(string key, ClusterConfig.ClusterSessionAffinityOptions options)
+        protected virtual string GetSettingValue(string key, ClusterSessionAffinityOptions options)
         {
             if (options.Settings == null || !options.Settings.TryGetValue(key, out var value))
             {
@@ -97,9 +97,9 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
 
         protected abstract T GetDestinationAffinityKey(DestinationInfo destination);
 
-        protected abstract (T Key, bool ExtractedSuccessfully) GetRequestAffinityKey(HttpContext context, in ClusterConfig.ClusterSessionAffinityOptions options);
+        protected abstract (T Key, bool ExtractedSuccessfully) GetRequestAffinityKey(HttpContext context, in ClusterSessionAffinityOptions options);
 
-        protected abstract void SetAffinityKey(HttpContext context, in ClusterConfig.ClusterSessionAffinityOptions options, T unencryptedKey);
+        protected abstract void SetAffinityKey(HttpContext context, in ClusterSessionAffinityOptions options, T unencryptedKey);
 
         protected string Protect(string unencryptedKey)
         {

--- a/src/ReverseProxy/Service/SessionAffinity/CookieSessionAffinityProvider.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/CookieSessionAffinityProvider.cs
@@ -31,13 +31,13 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
             return destination.DestinationId;
         }
 
-        protected override (string Key, bool ExtractedSuccessfully) GetRequestAffinityKey(HttpContext context, in ClusterConfig.ClusterSessionAffinityOptions options)
+        protected override (string Key, bool ExtractedSuccessfully) GetRequestAffinityKey(HttpContext context, in ClusterSessionAffinityOptions options)
         {
             var encryptedRequestKey = context.Request.Cookies.TryGetValue(_providerOptions.Cookie.Name, out var keyInCookie) ? keyInCookie : null;
             return Unprotect(encryptedRequestKey);
         }
 
-        protected override void SetAffinityKey(HttpContext context, in ClusterConfig.ClusterSessionAffinityOptions options, string unencryptedKey)
+        protected override void SetAffinityKey(HttpContext context, in ClusterSessionAffinityOptions options, string unencryptedKey)
         {
             var affinityCookieOptions = _providerOptions.Cookie.Build(context);
             context.Response.Cookies.Append(_providerOptions.Cookie.Name, Protect(unencryptedKey), affinityCookieOptions);

--- a/src/ReverseProxy/Service/SessionAffinity/CustomHeaderSessionAffinityProvider.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/CustomHeaderSessionAffinityProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
             return destination.DestinationId;
         }
 
-        protected override (string Key, bool ExtractedSuccessfully) GetRequestAffinityKey(HttpContext context, in ClusterConfig.ClusterSessionAffinityOptions options)
+        protected override (string Key, bool ExtractedSuccessfully) GetRequestAffinityKey(HttpContext context, in ClusterSessionAffinityOptions options)
         {
             var customHeaderName = options.Settings != null && options.Settings.TryGetValue(CustomHeaderNameKey, out var nameInSettings) ? nameInSettings : DefaultCustomHeaderName;
             var keyHeaderValues = context.Request.Headers[customHeaderName];
@@ -50,7 +50,7 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
             return Unprotect(keyHeaderValues[0]);
         }
 
-        protected override void SetAffinityKey(HttpContext context, in ClusterConfig.ClusterSessionAffinityOptions options, string unencryptedKey)
+        protected override void SetAffinityKey(HttpContext context, in ClusterSessionAffinityOptions options, string unencryptedKey)
         {
             var customHeaderName = GetSettingValue(CustomHeaderNameKey, options);
             context.Response.Headers.Append(customHeaderName, Protect(unencryptedKey));

--- a/src/ReverseProxy/Service/SessionAffinity/IAffinityFailurePolicy.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/IAffinityFailurePolicy.cs
@@ -3,7 +3,6 @@
 
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.ReverseProxy.Middleware;
 using Microsoft.ReverseProxy.RuntimeModel;
 
 namespace Microsoft.ReverseProxy.Service.SessionAffinity
@@ -29,6 +28,6 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
         /// <see cref="true"/> if the failure is considered recoverable and the request processing can proceed.
         /// Otherwise, <see cref="false"/> indicating that an error response has been generated and the request's processing must be terminated.
         /// </returns>
-        public Task<bool> Handle(HttpContext context, ClusterConfig.ClusterSessionAffinityOptions options, AffinityStatus affinityStatus);
+        public Task<bool> Handle(HttpContext context, ClusterSessionAffinityOptions options, AffinityStatus affinityStatus);
     }
 }

--- a/src/ReverseProxy/Service/SessionAffinity/ISessionAffinityProvider.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/ISessionAffinityProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
         /// <param name="clusterId">Target cluster ID.</param>
         /// <param name="options">Affinity options.</param>
         /// <returns><see cref="AffinityResult"/> carrying the found affinitized destinations if any and the <see cref="AffinityStatus"/>.</returns>
-        public AffinityResult FindAffinitizedDestinations(HttpContext context, IReadOnlyList<DestinationInfo> destinations, string clusterId, in ClusterConfig.ClusterSessionAffinityOptions options);
+        public AffinityResult FindAffinitizedDestinations(HttpContext context, IReadOnlyList<DestinationInfo> destinations, string clusterId, in ClusterSessionAffinityOptions options);
 
         /// <summary>
         /// Affinitize the current request to the given <see cref="DestinationInfo"/> by setting the affinity key extracted from <see cref="DestinationInfo"/>.
@@ -34,6 +34,6 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
         /// <param name="context">Current request's context.</param>
         /// <param name="options">Affinity options.</param>
         /// <param name="destination"><see cref="DestinationInfo"/> to which request is to be affinitized.</param>
-        public void AffinitizeRequest(HttpContext context, in ClusterConfig.ClusterSessionAffinityOptions options, DestinationInfo destination);
+        public void AffinitizeRequest(HttpContext context, in ClusterSessionAffinityOptions options, DestinationInfo destination);
     }
 }

--- a/src/ReverseProxy/Service/SessionAffinity/RedistributeAffinityFailurePolicy.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/RedistributeAffinityFailurePolicy.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.ReverseProxy.Abstractions.ClusterDiscovery.Contract;
 using Microsoft.ReverseProxy.RuntimeModel;
+using Microsoft.ReverseProxy.Utilities;
 
 namespace Microsoft.ReverseProxy.Service.SessionAffinity
 {
@@ -13,7 +14,7 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
     {
         public string Name => SessionAffinityConstants.AffinityFailurePolicies.Redistribute;
 
-        public Task<bool> Handle(HttpContext context, ClusterConfig.ClusterSessionAffinityOptions options, AffinityStatus affinityStatus)
+        public Task<bool> Handle(HttpContext context, ClusterSessionAffinityOptions options, AffinityStatus affinityStatus)
         {
             if (affinityStatus == AffinityStatus.OK
                 || affinityStatus == AffinityStatus.AffinityKeyNotSet)
@@ -23,7 +24,7 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
 
             // Available destinations list have not been changed in the context,
             // so simply allow processing to proceed to load balancing.
-            return Task.FromResult(true);
+            return TaskUtilities.TrueTask;
         }
     }
 }

--- a/src/ReverseProxy/Service/SessionAffinity/Return503ErrorAffinityFailurePolicy.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/Return503ErrorAffinityFailurePolicy.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.ReverseProxy.Abstractions.ClusterDiscovery.Contract;
 using Microsoft.ReverseProxy.RuntimeModel;
+using Microsoft.ReverseProxy.Utilities;
 
 namespace Microsoft.ReverseProxy.Service.SessionAffinity
 {
@@ -13,7 +14,7 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
     {
         public string Name => SessionAffinityConstants.AffinityFailurePolicies.Return503Error;
 
-        public Task<bool> Handle(HttpContext context, ClusterConfig.ClusterSessionAffinityOptions options, AffinityStatus affinityStatus)
+        public Task<bool> Handle(HttpContext context, ClusterSessionAffinityOptions options, AffinityStatus affinityStatus)
         {
             if (affinityStatus == AffinityStatus.OK
                 || affinityStatus == AffinityStatus.AffinityKeyNotSet)
@@ -22,7 +23,7 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
             }
 
             context.Response.StatusCode = 503;
-            return Task.FromResult(false);
+            return TaskUtilities.FalseTask;
         }
     }
 }

--- a/src/ReverseProxy/Utilities/TaskUtilities.cs
+++ b/src/ReverseProxy/Utilities/TaskUtilities.cs
@@ -12,6 +12,6 @@ namespace Microsoft.ReverseProxy.Utilities
     internal static class TaskUtilities
     {
         internal static readonly Task<bool> TrueTask = Task.FromResult(true);
-        internal static readonly Task<bool> FalseTask = Task.FromResult(true);
+        internal static readonly Task<bool> FalseTask = Task.FromResult(false);
     }
 }

--- a/src/ReverseProxy/Utilities/TaskUtilities.cs
+++ b/src/ReverseProxy/Utilities/TaskUtilities.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.ReverseProxy.Utilities
+{
+    internal static class TaskUtilities
+    {
+        internal static readonly Task<bool> TrueTask = Task.FromResult(true);
+        internal static readonly Task<bool> FalseTask = Task.FromResult(true);
+    }
+}

--- a/test/ReverseProxy.Tests/Middleware/AffinityMiddlewareTestBase.cs
+++ b/test/ReverseProxy.Tests/Middleware/AffinityMiddlewareTestBase.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ReverseProxy.Middleware
     {
         protected const string AffinitizedDestinationName = "dest-B";
         protected readonly IReadOnlyList<DestinationInfo> Destinations = new[] { new DestinationInfo("dest-A"), new DestinationInfo(AffinitizedDestinationName), new DestinationInfo("dest-C") };
-        protected readonly ClusterConfig ClusterConfig = new ClusterConfig(default, default, default, new ClusterConfig.ClusterSessionAffinityOptions(true, "Mode-B", "Policy-1", null),
+        protected readonly ClusterConfig ClusterConfig = new ClusterConfig(default, default, default, new ClusterSessionAffinityOptions(true, "Mode-B", "Policy-1", null),
             new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object), default, new Dictionary<string, string>());
 
         internal ClusterInfo GetCluster()
@@ -73,7 +73,7 @@ namespace Microsoft.ReverseProxy.Middleware
             {
                 var policy = new Mock<IAffinityFailurePolicy>(MockBehavior.Strict);
                 policy.SetupGet(p => p.Name).Returns(name);
-                policy.Setup(p => p.Handle(It.IsAny<HttpContext>(), It.Is<ClusterConfig.ClusterSessionAffinityOptions>(o => o.FailurePolicy == name), expectedStatus))
+                policy.Setup(p => p.Handle(It.IsAny<HttpContext>(), It.Is<ClusterSessionAffinityOptions>(o => o.FailurePolicy == name), expectedStatus))
                     .ReturnsAsync(handled)
                     .Callback(() => callback(policy.Object));
                 result.Add(policy);

--- a/test/ReverseProxy.Tests/Middleware/DestinationInitializerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/DestinationInitializerMiddlewareTests.cs
@@ -81,10 +81,10 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
                 destinationManager: new DestinationManager());
             cluster1.Config.Value = new ClusterConfig(
                 new Cluster(),
-                new ClusterConfig.ClusterHealthCheckOptions(enabled: true, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan, 0, ""),
-                new ClusterConfig.ClusterLoadBalancingOptions(),
-                new ClusterConfig.ClusterSessionAffinityOptions(),
-                httpClient, new ClusterConfig.ClusterProxyHttpClientOptions(),
+                new ClusterHealthCheckOptions(enabled: true, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan, 0, ""),
+                new ClusterLoadBalancingOptions(),
+                new ClusterSessionAffinityOptions(),
+                httpClient, new ClusterProxyHttpClientOptions(),
                 new Dictionary<string, string>());
             var destination1 = cluster1.DestinationManager.GetOrCreateItem(
                 "destination1",

--- a/test/ReverseProxy.Tests/Middleware/LoadBalancerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/LoadBalancerMiddlewareTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
             var cluster1 = new ClusterInfo(
                 clusterId: "cluster1",
                 destinationManager: new DestinationManager());
-            cluster1.Config.Value = new ClusterConfig(default, default, new ClusterConfig.ClusterLoadBalancingOptions(LoadBalancingMode.RoundRobin), default, httpClient, default, new Dictionary<string, string>());
+            cluster1.Config.Value = new ClusterConfig(default, default, new ClusterLoadBalancingOptions(LoadBalancingMode.RoundRobin), default, httpClient, default, new Dictionary<string, string>());
             var destination1 = cluster1.DestinationManager.GetOrCreateItem(
                 "destination1",
                 destination =>
@@ -97,7 +97,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
             var cluster1 = new ClusterInfo(
                 clusterId: "cluster1",
                 destinationManager: new DestinationManager());
-            cluster1.Config.Value = new ClusterConfig(default, default, new ClusterConfig.ClusterLoadBalancingOptions(LoadBalancingMode.RoundRobin), default, httpClient, default, new Dictionary<string, string>());
+            cluster1.Config.Value = new ClusterConfig(default, default, new ClusterLoadBalancingOptions(LoadBalancingMode.RoundRobin), default, httpClient, default, new Dictionary<string, string>());
             var destination1 = cluster1.DestinationManager.GetOrCreateItem(
                 "destination1",
                 destination =>
@@ -126,7 +126,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
             httpContext.SetEndpoint(aspNetCoreEndpoint);
 
             Mock<ILoadBalancer>()
-                .Setup(l => l.PickDestination(It.IsAny<IReadOnlyList<DestinationInfo>>(), It.IsAny<ClusterConfig.ClusterLoadBalancingOptions>()))
+                .Setup(l => l.PickDestination(It.IsAny<IReadOnlyList<DestinationInfo>>(), It.IsAny<ClusterLoadBalancingOptions>()))
                 .Returns((DestinationInfo)null);
 
             httpContext.Features.Set<IReverseProxyFeature>(

--- a/test/ReverseProxy.Tests/Service/Proxy/Infrastructure/ProxyHttpClientFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/Infrastructure/ProxyHttpClientFactoryTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
         public void CreateClient_ApplySslProtocols_Success()
         {
             var factory = new ProxyHttpClientFactory(Mock<ILogger<ProxyHttpClientFactory>>().Object);
-            var options = new ClusterConfig.ClusterProxyHttpClientOptions(SslProtocols.Tls12 | SslProtocols.Tls13, default, default, default);
+            var options = new ClusterProxyHttpClientOptions(SslProtocols.Tls12 | SslProtocols.Tls13, default, default, default);
             var client = factory.CreateClient(new ProxyHttpClientContext { NewOptions = options });
 
             var handler = GetHandler(client);
@@ -58,7 +58,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
         public void CreateClient_ApplyDangerousAcceptAnyServerCertificate_Success()
         {
             var factory = new ProxyHttpClientFactory(Mock<ILogger<ProxyHttpClientFactory>>().Object);
-            var options = new ClusterConfig.ClusterProxyHttpClientOptions(default, true, default, default);
+            var options = new ClusterProxyHttpClientOptions(default, true, default, default);
             var client = factory.CreateClient(new ProxyHttpClientContext { NewOptions = options });
 
             var handler = GetHandler(client);
@@ -74,7 +74,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
         {
             var factory = new ProxyHttpClientFactory(Mock<ILogger<ProxyHttpClientFactory>>().Object);
             var certificate = TestResources.GetTestCertificate();
-            var options = new ClusterConfig.ClusterProxyHttpClientOptions(default, default, certificate, default);
+            var options = new ClusterProxyHttpClientOptions(default, default, certificate, default);
             var client = factory.CreateClient(new ProxyHttpClientContext { NewOptions = options });
 
             var handler = GetHandler(client);
@@ -89,7 +89,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
         public void CreateClient_ApplyMaxConnectionsPerServer_Success()
         {
             var factory = new ProxyHttpClientFactory(Mock<ILogger<ProxyHttpClientFactory>>().Object);
-            var options = new ClusterConfig.ClusterProxyHttpClientOptions(default, default, default, 22);
+            var options = new ClusterProxyHttpClientOptions(default, default, default, 22);
             var client = factory.CreateClient(new ProxyHttpClientContext { NewOptions = options });
 
             var handler = GetHandler(client);
@@ -105,8 +105,8 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
             var factory = new ProxyHttpClientFactory(Mock<ILogger<ProxyHttpClientFactory>>().Object);
             var oldClient = new HttpMessageInvoker(new SocketsHttpHandler());
             var clientCertificate = TestResources.GetTestCertificate();
-            var oldOptions = new ClusterConfig.ClusterProxyHttpClientOptions(SslProtocols.Tls11 | SslProtocols.Tls12, true, clientCertificate, 10);
-            var newOptions = new ClusterConfig.ClusterProxyHttpClientOptions(SslProtocols.Tls11 | SslProtocols.Tls12, true, clientCertificate, 10);
+            var oldOptions = new ClusterProxyHttpClientOptions(SslProtocols.Tls11 | SslProtocols.Tls12, true, clientCertificate, 10);
+            var newOptions = new ClusterProxyHttpClientOptions(SslProtocols.Tls11 | SslProtocols.Tls12, true, clientCertificate, 10);
             var oldMetadata = new Dictionary<string, string> { { "key1", "value1" }, { "key2", "value2" } };
             var newMetadata = new Dictionary<string, string> { { "key1", "value1" }, { "key2", "value2" } };
             var context = new ProxyHttpClientContext { ClusterId = "cluster1", OldOptions = oldOptions, OldMetadata = oldMetadata, OldClient = oldClient, NewOptions = newOptions, NewMetadata = newMetadata };
@@ -119,7 +119,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
 
         [Theory]
         [MemberData(nameof(GetChangedHttpClientOptions))]
-        public void CreateClient_OldClientExistsHttpClientOptionsChanged_ReturnsNewInstance(ClusterConfig.ClusterProxyHttpClientOptions oldOptions, ClusterConfig.ClusterProxyHttpClientOptions newOptions)
+        public void CreateClient_OldClientExistsHttpClientOptionsChanged_ReturnsNewInstance(ClusterProxyHttpClientOptions oldOptions, ClusterProxyHttpClientOptions newOptions)
         {
             var factory = new ProxyHttpClientFactory(Mock<ILogger<ProxyHttpClientFactory>>().Object);
             var oldClient = new HttpMessageInvoker(new SocketsHttpHandler());
@@ -137,32 +137,32 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
             return new[]
             {
                 new object[] {
-                    new ClusterConfig.ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, clientCertificate, null),
-                    new ClusterConfig.ClusterProxyHttpClientOptions(SslProtocols.Tls11 | SslProtocols.Tls12, true, clientCertificate, null)
+                    new ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, clientCertificate, null),
+                    new ClusterProxyHttpClientOptions(SslProtocols.Tls11 | SslProtocols.Tls12, true, clientCertificate, null)
                 },
                 new object[] {
-                    new ClusterConfig.ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, clientCertificate, null),
-                    new ClusterConfig.ClusterProxyHttpClientOptions(SslProtocols.Tls11, false, clientCertificate, null)
+                    new ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, clientCertificate, null),
+                    new ClusterProxyHttpClientOptions(SslProtocols.Tls11, false, clientCertificate, null)
                 },
                 new object[] {
-                    new ClusterConfig.ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, clientCertificate, null),
-                    new ClusterConfig.ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, null, null)
+                    new ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, clientCertificate, null),
+                    new ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, null, null)
                 },
                 new object[] {
-                    new ClusterConfig.ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, null, null),
-                    new ClusterConfig.ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, clientCertificate, null)
+                    new ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, null, null),
+                    new ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, clientCertificate, null)
                 },
                 new object[] {
-                    new ClusterConfig.ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, null, null),
-                    new ClusterConfig.ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, clientCertificate, 10)
+                    new ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, null, null),
+                    new ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, clientCertificate, 10)
                 },
                 new object[] {
-                    new ClusterConfig.ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, null, 10),
-                    new ClusterConfig.ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, clientCertificate, null)
+                    new ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, null, 10),
+                    new ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, clientCertificate, null)
                 },
                 new object[] {
-                    new ClusterConfig.ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, null, 10),
-                    new ClusterConfig.ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, clientCertificate, 20)
+                    new ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, null, 10),
+                    new ClusterProxyHttpClientOptions(SslProtocols.Tls11, true, clientCertificate, 20)
                 },
             };
         }

--- a/test/ReverseProxy.Tests/Service/Proxy/LoadBalancerTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/LoadBalancerTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
         {
             var loadBalancer = Create<LoadBalancer>();
             var destinations = new DestinationInfo[0];
-            var options = new ClusterConfig.ClusterLoadBalancingOptions((LoadBalancingMode)(-1));
+            var options = new ClusterLoadBalancingOptions((LoadBalancingMode)(-1));
 
             var result = loadBalancer.PickDestination(destinations, in options);
 
@@ -42,7 +42,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
             {
                 new DestinationInfo("d1"),
             };
-            var options = new ClusterConfig.ClusterLoadBalancingOptions((LoadBalancingMode)(-1));
+            var options = new ClusterLoadBalancingOptions((LoadBalancingMode)(-1));
 
             var result = loadBalancer.PickDestination(destinations, in options);
 
@@ -58,7 +58,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                 new DestinationInfo("d1"),
                 new DestinationInfo("d2"),
             };
-            var options = new ClusterConfig.ClusterLoadBalancingOptions((LoadBalancingMode)(-1));
+            var options = new ClusterLoadBalancingOptions((LoadBalancingMode)(-1));
 
             Action action = () => loadBalancer.PickDestination(destinations, in options);
 
@@ -76,7 +76,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                 new DestinationInfo("d1"),
                 new DestinationInfo("d2"),
             };
-            var options = new ClusterConfig.ClusterLoadBalancingOptions(LoadBalancingMode.First);
+            var options = new ClusterLoadBalancingOptions(LoadBalancingMode.First);
 
             var result = loadBalancer.PickDestination(destinations, in options);
 
@@ -93,7 +93,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                 new DestinationInfo("d2"),
             };
             RandomInstance.Sequence = new[] { 1 };
-            var options = new ClusterConfig.ClusterLoadBalancingOptions(LoadBalancingMode.Random);
+            var options = new ClusterLoadBalancingOptions(LoadBalancingMode.Random);
 
             var result = loadBalancer.PickDestination(destinations, in options);
 
@@ -111,7 +111,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
             };
             destinations[0].ConcurrencyCounter.Increment();
             RandomInstance.Sequence = new[] { 1, 0 };
-            var options = new ClusterConfig.ClusterLoadBalancingOptions(LoadBalancingMode.PowerOfTwoChoices);
+            var options = new ClusterLoadBalancingOptions(LoadBalancingMode.PowerOfTwoChoices);
 
             var result = loadBalancer.PickDestination(destinations, in options);
 
@@ -128,7 +128,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                 new DestinationInfo("d2"),
             };
             destinations[0].ConcurrencyCounter.Increment();
-            var options = new ClusterConfig.ClusterLoadBalancingOptions(LoadBalancingMode.LeastRequests);
+            var options = new ClusterLoadBalancingOptions(LoadBalancingMode.LeastRequests);
 
             var result = loadBalancer.PickDestination(destinations, in options);
 
@@ -145,7 +145,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                 new DestinationInfo("d2"),
             };
             destinations[0].ConcurrencyCounter.Increment();
-            var options = new ClusterConfig.ClusterLoadBalancingOptions(LoadBalancingMode.RoundRobin);
+            var options = new ClusterLoadBalancingOptions(LoadBalancingMode.RoundRobin);
 
             var result0 = loadBalancer.PickDestination(destinations, in options);
             var result1 = loadBalancer.PickDestination(destinations, in options);

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/ClusterInfoTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/ClusterInfoTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.ReverseProxy.RuntimeModel.Tests
             // Pretend that health checks are enabled so that destination health states are honored
             cluster.Config.Value = new ClusterConfig(
                 new Cluster(),
-                healthCheckOptions: new ClusterConfig.ClusterHealthCheckOptions(
+                healthCheckOptions: new ClusterHealthCheckOptions(
                     enabled: true,
                     interval: TimeSpan.FromSeconds(5),
                     timeout: TimeSpan.FromSeconds(30),

--- a/test/ReverseProxy.Tests/Service/SessionAffinity/BaseSesstionAffinityProviderTests.cs
+++ b/test/ReverseProxy.Tests/Service/SessionAffinity/BaseSesstionAffinityProviderTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
         private const string InvalidKeyNull = "!invalid key - null!";
         private const string InvalidKeyThrow = "!invalid key - throw!";
         private const string KeyName = "StubAffinityKey";
-        private readonly ClusterConfig.ClusterSessionAffinityOptions _defaultOptions = new ClusterConfig.ClusterSessionAffinityOptions(true, "Stub", "Return503", new Dictionary<string, string> { { "AffinityKeyName", KeyName } });
+        private readonly ClusterSessionAffinityOptions _defaultOptions = new ClusterSessionAffinityOptions(true, "Stub", "Return503", new Dictionary<string, string> { { "AffinityKeyName", KeyName } });
 
         [Theory]
         [MemberData(nameof(FindAffinitizedDestinationsCases))]
@@ -67,7 +67,7 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
         public void FindAffinitizedDestination_AffinityDisabledOnCluster_ReturnsAffinityDisabled()
         {
             var provider = new ProviderStub(GetDataProtector().Object, AffinityTestHelper.GetLogger<BaseSessionAffinityProvider<string>>().Object);
-            var options = new ClusterConfig.ClusterSessionAffinityOptions(false, _defaultOptions.Mode, _defaultOptions.FailurePolicy, _defaultOptions.Settings);
+            var options = new ClusterSessionAffinityOptions(false, _defaultOptions.Mode, _defaultOptions.FailurePolicy, _defaultOptions.Settings);
             Assert.Throws<InvalidOperationException>(() => provider.FindAffinitizedDestinations(new DefaultHttpContext(), new[] { new DestinationInfo("1") }, "cluster-1", options));
         }
 
@@ -140,9 +140,9 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
             yield return new object[] { GetHttpContext(new[] { (KeyName, InvalidKeyThrow) }), destinations, AffinityStatus.AffinityKeyExtractionFailed, null, Encoding.UTF8.GetBytes(InvalidKeyThrow), true, LogLevel.Error, EventIds.RequestAffinityKeyDecryptionFailed };
         }
 
-        private static ClusterConfig.ClusterSessionAffinityOptions GetOptionsWithUnknownSetting()
+        private static ClusterSessionAffinityOptions GetOptionsWithUnknownSetting()
         {
-            return new ClusterConfig.ClusterSessionAffinityOptions(true, "Stub", "Return503", new Dictionary<string, string> { { "Unknown", "ZZZ" } });
+            return new ClusterSessionAffinityOptions(true, "Stub", "Return503", new Dictionary<string, string> { { "Unknown", "ZZZ" } });
         }
 
         private static HttpContext GetHttpContext((string Key, string Value)[] items, bool encodeToBase64 = true)
@@ -189,7 +189,7 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
                 return destination.DestinationId;
             }
 
-            protected override (string Key, bool ExtractedSuccessfully) GetRequestAffinityKey(HttpContext context, in ClusterConfig.ClusterSessionAffinityOptions options)
+            protected override (string Key, bool ExtractedSuccessfully) GetRequestAffinityKey(HttpContext context, in ClusterSessionAffinityOptions options)
             {
                 Assert.Equal(Mode, options.Mode);
                 var keyName = GetSettingValue(KeyNameSetting, options);
@@ -199,7 +199,7 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
                 return Unprotect((string)encryptedKey);
             }
 
-            protected override void SetAffinityKey(HttpContext context, in ClusterConfig.ClusterSessionAffinityOptions options, string unencryptedKey)
+            protected override void SetAffinityKey(HttpContext context, in ClusterSessionAffinityOptions options, string unencryptedKey)
             {
                 var keyName = GetSettingValue(KeyNameSetting, options);
                 var encryptedKey = Protect(unencryptedKey);

--- a/test/ReverseProxy.Tests/Service/SessionAffinity/CookieSessionAffinityProviderTests.cs
+++ b/test/ReverseProxy.Tests/Service/SessionAffinity/CookieSessionAffinityProviderTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
     public class CookieSessionAffinityProviderTests
     {
         private readonly CookieSessionAffinityProviderOptions _defaultProviderOptions = new CookieSessionAffinityProviderOptions();
-        private readonly ClusterConfig.ClusterSessionAffinityOptions _defaultOptions = new ClusterConfig.ClusterSessionAffinityOptions(true, "Cookie", "Return503", null);
+        private readonly ClusterSessionAffinityOptions _defaultOptions = new ClusterSessionAffinityOptions(true, "Cookie", "Return503", null);
         private readonly IReadOnlyList<DestinationInfo> _destinations = new[] { new DestinationInfo("dest-A"), new DestinationInfo("dest-B"), new DestinationInfo("dest-C") };
 
         [Fact]

--- a/test/ReverseProxy.Tests/Service/SessionAffinity/CustomHeaderSessionAffinityProviderTests.cs
+++ b/test/ReverseProxy.Tests/Service/SessionAffinity/CustomHeaderSessionAffinityProviderTests.cs
@@ -13,8 +13,8 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
     public class CustomHeaderSessionAffinityProviderTests
     {
         private const string AffinityHeaderName = "X-MyAffinity";
-        private readonly ClusterConfig.ClusterSessionAffinityOptions _defaultOptions =
-            new ClusterConfig.ClusterSessionAffinityOptions(true, "Cookie", "Return503", new Dictionary<string, string> { { "CustomHeaderName", AffinityHeaderName } });
+        private readonly ClusterSessionAffinityOptions _defaultOptions =
+            new ClusterSessionAffinityOptions(true, "Cookie", "Return503", new Dictionary<string, string> { { "CustomHeaderName", AffinityHeaderName } });
         private readonly IReadOnlyList<DestinationInfo> _destinations = new[] { new DestinationInfo("dest-A"), new DestinationInfo("dest-B"), new DestinationInfo("dest-C") };
 
         [Fact]
@@ -53,7 +53,7 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
         [MemberData(nameof(FindAffinitizedDestination_CustomHeaderNameIsNotSpecified_Cases))]
         public void FindAffinitizedDestination_CustomHeaderNameIsNotSpecified_UseDefaultName(Dictionary<string, string> settings)
         {
-            var options = new ClusterConfig.ClusterSessionAffinityOptions(true, "CustomHeader", "Return503", settings);
+            var options = new ClusterSessionAffinityOptions(true, "CustomHeader", "Return503", settings);
             var provider = new CustomHeaderSessionAffinityProvider(AffinityTestHelper.GetDataProtector().Object, AffinityTestHelper.GetLogger<CustomHeaderSessionAffinityProvider>().Object);
             var context = new DefaultHttpContext();
             var affinitizedDestination = _destinations[1];


### PR DESCRIPTION
- Use a cached Task to represent true and false
- Remove nested classes around session affinity
- Use nameof for SessionAffinityConstants
- Updated calling code and tests

PS: this PR is mostly cosmetic but the nested classes have been bugging me for a long time. There's more but I was looking at the session affinity logic.