### PR TITLE
Merge RequestOptions types

### DIFF
--- a/samples/ReverseProxy.Direct.Sample/Startup.cs
+++ b/samples/ReverseProxy.Direct.Sample/Startup.cs
@@ -40,10 +40,9 @@ namespace Microsoft.ReverseProxy.Sample
                 AutomaticDecompression = DecompressionMethods.None,
                 UseCookies = false
             });
-            var proxyOptions = new RequestProxyOptions()
-            {
+            var proxyOptions = new RequestProxyOptions(
                 // Copy all request headers except Host
-                Transforms = new Transforms(
+                new Transforms(
                     copyRequestHeaders: true,
                     requestTransforms: Array.Empty<RequestParametersTransform>(),
                     requestHeaderTransforms: new Dictionary<string, RequestHeaderTransform>()
@@ -52,8 +51,7 @@ namespace Microsoft.ReverseProxy.Sample
                     },
                     responseHeaderTransforms: new Dictionary<string, ResponseHeaderTransform>(),
                     responseTrailerTransforms: new Dictionary<string, ResponseHeaderTransform>()),
-                RequestOptions = new ClusterProxyHttpRequestOptions(timeout: TimeSpan.FromSeconds(100), null),
-            };
+                new ClusterProxyHttpRequestOptions(TimeSpan.FromSeconds(100), null));
 
             app.UseRouting();
             app.UseAuthorization();

--- a/samples/ReverseProxy.Direct.Sample/Startup.cs
+++ b/samples/ReverseProxy.Direct.Sample/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.ReverseProxy.Service.Proxy;
 using Microsoft.ReverseProxy.Service.RuntimeModel.Transforms;
 using Microsoft.Net.Http.Headers;
 using System.Collections.Generic;
+using Microsoft.ReverseProxy.RuntimeModel;
 
 namespace Microsoft.ReverseProxy.Sample
 {
@@ -41,7 +42,6 @@ namespace Microsoft.ReverseProxy.Sample
             });
             var proxyOptions = new RequestProxyOptions()
             {
-                RequestTimeout = TimeSpan.FromSeconds(100),
                 // Copy all request headers except Host
                 Transforms = new Transforms(
                     copyRequestHeaders: true,
@@ -51,7 +51,8 @@ namespace Microsoft.ReverseProxy.Sample
                         { HeaderNames.Host, new RequestHeaderValueTransform(string.Empty, append: false) }
                     },
                     responseHeaderTransforms: new Dictionary<string, ResponseHeaderTransform>(),
-                    responseTrailerTransforms: new Dictionary<string, ResponseHeaderTransform>())
+                    responseTrailerTransforms: new Dictionary<string, ResponseHeaderTransform>()),
+                RequestOptions = new ClusterProxyHttpRequestOptions(timeout: TimeSpan.FromSeconds(100), null),
             };
 
             app.UseRouting();

