### PR TITLE
ITimer abstracts out a real Timer

### DIFF
--- a/src/ReverseProxy/Service/Management/EntityActionScheduler.cs
+++ b/src/ReverseProxy/Service/Management/EntityActionScheduler.cs
@@ -69,7 +69,7 @@ namespace Microsoft.ReverseProxy.Service.Management
         {
             if (_entries.TryGetValue(entity, out var entry))
             {
-                entry.ChangePeriod((long)newPeriod.TotalMilliseconds);
+                entry.ChangePeriod((long)newPeriod.TotalMilliseconds, Volatile.Read(ref _isStarted) == 1);
             }
         }
 
@@ -119,12 +119,15 @@ namespace Microsoft.ReverseProxy.Service.Management
 
             public long Period => _period;
 
-            public Timer Timer { get; }
+            public ITimer Timer { get; }
 
-            public void ChangePeriod(long newPeriod)
+            public void ChangePeriod(long newPeriod, bool resetTimer)
             {
                 Interlocked.Exchange(ref _period, newPeriod);
-                SetTimer();
+                if (resetTimer)
+                {
+                    SetTimer();
+                }
             }
 
             public void SetTimer()

--- a/src/ReverseProxy/Utilities/ITimer.cs
+++ b/src/ReverseProxy/Utilities/ITimer.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.ReverseProxy.Utilities
+{
+    internal interface ITimer : IDisposable
+    {
+        void Change(long dueTime, long period);
+    }
+}

--- a/src/ReverseProxy/Utilities/ITimerFactory.cs
+++ b/src/ReverseProxy/Utilities/ITimerFactory.cs
@@ -1,13 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Threading;
 
 namespace Microsoft.ReverseProxy.Utilities
 {
     internal interface ITimerFactory
     {
-        Timer CreateTimer(TimerCallback callback, object state, long dueTime, long period);
+        ITimer CreateTimer(TimerCallback callback, object state, long dueTime, long period);
     }
 }

--- a/src/ReverseProxy/Utilities/TimerFactory.cs
+++ b/src/ReverseProxy/Utilities/TimerFactory.cs
@@ -8,9 +8,9 @@ namespace Microsoft.ReverseProxy.Utilities
 {
     internal class TimerFactory : ITimerFactory
     {
-        public Timer CreateTimer(TimerCallback callback, object state, long dueTime, long period)
+        public ITimer CreateTimer(TimerCallback callback, object state, long dueTime, long period)
         {
-            return new Timer(callback, state, dueTime, period);
+            return new TimerWrapper(callback, state, dueTime, period);
         }
     }
 }

--- a/src/ReverseProxy/Utilities/TimerWrapper.cs
+++ b/src/ReverseProxy/Utilities/TimerWrapper.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading;
+
+namespace Microsoft.ReverseProxy.Utilities
+{
+    internal class TimerWrapper : ITimer
+    {
+        private readonly Timer _realTimer;
+
+        public TimerWrapper(TimerCallback callback, object state, long dueTime, long period)
+        {
+            _realTimer = new Timer(callback, state, dueTime, period);
+        }
+
+        public void Change(long dueTime, long period)
+        {
+            _realTimer.Change(dueTime, period);
+        }
+
+        public void Dispose()
+        {
+            _realTimer.Dispose();
+        }
+    }
+}

