### PR TITLE
Performing HttpClient vs HttpMessageInvoker check in HttpProxy

### DIFF
--- a/src/ReverseProxy/Service/Proxy/HttpProxy.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpProxy.cs
@@ -95,13 +95,14 @@ namespace Microsoft.ReverseProxy.Service.Proxy
         {
             _ = context ?? throw new ArgumentNullException(nameof(context));
             _ = destinationPrefix ?? throw new ArgumentNullException(nameof(destinationPrefix));
+            _ = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             _ = proxyOptions ?? throw new ArgumentNullException(nameof(proxyOptions));
 
             // HttpClient overload for SendAsync changes response behavior to fully buffered which impacts performance
             // See discussion in https://github.com/microsoft/reverse-proxy/issues/458
-            if (httpClient is HttpClient || httpClient == null)
+            if (httpClient is HttpClient)
             {
-                throw new ArgumentNullException(nameof(httpClient));
+                throw new InvalidOperationException($"{nameof(httpClient)} should be of type HttpMessageInvoker, not HttpClient");
             }
 
             ProxyTelemetry.Log.ProxyStart(destinationPrefix);

--- a/src/ReverseProxy/Service/Proxy/HttpProxy.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpProxy.cs
@@ -102,7 +102,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy
             // See discussion in https://github.com/microsoft/reverse-proxy/issues/458
             if (httpClient is HttpClient)
             {
-                throw new ArgumentException($"{nameof(httpClient)} should be of type HttpMessageInvoker, not HttpClient");
+                throw new ArgumentException($"The http client must be of type HttpMessageInvoker, not HttpClient", nameof(httpClient));
             }
 
             ProxyTelemetry.Log.ProxyStart(destinationPrefix);

--- a/src/ReverseProxy/Service/Proxy/HttpProxy.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpProxy.cs
@@ -102,7 +102,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy
             // See discussion in https://github.com/microsoft/reverse-proxy/issues/458
             if (httpClient is HttpClient)
             {
-                throw new InvalidOperationException($"{nameof(httpClient)} should be of type HttpMessageInvoker, not HttpClient");
+                throw new ArgumentException($"{nameof(httpClient)} should be of type HttpMessageInvoker, not HttpClient");
             }
 
             ProxyTelemetry.Log.ProxyStart(destinationPrefix);

--- a/src/ReverseProxy/Service/Proxy/HttpProxy.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpProxy.cs
@@ -97,6 +97,8 @@ namespace Microsoft.ReverseProxy.Service.Proxy
             _ = destinationPrefix ?? throw new ArgumentNullException(nameof(destinationPrefix));
             _ = proxyOptions ?? throw new ArgumentNullException(nameof(proxyOptions));
 
+            // HttpClient overload for SendAsync changes response behavior to fully buffered which impacts performance
+            // See discussion in https://github.com/microsoft/reverse-proxy/issues/458
             if (httpClient is HttpClient || httpClient == null)
             {
                 throw new ArgumentNullException(nameof(httpClient));

--- a/src/ReverseProxy/Service/Proxy/HttpProxy.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpProxy.cs
@@ -95,8 +95,12 @@ namespace Microsoft.ReverseProxy.Service.Proxy
         {
             _ = context ?? throw new ArgumentNullException(nameof(context));
             _ = destinationPrefix ?? throw new ArgumentNullException(nameof(destinationPrefix));
-            _ = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             _ = proxyOptions ?? throw new ArgumentNullException(nameof(proxyOptions));
+
+            if (httpClient is HttpClient || httpClient == null)
+            {
+                throw new ArgumentNullException(nameof(httpClient));
+            }
 
             ProxyTelemetry.Log.ProxyStart(destinationPrefix);
             try

--- a/test/ReverseProxy.Tests/Service/Proxy/HttpProxyTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/HttpProxyTests.cs
@@ -1551,6 +1551,19 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
             events.AssertContainProxyStages(upgrade: true);
         }
 
+        [Fact]
+        public async Task ProxyAsync_WithHttpClient_Fails()
+        {
+            var httpClient = new HttpClient();
+            var httpContext = new DefaultHttpContext();
+            var destinationPrefix = "";
+            var requestProxyOptions = new RequestProxyOptions();
+            var proxy = CreateProxy();
+
+            await Assert.ThrowsAsync<ArgumentException>(() => proxy.ProxyAsync(httpContext,
+                destinationPrefix, httpClient, requestProxyOptions));
+        }
+
         private static void AssertProxyStartStop(List<EventWrittenEventArgs> events, string destinationPrefix, int statusCode)
         {
             AssertProxyStartFailedStop(events, destinationPrefix, statusCode, error: null);


### PR DESCRIPTION
As discussed in issue 458, the HttpClient SendAsync overload changes the response buffering behavior which results in a performance impact. This change performs a downcast check on the httpClient parameter and hard fails if it is of type HttpClient. 

Fixes #458 