--- a/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/ProxyHttpRequestOptions.cs
+++ b/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/ProxyHttpRequestOptions.cs
@@ -9,22 +9,20 @@ namespace Microsoft.ReverseProxy.Abstractions
     public sealed class ProxyHttpRequestOptions
     {
         /// <summary>
-        /// Timeout for the outgoing request.
-        /// Default is 100 seconds.
+        /// The time allowed to send the request and receive the response headers. This may include
+        /// the time needed to send the request body.
         /// </summary>
-        public TimeSpan? RequestTimeout { get; set; }
+        public TimeSpan? Timeout { get; set; }
 
         /// <summary>
-        /// HTTP version for the outgoing request.
-        /// Default is HTTP/2.
+        /// Preferred version of the outgoing request.
         /// </summary>
         public Version Version { get; set; }
 
 #if NET
         /// <summary>
-        /// Version policy for the outgoing request.
-        /// Defines whether to upgrade or downgrade HTTP version if possible.
-        /// Default is <c>RequestVersionOrLower</c>.
+        /// The policy applied to version selection, e.g. whether to prefer downgrades, upgrades or
+        /// request an exact version.
         /// </summary>
         public HttpVersionPolicy? VersionPolicy { get; set; }
 #endif
@@ -33,7 +31,7 @@ namespace Microsoft.ReverseProxy.Abstractions
         {
             return new ProxyHttpRequestOptions
             {
-                RequestTimeout = RequestTimeout,
+                Timeout = Timeout,
                 Version = Version,
 #if NET
                 VersionPolicy = VersionPolicy,
@@ -53,7 +51,7 @@ namespace Microsoft.ReverseProxy.Abstractions
                 return false;
             }
 
-            return options1.RequestTimeout == options2.RequestTimeout
+            return options1.Timeout == options2.Timeout
                    && options1.Version == options2.Version
 #if NET
                    && options1.VersionPolicy == options2.VersionPolicy

--- a/src/ReverseProxy/Configuration/ConfigurationConfigProvider.cs
+++ b/src/ReverseProxy/Configuration/ConfigurationConfigProvider.cs
@@ -394,7 +394,7 @@ namespace Microsoft.ReverseProxy.Configuration
 
             return new ProxyHttpRequestOptions
             {
-                RequestTimeout = section.ReadTimeSpan(nameof(ProxyHttpRequestOptions.RequestTimeout)),
+                Timeout = section.ReadTimeSpan(nameof(ProxyHttpRequestOptions.Timeout)),
                 Version = section.ReadVersion(nameof(ProxyHttpRequestOptions.Version)),
 #if NET
                 VersionPolicy = section.ReadEnum<HttpVersionPolicy>(nameof(ProxyHttpRequestOptions.VersionPolicy)),

--- a/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
+++ b/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
@@ -71,11 +71,7 @@ namespace Microsoft.ReverseProxy.Middleware
             }
 
             // TODO: Make this configurable on a route rather than create it per request?
-            var proxyOptions = new RequestProxyOptions()
-            {
-                Transforms = routeConfig.Transforms,
-                RequestOptions = reverseProxyFeature.ClusterConfig.HttpRequestOptions
-            };
+            var proxyOptions = new RequestProxyOptions(routeConfig.Transforms, reverseProxyFeature.ClusterConfig.HttpRequestOptions);
 
             try
             {

--- a/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
+++ b/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
@@ -74,23 +74,8 @@ namespace Microsoft.ReverseProxy.Middleware
             var proxyOptions = new RequestProxyOptions()
             {
                 Transforms = routeConfig.Transforms,
+                RequestOptions = reverseProxyFeature.ClusterConfig.HttpRequestOptions
             };
-
-            var requestOptions = reverseProxyFeature.ClusterConfig.HttpRequestOptions;
-            if (requestOptions.RequestTimeout.HasValue)
-            {
-                proxyOptions.RequestTimeout = requestOptions.RequestTimeout.Value;
-            }
-            if (requestOptions.Version != null)
-            {
-                proxyOptions.Version = requestOptions.Version;
-            }
-#if NET
-            if (requestOptions.VersionPolicy.HasValue)
-            {
-                proxyOptions.VersionPolicy = requestOptions.VersionPolicy.Value;
-            }
-#endif
 
             try
             {

--- a/src/ReverseProxy/Service/HealthChecks/DefaultProbingRequestFactory.cs
+++ b/src/ReverseProxy/Service/HealthChecks/DefaultProbingRequestFactory.cs
@@ -18,9 +18,9 @@ namespace Microsoft.ReverseProxy.Service.HealthChecks
             var probeUri = UriHelper.BuildAbsolute(destinationScheme, destinationHost, destinationPathBase, probePath, default);
             return new HttpRequestMessage(HttpMethod.Get, probeUri)
             {
-                Version = clusterConfig.HttpRequestOptions.Version ?? HttpVersion.Version20,
+                Version = clusterConfig.HttpRequestOptions.Version,
 #if NET
-                VersionPolicy = clusterConfig.HttpRequestOptions.VersionPolicy ?? HttpVersionPolicy.RequestVersionOrLower
+                VersionPolicy = clusterConfig.HttpRequestOptions.VersionPolicy
 #endif
             };
         }

--- a/src/ReverseProxy/Service/HealthChecks/DefaultProbingRequestFactory.cs
+++ b/src/ReverseProxy/Service/HealthChecks/DefaultProbingRequestFactory.cs
@@ -18,9 +18,9 @@ namespace Microsoft.ReverseProxy.Service.HealthChecks
             var probeUri = UriHelper.BuildAbsolute(destinationScheme, destinationHost, destinationPathBase, probePath, default);
             return new HttpRequestMessage(HttpMethod.Get, probeUri)
             {
-                Version = clusterConfig.HttpRequestOptions.Version,
+                Version = clusterConfig.HttpRequestOptions.Version ?? HttpVersion.Version20,
 #if NET
-                VersionPolicy = clusterConfig.HttpRequestOptions.VersionPolicy
+                VersionPolicy = clusterConfig.HttpRequestOptions.VersionPolicy ?? HttpVersionPolicy.RequestVersionOrLower
 #endif
             };
         }

--- a/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
@@ -314,7 +314,7 @@ namespace Microsoft.ReverseProxy.Service.Management
                                 httpClient,
                                 newClusterHttpClientOptions,
                                 new ClusterProxyHttpRequestOptions(
-                                    requestTimeout: newCluster.HttpRequest?.RequestTimeout,
+                                    timeout: newCluster.HttpRequest?.Timeout,
                                     version: newCluster.HttpRequest?.Version
 #if NET
                                     , versionPolicy: newCluster.HttpRequest?.VersionPolicy

--- a/src/ReverseProxy/Service/Proxy/HttpProxy.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpProxy.cs
@@ -102,7 +102,6 @@ namespace Microsoft.ReverseProxy.Service.Proxy
             _ = context ?? throw new ArgumentNullException(nameof(context));
             _ = destinationPrefix ?? throw new ArgumentNullException(nameof(destinationPrefix));
             _ = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
-            _ = proxyOptions ?? throw new ArgumentNullException(nameof(proxyOptions));
 
             // HttpClient overload for SendAsync changes response behavior to fully buffered which impacts performance
             // See discussion in https://github.com/microsoft/reverse-proxy/issues/458

--- a/src/ReverseProxy/Service/Proxy/HttpProxy.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpProxy.cs
@@ -134,7 +134,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy
                 // :: Step 4: Send the outgoing request using HttpClient
                 HttpResponseMessage destinationResponse;
                 var requestTimeoutSource = CancellationTokenSource.CreateLinkedTokenSource(requestAborted);
-                requestTimeoutSource.CancelAfter(proxyOptions.RequestTimeout);
+                requestTimeoutSource.CancelAfter(proxyOptions.RequestOptions.Timeout);
                 var requestTimeoutToken = requestTimeoutSource.Token;
                 try
                 {
@@ -266,9 +266,9 @@ namespace Microsoft.ReverseProxy.Service.Proxy
             // based on VersionPolicy (for .NET 5 and higher). For example, downgrading to HTTP/1.1 if it cannot establish HTTP/2 with the target.
             // This is done without extra round-trips thanks to ALPN. We can detect a downgrade after calling HttpClient.SendAsync
             // (see Step 3 below). TBD how this will change when HTTP/3 is supported.
-            var httpVersion = isUpgradeRequest ? ProtocolHelper.Http11Version : proxyOptions.Version;
+            var httpVersion = isUpgradeRequest ? ProtocolHelper.Http11Version : proxyOptions.RequestOptions.Version;
 #if NET
-            var httpVersionPolicy = isUpgradeRequest ? HttpVersionPolicy.RequestVersionOrLower : proxyOptions.VersionPolicy;
+            var httpVersionPolicy = isUpgradeRequest ? HttpVersionPolicy.RequestVersionOrLower : proxyOptions.RequestOptions.VersionPolicy;
 #endif
 
             // TODO Perf: We could probably avoid splitting this and just append the final path and query

--- a/src/ReverseProxy/Service/Proxy/RequestProxyOptions.cs
+++ b/src/ReverseProxy/Service/Proxy/RequestProxyOptions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using Microsoft.ReverseProxy.RuntimeModel;
 using Microsoft.ReverseProxy.Service.RuntimeModel.Transforms;
 
 namespace Microsoft.ReverseProxy.Service.Proxy
@@ -19,24 +20,9 @@ namespace Microsoft.ReverseProxy.Service.Proxy
         public Transforms Transforms { get; set; } = Transforms.Empty;
 
         /// <summary>
-        /// The time allowed to send the request and receive the response headers. This may include
-        /// the time needed to send the request body. The default is 100 seconds.
+        /// Outgoing HTTP request options.
         /// </summary>
-        public TimeSpan RequestTimeout { get; set; } = TimeSpan.FromSeconds(100);
-
-        /// <summary>
-        /// Preferred version of the outgoing request.
-        /// The default is HTTP/2.0.
-        /// </summary>
-        public Version Version { get; set; } = HttpVersion.Version20;
-
-#if NET
-        /// <summary>
-        /// The policy applied to version selection, e.g. whether to prefer downgrades, upgrades or request an exact version.
-        /// The default is `RequestVersionOrLower`.
-        /// </summary>
-        public HttpVersionPolicy VersionPolicy { get; set; } = HttpVersionPolicy.RequestVersionOrLower;
-#endif
+        public ClusterProxyHttpRequestOptions RequestOptions { get; set; }
     }
 }
 

--- a/src/ReverseProxy/Service/Proxy/RequestProxyOptions.cs
+++ b/src/ReverseProxy/Service/Proxy/RequestProxyOptions.cs
@@ -12,17 +12,34 @@ namespace Microsoft.ReverseProxy.Service.Proxy
     /// <summary>
     /// Options for <see cref="IHttpProxy.ProxyAsync"/>
     /// </summary>
-    public class RequestProxyOptions
+    public readonly struct RequestProxyOptions
     {
+        public RequestProxyOptions(Transforms transforms, ClusterProxyHttpRequestOptions requestOptions = default)
+        {
+            _transforms = transforms;
+            RequestOptions = requestOptions;
+        }
+
+#if NET
+        public RequestProxyOptions(TimeSpan? timeout, Version version, HttpVersionPolicy? versionPolicy)
+            : this(null, new ClusterProxyHttpRequestOptions(timeout, version, versionPolicy))
+        { }
+#endif
+
+        public RequestProxyOptions(TimeSpan? timeout, Version version)
+            : this(null, new ClusterProxyHttpRequestOptions(timeout, version))
+        { }
+
+        private readonly Transforms _transforms;
         /// <summary>
         /// Optional transforms for modifying the request and response.
         /// </summary>
-        public Transforms Transforms { get; set; } = Transforms.Empty;
+        public Transforms Transforms => _transforms ?? Transforms.Empty;
 
         /// <summary>
         /// Outgoing HTTP request options.
         /// </summary>
-        public ClusterProxyHttpRequestOptions RequestOptions { get; set; }
+        public ClusterProxyHttpRequestOptions RequestOptions { get; }
     }
 }
 

--- a/src/ReverseProxy/Service/RuntimeModel/ClusterProxyHttpRequestOptions.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/ClusterProxyHttpRequestOptions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using System.Net.Http;
 
 namespace Microsoft.ReverseProxy.RuntimeModel
@@ -11,51 +10,42 @@ namespace Microsoft.ReverseProxy.RuntimeModel
     /// </summary>
     public readonly struct ClusterProxyHttpRequestOptions
     {
-        public static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(100);
-        public static readonly Version DefaultVersion = HttpVersion.Version20;
-#if NET
-        public static readonly HttpVersionPolicy DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
-#endif
-
 #if NET
         public ClusterProxyHttpRequestOptions(TimeSpan? timeout, Version version, HttpVersionPolicy? versionPolicy)
         {
-            _timeout = timeout;
-            _version = version;
-            _versionPolicy = versionPolicy;
+            Timeout = timeout;
+            Version = version;
+            VersionPolicy = versionPolicy;
         }
 #endif
 
         public ClusterProxyHttpRequestOptions(TimeSpan? timeout, Version version)
         {
-            _timeout = timeout;
-            _version = version;
+            Timeout = timeout;
+            Version = version;
 #if NET
-            _versionPolicy = null;
+            VersionPolicy = null;
 #endif
         }
 
-        private readonly TimeSpan? _timeout;
         /// <summary>
         /// The time allowed to send the request and receive the response headers. This may include
         /// the time needed to send the request body. The default is 100 seconds.
         /// </summary>
-        public TimeSpan Timeout => _timeout ?? DefaultTimeout;
+        public TimeSpan? Timeout { get; }
 
-        private readonly Version _version;
         /// <summary>
         /// Preferred version of the outgoing request.
         /// The default is HTTP/2.0.
         /// </summary>
-        public Version Version => _version ?? DefaultVersion;
+        public Version Version { get; }
 
 #if NET
-        private readonly HttpVersionPolicy? _versionPolicy;
         /// <summary>
         /// The policy applied to version selection, e.g. whether to prefer downgrades, upgrades or
         /// request an exact version. The default is `RequestVersionOrLower`.
         /// </summary>
-        public HttpVersionPolicy VersionPolicy => _versionPolicy ?? DefaultVersionPolicy;
+        public HttpVersionPolicy? VersionPolicy { get; }
 #endif
     }
 }