--- a/test/ReverseProxy.Tests/Service/Management/EntityActionSchedulerTests.cs
+++ b/test/ReverseProxy.Tests/Service/Management/EntityActionSchedulerTests.cs
@@ -12,109 +12,121 @@ namespace Microsoft.ReverseProxy.Service.Management
     // It uses a real TimerFactory to verify scheduling work E2E.
     public class EntityActionSchedulerTests
     {
+        private const long Period0 = 20000;
+        private const long Period1 = 10000;
+
         [Fact]
         public void Schedule_AutoStartEnabledRunOnceDisabled_StartsAutomaticallyAndRunsIndefinitely()
         {
-            var invoked = new AutoResetEvent(false);
             var entity0 = new Entity { Id = "entity0" };
-            var period0 = TimeSpan.FromMilliseconds(1100);
             var entity1 = new Entity { Id = "entity1" };
-            var period1 = TimeSpan.FromMilliseconds(900);
-            var timeout = TimeSpan.FromSeconds(2);
+            var timerFactory = new TestTimerFactory();
             Entity lastInvokedEntity = null;
             using var scheduler = new EntityActionScheduler<Entity>(e =>
             {
                 lastInvokedEntity = e;
-                invoked.Set();
                 return Task.CompletedTask;
-            }, autoStart: true, runOnce: false, new TimerFactory());
+            }, autoStart: true, runOnce: false, timerFactory);
 
-            scheduler.ScheduleEntity(entity0, period0);
-            scheduler.ScheduleEntity(entity1, period1);
-
-            VerifyEntities(scheduler, entity0, entity1);
-
-            Assert.True(invoked.WaitOne(timeout));
-            Assert.Same(entity1, lastInvokedEntity);
-
-            Assert.True(invoked.WaitOne(timeout));
-            Assert.Same(entity0, lastInvokedEntity);
-
-            Assert.True(invoked.WaitOne(timeout));
-            Assert.Same(entity1, lastInvokedEntity);
-
-            Assert.True(invoked.WaitOne(timeout));
-            Assert.Same(entity0, lastInvokedEntity);
+            scheduler.ScheduleEntity(entity0, TimeSpan.FromMilliseconds(20000));
+            scheduler.ScheduleEntity(entity1, TimeSpan.FromMilliseconds(10000));
 
             VerifyEntities(scheduler, entity0, entity1);
+            Assert.Equal(2, timerFactory.Count);
+            timerFactory.VerifyTimer(0, Period0);
+            timerFactory.VerifyTimer(1, Period1);
+
+            timerFactory.FireTimer(1);
+            Assert.Same(entity1, lastInvokedEntity);
+
+            timerFactory.FireTimer(0);
+            Assert.Same(entity0, lastInvokedEntity);
+
+            timerFactory.FireTimer(1);
+            Assert.Same(entity1, lastInvokedEntity);
+
+            timerFactory.FireTimer(0);
+            Assert.Same(entity0, lastInvokedEntity);
+
+            VerifyEntities(scheduler, entity0, entity1);
+            Assert.Equal(2, timerFactory.Count);
+            timerFactory.VerifyTimer(0, Period0);
+            timerFactory.VerifyTimer(1, Period1);
         }
 
         [Fact]
         public void Schedule_AutoStartDisabledRunOnceEnabled_StartsManuallyAndRunsEachRegistrationOnlyOnce()
         {
-            var invoked = new AutoResetEvent(false);
             var entity0 = new Entity { Id = "entity0" };
-            var period0 = TimeSpan.FromMilliseconds(1100);
             var entity1 = new Entity { Id = "entity1" };
-            var period1 = TimeSpan.FromMilliseconds(700);
-            var timeout = TimeSpan.FromSeconds(2);
             Entity lastInvokedEntity = null;
+            var timerFactory = new TestTimerFactory();
             using var scheduler = new EntityActionScheduler<Entity>(e =>
             {
                 lastInvokedEntity = e;
-                invoked.Set();
                 return Task.CompletedTask;
-            }, autoStart: false, runOnce: true, new TimerFactory());
+            }, autoStart: false, runOnce: true, timerFactory);
 
-            scheduler.ScheduleEntity(entity0, period0);
-            scheduler.ScheduleEntity(entity1, period1);
-
-            Assert.False(invoked.WaitOne(timeout));
+            scheduler.ScheduleEntity(entity0, TimeSpan.FromMilliseconds(Period0));
+            scheduler.ScheduleEntity(entity1, TimeSpan.FromMilliseconds(Period1));
+            Assert.Equal(2, timerFactory.Count);
+            timerFactory.VerifyTimer(0, Timeout.Infinite);
+            timerFactory.VerifyTimer(1, Timeout.Infinite);
 
             scheduler.Start();
 
             VerifyEntities(scheduler, entity0, entity1);
+            Assert.Equal(2, timerFactory.Count);
+            timerFactory.VerifyTimer(0, Period0);
+            timerFactory.VerifyTimer(1, Period1);
 
-            Assert.True(invoked.WaitOne(timeout));
+            timerFactory.FireTimer(1);
+            
             Assert.Same(entity1, lastInvokedEntity);
 
             VerifyEntities(scheduler, entity0);
 
-            Assert.True(invoked.WaitOne(timeout));
+            timerFactory.FireTimer(0);
+
             Assert.Same(entity0, lastInvokedEntity);
 
             Assert.False(scheduler.IsScheduled(entity0));
             Assert.False(scheduler.IsScheduled(entity1));
+            timerFactory.AssertTimerDisposed(0);
+            timerFactory.AssertTimerDisposed(1);
         }
 
         [Fact]
         public void Unschedule_EntityUnscheduledBeforeFirstCall_CallbackNotInvoked()
         {
-            var invoked = new AutoResetEvent(false);
             var entity0 = new Entity { Id = "entity0" };
-            var period0 = TimeSpan.FromMilliseconds(1100);
             var entity1 = new Entity { Id = "entity1" };
-            var period1 = TimeSpan.FromMilliseconds(700);
-            var timeout = TimeSpan.FromSeconds(2);
             Entity lastInvokedEntity = null;
+            var timerFactory = new TestTimerFactory();
             using var scheduler = new EntityActionScheduler<Entity>(e =>
             {
                 lastInvokedEntity = e;
-                invoked.Set();
                 return Task.CompletedTask;
-            }, autoStart: false, runOnce: false, new TimerFactory());
+            }, autoStart: false, runOnce: false, timerFactory);
 
-            scheduler.ScheduleEntity(entity0, period0);
-            scheduler.ScheduleEntity(entity1, period1);
+            scheduler.ScheduleEntity(entity0, TimeSpan.FromMilliseconds(Period0));
+            scheduler.ScheduleEntity(entity1, TimeSpan.FromMilliseconds(Period1));
 
             VerifyEntities(scheduler, entity0, entity1);
+            Assert.Equal(2, timerFactory.Count);
+            timerFactory.VerifyTimer(0, Timeout.Infinite);
+            timerFactory.VerifyTimer(1, Timeout.Infinite);
 
             scheduler.UnscheduleEntity(entity1);
             VerifyEntities(scheduler, entity0);
+            timerFactory.AssertTimerDisposed(1);
 
             scheduler.Start();
 
-            Assert.True(invoked.WaitOne(timeout));
+            timerFactory.VerifyTimer(0, Period0);
+
+            timerFactory.FireTimer(0);
+
             Assert.Same(entity0, lastInvokedEntity);
 
             VerifyEntities(scheduler, entity0);
@@ -123,163 +135,89 @@ namespace Microsoft.ReverseProxy.Service.Management
         [Fact]
         public void Unschedule_EntityUnscheduledAfterFirstCall_CallbackInvokedOnlyOnce()
         {
-            var invoked = new AutoResetEvent(false);
             var entity0 = new Entity { Id = "entity0" };
-            var period0 = TimeSpan.FromMilliseconds(1100);
             var entity1 = new Entity { Id = "entity1" };
-            var period1 = TimeSpan.FromMilliseconds(700);
-            var timeout = TimeSpan.FromSeconds(2);
             Entity lastInvokedEntity = null;
+            var timerFactory = new TestTimerFactory();
             using var scheduler = new EntityActionScheduler<Entity>(e =>
             {
                 lastInvokedEntity = e;
-                invoked.Set();
                 return Task.CompletedTask;
-            }, autoStart: true, runOnce: false, new TimerFactory());
+            }, autoStart: true, runOnce: false, timerFactory);
 