--- a/src/ReverseProxy/Service/RuntimeModel/ClusterProxyHttpRequestOptions.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/ClusterProxyHttpRequestOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Net.Http;
 
 namespace Microsoft.ReverseProxy.RuntimeModel
@@ -10,43 +11,51 @@ namespace Microsoft.ReverseProxy.RuntimeModel
     /// </summary>
     public readonly struct ClusterProxyHttpRequestOptions
     {
+        public static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(100);
+        public static readonly Version DefaultVersion = HttpVersion.Version20;
 #if NET
-        public ClusterProxyHttpRequestOptions(TimeSpan? requestTimeout, Version version, HttpVersionPolicy? versionPolicy)
+        public static readonly HttpVersionPolicy DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
+#endif
+
+#if NET
+        public ClusterProxyHttpRequestOptions(TimeSpan? timeout, Version version, HttpVersionPolicy? versionPolicy)
         {
-            RequestTimeout = requestTimeout;
-            Version = version;
-            VersionPolicy = versionPolicy;
+            _timeout = timeout;
+            _version = version;
+            _versionPolicy = versionPolicy;
         }
 #endif
 
-        public ClusterProxyHttpRequestOptions(TimeSpan? requestTimeout, Version version)
+        public ClusterProxyHttpRequestOptions(TimeSpan? timeout, Version version)
         {
-            RequestTimeout = requestTimeout;
-            Version = version;
+            _timeout = timeout;
+            _version = version;
 #if NET
-            VersionPolicy = null;
+            _versionPolicy = null;
 #endif
         }
 
+        private readonly TimeSpan? _timeout;
         /// <summary>
-        /// Timeout for the outgoing request.
-        /// Default is 100 seconds.
+        /// The time allowed to send the request and receive the response headers. This may include
+        /// the time needed to send the request body. The default is 100 seconds.
         /// </summary>
-        public TimeSpan? RequestTimeout { get; }
+        public TimeSpan Timeout => _timeout ?? DefaultTimeout;
 
+        private readonly Version _version;
         /// <summary>
-        /// HTTP version for the outgoing request.
-        /// Default is HTTP/2.
+        /// Preferred version of the outgoing request.
+        /// The default is HTTP/2.0.
         /// </summary>
-        public Version Version { get; }
+        public Version Version => _version ?? DefaultVersion;
 
 #if NET
+        private readonly HttpVersionPolicy? _versionPolicy;
         /// <summary>
-        /// Version policy for the outgoing request.
-        /// Defines whether to upgrade or downgrade HTTP version if possible.
-        /// Default is <c>RequestVersionOrLower</c>.
+        /// The policy applied to version selection, e.g. whether to prefer downgrades, upgrades or
+        /// request an exact version. The default is `RequestVersionOrLower`.
         /// </summary>
-        public HttpVersionPolicy? VersionPolicy { get; }
+        public HttpVersionPolicy VersionPolicy => _versionPolicy ?? DefaultVersionPolicy;
 #endif
     }
 }

--- a/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/ProxyHttpRequestOptionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/ProxyHttpRequestOptionsTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
         {
             var options = new ProxyHttpRequestOptions
             {
-                RequestTimeout = TimeSpan.FromSeconds(60),
+                Timeout = TimeSpan.FromSeconds(60),
                 Version = HttpVersion.Version11,
 #if NET
                 VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher
@@ -31,7 +31,7 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
             var clone = options.DeepClone();
 
             Assert.NotSame(options, clone);
-            Assert.Equal(options.RequestTimeout, clone.RequestTimeout);
+            Assert.Equal(options.Timeout, clone.Timeout);
             Assert.Equal(options.Version, clone.Version);
 #if NET
             Assert.Equal(options.VersionPolicy, clone.VersionPolicy);
@@ -44,7 +44,7 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
         {
             var options1 = new ProxyHttpRequestOptions
             {
-                RequestTimeout = TimeSpan.FromSeconds(60),
+                Timeout = TimeSpan.FromSeconds(60),
                 Version = HttpVersion.Version11,
 #if NET
                 VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher
@@ -53,7 +53,7 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
 
             var options2 = new ProxyHttpRequestOptions
             {
-                RequestTimeout = TimeSpan.FromSeconds(60),
+                Timeout = TimeSpan.FromSeconds(60),
                 Version = HttpVersion.Version11,
 #if NET
                 VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher
@@ -70,7 +70,7 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
         {
             var options1 = new ProxyHttpRequestOptions
             {
-                RequestTimeout = TimeSpan.FromSeconds(60),
+                Timeout = TimeSpan.FromSeconds(60),
                 Version = HttpVersion.Version11,
 #if NET
                 VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher
@@ -79,7 +79,7 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
 
             var options2 = new ProxyHttpRequestOptions
             {
-                RequestTimeout = TimeSpan.FromSeconds(60),
+                Timeout = TimeSpan.FromSeconds(60),
                 Version = HttpVersion.Version20,
 #if NET
                 VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher
@@ -88,7 +88,7 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
 
             var options3 = new ProxyHttpRequestOptions
             {
-                RequestTimeout = TimeSpan.FromSeconds(60),
+                Timeout = TimeSpan.FromSeconds(60),
                 Version = HttpVersion.Version11,
 #if NET
                 VersionPolicy = HttpVersionPolicy.RequestVersionOrLower
@@ -111,7 +111,7 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
         {
             var options2 = new ProxyHttpRequestOptions
             {
-                RequestTimeout = TimeSpan.FromSeconds(60),
+                Timeout = TimeSpan.FromSeconds(60),
                 Version = HttpVersion.Version11,
 #if NET
                 VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher
@@ -128,7 +128,7 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
         {
             var options1 = new ProxyHttpRequestOptions
             {
-                RequestTimeout = TimeSpan.FromSeconds(60),
+                Timeout = TimeSpan.FromSeconds(60),
                 Version = HttpVersion.Version11,
 #if NET
                 VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher

--- a/test/ReverseProxy.Tests/Configuration/ConfigurationConfigProviderTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigurationConfigProviderTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.ReverseProxy.Configuration
                         },
                         HttpRequest = new ProxyHttpRequestOptions()
                         {
-                            RequestTimeout = TimeSpan.FromSeconds(60),
+                            Timeout = TimeSpan.FromSeconds(60),
                             Version = Version.Parse("1.0"),
 #if NET
                             VersionPolicy = HttpVersionPolicy.RequestVersionExact,
@@ -232,7 +232,7 @@ namespace Microsoft.ReverseProxy.Configuration
                 ""PropagateActivityContext"": true,
             },
             ""HttpRequest"": {
-                ""RequestTimeout"": ""00:01:00"",
+                ""Timeout"": ""00:01:00"",
                 ""Version"": ""1"",
                 ""VersionPolicy"": ""RequestVersionExact""
             },
@@ -622,7 +622,7 @@ namespace Microsoft.ReverseProxy.Configuration
             Assert.Equal(cluster1.HttpClient.MaxConnectionsPerServer, abstractCluster1.HttpClient.MaxConnectionsPerServer);
             Assert.Equal(cluster1.HttpClient.PropagateActivityContext, abstractCluster1.HttpClient.PropagateActivityContext);
             Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, abstractCluster1.HttpClient.SslProtocols);
-            Assert.Equal(cluster1.HttpRequest.RequestTimeout, abstractCluster1.HttpRequest.RequestTimeout);
+            Assert.Equal(cluster1.HttpRequest.Timeout, abstractCluster1.HttpRequest.Timeout);
             Assert.Equal(HttpVersion.Version10, abstractCluster1.HttpRequest.Version);
 #if NET
             Assert.Equal(cluster1.HttpRequest.VersionPolicy, abstractCluster1.HttpRequest.VersionPolicy);

--- a/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
@@ -80,10 +80,10 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
                     It.Is<string>(uri => uri == "https://localhost:123/a/b/"),
                     httpClient,
                     It.Is<RequestProxyOptions>(options =>
-                        options.RequestTimeout == httpRequestOptions.RequestTimeout
-                        && options.Version == httpRequestOptions.Version
+                        options.RequestOptions.Timeout == httpRequestOptions.Timeout
+                        && options.RequestOptions.Version == httpRequestOptions.Version
 #if NET
-                        && options.VersionPolicy == httpRequestOptions.VersionPolicy
+                        && options.RequestOptions.VersionPolicy == httpRequestOptions.VersionPolicy
 #endif
                         )))
                 .Returns(

--- a/test/ReverseProxy.Tests/Service/Proxy/HttpProxyTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/HttpProxyTests.cs
@@ -194,10 +194,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return response;
                 });
 
-            var proxyOptions = new RequestProxyOptions()
-            {
-                Transforms = transforms,
-            };
+            var proxyOptions = new RequestProxyOptions(transforms);
 
             await sut.ProxyAsync(httpContext, destinationPrefix, client, proxyOptions);
 
@@ -292,10 +289,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return response;
                 });
 
-            var proxyOptions = new RequestProxyOptions()
-            {
-                Transforms = transforms,
-            };
+            var proxyOptions = new RequestProxyOptions(transforms);
 
             await sut.ProxyAsync(httpContext, destinationPrefix, client, proxyOptions);
 
@@ -373,10 +367,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return response;
                 });
 
-            var proxyOptions = new RequestProxyOptions()
-            {
-                Transforms = transforms,
-            };
+            var proxyOptions = new RequestProxyOptions(transforms);
 
             await sut.ProxyAsync(httpContext, destinationPrefix, client, proxyOptions);
 
@@ -699,14 +690,11 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return Task.FromResult(response);
                 });
 
-            var options = new RequestProxyOptions()
-            {
 #if NET
-                RequestOptions = new ClusterProxyHttpRequestOptions(timeout: null, version: version, versionPolicy: versionPolicy)
+            var options = new RequestProxyOptions(null, version, versionPolicy);
 #else
-                RequestOptions = new ClusterProxyHttpRequestOptions(timeout: null, version: version)
+            var options = new RequestProxyOptions(null, version);
 #endif
-            };
             await sut.ProxyAsync(httpContext, destinationPrefix, client, options);
 
             Assert.Null(httpContext.Features.Get<IProxyErrorFeature>());
@@ -762,15 +750,13 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                 responseHeaderTransforms: new Dictionary<string, ResponseHeaderTransform>(StringComparer.OrdinalIgnoreCase),
                 responseTrailerTransforms: new Dictionary<string, ResponseHeaderTransform>(StringComparer.OrdinalIgnoreCase));
 
-            var options = new RequestProxyOptions()
-            {
-                Transforms = transforms,
+
 #if NET
-                RequestOptions = new ClusterProxyHttpRequestOptions(timeout: null, version: version, versionPolicy: versionPolicy)
+            var requestOptions = new ClusterProxyHttpRequestOptions(null, version, versionPolicy);
 #else
-                RequestOptions = new ClusterProxyHttpRequestOptions(timeout: null, version: version)
+            var requestOptions = new ClusterProxyHttpRequestOptions(null, version);
 #endif
-            };
+            var options = new RequestProxyOptions(transforms, requestOptions);
             await sut.ProxyAsync(httpContext, destinationPrefix, client, options);
 
             Assert.Null(httpContext.Features.Get<IProxyErrorFeature>());
@@ -868,15 +854,9 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return Task.FromResult(new HttpResponseMessage());
                 });
 