-            scheduler.ScheduleEntity(entity0, period0);
-            scheduler.ScheduleEntity(entity1, period1);
+            scheduler.ScheduleEntity(entity0, TimeSpan.FromMilliseconds(Period0));
+            scheduler.ScheduleEntity(entity1, TimeSpan.FromMilliseconds(Period1));
 
             VerifyEntities(scheduler, entity0, entity1);
 
-            Assert.True(invoked.WaitOne(timeout));
+            timerFactory.FireTimer(1);
+
             Assert.Same(entity1, lastInvokedEntity);
 
-            Assert.True(invoked.WaitOne(timeout));
+            timerFactory.FireTimer(0);
+
             Assert.Same(entity0, lastInvokedEntity);
 
             scheduler.UnscheduleEntity(entity1);
             VerifyEntities(scheduler, entity0);
+            timerFactory.AssertTimerDisposed(1);
 
-            Assert.True(invoked.WaitOne(timeout));
+            timerFactory.FireTimer(0);
+
             Assert.Same(entity0, lastInvokedEntity);
 
             VerifyEntities(scheduler, entity0);
         }
 
         [Fact]
-        public void ChangePeriod_PeriodDecreasedTimerNotStarted_PeriodChangedBeforeFirstCall()
+        public void ChangePeriod_PeriodChangedTimerNotStarted_PeriodChangedBeforeFirstCall()
         {
-            var invoked = new AutoResetEvent(false);
             var entity = new Entity { Id = "entity0" };
-            var period = TimeSpan.FromMilliseconds(1000);
-            var timeout = TimeSpan.FromSeconds(2);
-            var clock = new UptimeClock();
             Entity lastInvokedEntity = null;
+            var timerFactory = new TestTimerFactory();
             using var scheduler = new EntityActionScheduler<Entity>(e =>
             {
                 lastInvokedEntity = e;
-                invoked.Set();
                 return Task.CompletedTask;
-            }, autoStart: false, runOnce: false, new TimerFactory());
+            }, autoStart: false, runOnce: false, timerFactory);
 
-            scheduler.ScheduleEntity(entity, period);
+            scheduler.ScheduleEntity(entity, TimeSpan.FromMilliseconds(Period0));
+            timerFactory.VerifyTimer(0, Timeout.Infinite);
 
-            var newPeriod = TimeSpan.FromMilliseconds(500);
+            var newPeriod = TimeSpan.FromMilliseconds(Period1);
             scheduler.ChangePeriod(entity, newPeriod);
+            timerFactory.VerifyTimer(0, Timeout.Infinite);
 
             scheduler.Start();
 
-            var before = clock.TickCount;
-            Assert.True(invoked.WaitOne(timeout));
+            timerFactory.VerifyTimer(0, Period1);
 
-            var elapsed = TimeSpan.FromMilliseconds(clock.TickCount - before);
-            Assert.True(elapsed >= newPeriod && elapsed < period);
+            timerFactory.FireTimer(0);
+
             Assert.Same(entity, lastInvokedEntity);
         }
 
         [Fact]
-        public void ChangePeriod_PeriodIncreasedTimerNotStarted_PeriodChangedBeforeFirstCall()
+        public void ChangePeriod_TimerStartedPeriodChangedAfterFirstCall_PeriodChangedBeforeNextCall()
         {
-            var invoked = new AutoResetEvent(false);
             var entity = new Entity { Id = "entity0" };
-            var period = TimeSpan.FromMilliseconds(250);
-            var timeout = TimeSpan.FromSeconds(2);
-            var clock = new UptimeClock();
             Entity lastInvokedEntity = null;
+            var timerFactory = new TestTimerFactory();
             using var scheduler = new EntityActionScheduler<Entity>(e =>
             {
                 lastInvokedEntity = e;
-                invoked.Set();
                 return Task.CompletedTask;
-            }, autoStart: false, runOnce: false, new TimerFactory());
+            }, autoStart: true, runOnce: false, timerFactory);
 