-            var proxyOptions = new RequestProxyOptions()
-            {
-                // Time out immediately
-#if NET
-                RequestOptions = new ClusterProxyHttpRequestOptions(timeout: TimeSpan.FromTicks(1), version: null, versionPolicy: null)
-#else
-                RequestOptions = new ClusterProxyHttpRequestOptions(timeout: TimeSpan.FromTicks(1), version: null)
-#endif
-            };
+            // Time out immediately
+            var requestOptions = new ClusterProxyHttpRequestOptions(TimeSpan.FromTicks(1), null);
+            var proxyOptions = new RequestProxyOptions(null, requestOptions);
 
             await sut.ProxyAsync(httpContext, destinationPrefix, client, proxyOptions);
 
@@ -948,15 +928,9 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return Task.FromResult(new HttpResponseMessage());
                 });
 
-            var proxyOptions = new RequestProxyOptions()
-            {
-                // Time out immediately
-#if NET
-                RequestOptions = new ClusterProxyHttpRequestOptions(timeout: TimeSpan.FromTicks(1), version: null, versionPolicy: null)
-#else
-                RequestOptions = new ClusterProxyHttpRequestOptions(timeout: TimeSpan.FromTicks(1), version: null)
-#endif
-            };
+            // Time out immediately
+            var requestOptions = new ClusterProxyHttpRequestOptions(TimeSpan.FromTicks(1), null);
+            var proxyOptions = new RequestProxyOptions(null, requestOptions);
 
             await sut.ProxyAsync(httpContext, destinationPrefix, client, proxyOptions);
 

--- a/test/ReverseProxy.Tests/Service/Proxy/HttpProxyTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/HttpProxyTests.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Net.Http.Headers;
 using Microsoft.ReverseProxy.Common.Tests;
+using Microsoft.ReverseProxy.RuntimeModel;
 using Microsoft.ReverseProxy.Service.RuntimeModel.Transforms;
 using Microsoft.ReverseProxy.Telemetry;
 using Microsoft.ReverseProxy.Utilities;
@@ -700,9 +701,10 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
 
             var options = new RequestProxyOptions()
             {
-                Version = version,
 #if NET
-                VersionPolicy = versionPolicy,
+                RequestOptions = new ClusterProxyHttpRequestOptions(timeout: null, version: version, versionPolicy: versionPolicy)
+#else
+                RequestOptions = new ClusterProxyHttpRequestOptions(timeout: null, version: version)
 #endif
             };
             await sut.ProxyAsync(httpContext, destinationPrefix, client, options);
@@ -762,10 +764,11 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
 
             var options = new RequestProxyOptions()
             {
-                Version = version,
                 Transforms = transforms,
 #if NET
-                VersionPolicy = versionPolicy,
+                RequestOptions = new ClusterProxyHttpRequestOptions(timeout: null, version: version, versionPolicy: versionPolicy)
+#else
+                RequestOptions = new ClusterProxyHttpRequestOptions(timeout: null, version: version)
 #endif
             };
             await sut.ProxyAsync(httpContext, destinationPrefix, client, options);