-            scheduler.ScheduleEntity(entity, period);
+            scheduler.ScheduleEntity(entity, TimeSpan.FromMilliseconds(Period0));
+            timerFactory.VerifyTimer(0, Period0);
 
-            var newPeriod = TimeSpan.FromMilliseconds(500);
+            timerFactory.FireTimer(0);
+
+            var newPeriod = TimeSpan.FromMilliseconds(Period1);
             scheduler.ChangePeriod(entity, newPeriod);
 
-            scheduler.Start();
-
-            var before = clock.TickCount;
-            Assert.True(invoked.WaitOne(timeout));
-
-            var elapsed = TimeSpan.FromMilliseconds(clock.TickCount - before);
-            Assert.True(elapsed >= newPeriod);
-            Assert.Same(entity, lastInvokedEntity);
-        }
-
-        [Fact(Skip = "https://github.com/microsoft/reverse-proxy/issues/508")]
-        public void ChangePeriod_TimerStartedPeriodDecreasedAfterFirstCall_PeriodChangedBeforeNextCall()
-        {
-            var invoked = new AutoResetEvent(false);
-            var entity = new Entity { Id = "entity0" };
-            var period = TimeSpan.FromMilliseconds(1000);
-            var timeout = TimeSpan.FromSeconds(2);
-            var clock = new UptimeClock();
-            Entity lastInvokedEntity = null;
-            using var scheduler = new EntityActionScheduler<Entity>(e =>
-            {
-                lastInvokedEntity = e;
-                invoked.Set();
-                return Task.CompletedTask;
-            }, autoStart: true, runOnce: false, new TimerFactory());
-
-            scheduler.ScheduleEntity(entity, period);
-
-            Assert.True(invoked.WaitOne(timeout));
-            lastInvokedEntity = null;
-
-            var newPeriod = TimeSpan.FromMilliseconds(500);
-            scheduler.ChangePeriod(entity, newPeriod);
-
-            var before = clock.TickCount;
-            Assert.True(invoked.WaitOne(timeout));
-
-            var elapsed = TimeSpan.FromMilliseconds(clock.TickCount - before);
-            Assert.True(elapsed >= newPeriod && elapsed < period);
-            Assert.Same(entity, lastInvokedEntity);
-        }
-
-        [Fact]
-        public void ChangePeriod_TimerStartedPeriodIncreasedAfterFirstCall_PeriodChangedBeforeNextCall()
-        {
-            var invoked = new AutoResetEvent(false);
-            var entity = new Entity { Id = "entity0" };
-            var period = TimeSpan.FromMilliseconds(250);
-            var timeout = TimeSpan.FromSeconds(2);
-            var clock = new UptimeClock();
-            Entity lastInvokedEntity = null;
-            using var scheduler = new EntityActionScheduler<Entity>(e =>
-            {
-                lastInvokedEntity = e;
-                invoked.Set();
-                return Task.CompletedTask;
-            }, autoStart: true, runOnce: false, new TimerFactory());
-
-            scheduler.ScheduleEntity(entity, period);
-
-            Assert.True(invoked.WaitOne(timeout));
-            lastInvokedEntity = null;
-
-            var newPeriod = TimeSpan.FromMilliseconds(500);
-            scheduler.ChangePeriod(entity, newPeriod);
-
-            var before = clock.TickCount;
-            Assert.True(invoked.WaitOne(timeout));
-
-            var elapsed = TimeSpan.FromMilliseconds(clock.TickCount - before);
-            Assert.True(elapsed >= newPeriod);
+            timerFactory.VerifyTimer(0, Period1);
             Assert.Same(entity, lastInvokedEntity);
         }
 


### PR DESCRIPTION
This PR adds `ITimer` abstraction and makes all timer-dependent tests use it to improve their stability and performance.

Fixes #508