@@ -867,7 +870,12 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
 
             var proxyOptions = new RequestProxyOptions()
             {
-                RequestTimeout = TimeSpan.FromTicks(1), // Time out immediately
+                // Time out immediately
+#if NET
+                RequestOptions = new ClusterProxyHttpRequestOptions(timeout: TimeSpan.FromTicks(1), version: null, versionPolicy: null)
+#else
+                RequestOptions = new ClusterProxyHttpRequestOptions(timeout: TimeSpan.FromTicks(1), version: null)
+#endif
             };
 
             await sut.ProxyAsync(httpContext, destinationPrefix, client, proxyOptions);
@@ -942,7 +950,12 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
 
             var proxyOptions = new RequestProxyOptions()
             {
-                RequestTimeout = TimeSpan.FromTicks(1), // Time out immediately
+                // Time out immediately
+#if NET
+                RequestOptions = new ClusterProxyHttpRequestOptions(timeout: TimeSpan.FromTicks(1), version: null, versionPolicy: null)
+#else
+                RequestOptions = new ClusterProxyHttpRequestOptions(timeout: TimeSpan.FromTicks(1), version: null)
+#endif
             };
 
             await sut.ProxyAsync(httpContext, destinationPrefix, client, proxyOptions);


### PR DESCRIPTION
**This is to open the discussion about the type merging and see what changes it brings.**

Replaces `RequestProxyOption` individual properties with an instance of `ClusterProxyHttpRequestOptions` struct. Moves default values for the options into a single place in `ClusterProxyHttpRequestOptions`.

Also renames `RequestTimeout` --> `Timeout`. As it was pointed out that the name is redundant.

Kept `ClusterProxyHttpRequestOptions` as a struct to keep consistency with other `Cluster*` types used by `ClusterConfig`.

Further possibilities:
- `RequestProxyOption` can be completely removed and replaced with `Transforms` and `ClusterProxyHttpRequestOptions`
- `ClusterProxyHttpRequestOptions` can be renamed and/or changed to a class.

I'll update docs once we settle on a solution.

Fixes #525 