### PR TITLE
Dispose FabricClient

### DIFF
--- a/src/ReverseProxy.ServiceFabric/Configuration/ServiceFabricServiceCollectionExtensions.cs
+++ b/src/ReverseProxy.ServiceFabric/Configuration/ServiceFabricServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ namespace Microsoft.ReverseProxy.ServiceFabric
         /// </summary>
         public static IReverseProxyBuilder LoadFromServiceFabric(this IReverseProxyBuilder builder)
         {
+            builder.Services.AddSingleton<IFabricClientWrapper, FabricClientWrapper>();
             builder.Services.AddSingleton<IQueryClientWrapper, QueryClientWrapper>();
             builder.Services.AddSingleton<IPropertyManagementClientWrapper, PropertyManagementClientWrapper>();
             builder.Services.AddSingleton<IServiceManagementClientWrapper, ServiceManagementClientWrapper>();

--- a/src/ReverseProxy.ServiceFabric/FabricWrapper/FabricClientWrapper.cs
+++ b/src/ReverseProxy.ServiceFabric/FabricWrapper/FabricClientWrapper.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Fabric;
+
+namespace Microsoft.ReverseProxy.ServiceFabric
+{
+    internal class FabricClientWrapper : IFabricClientWrapper, IDisposable
+    {
+        public FabricClientWrapper()
+        {
+            FabricClient = new FabricClient();
+        }
+
+        public FabricClient FabricClient { get; }
+
+        public void Dispose()
+        {
+            FabricClient.Dispose();
+        }
+    }
+}

--- a/src/ReverseProxy.ServiceFabric/FabricWrapper/HealthClientWrapper.cs
+++ b/src/ReverseProxy.ServiceFabric/FabricWrapper/HealthClientWrapper.cs
@@ -1,19 +1,28 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Fabric;
 using System.Fabric.Health;
 
 namespace Microsoft.ReverseProxy.ServiceFabric
 {
     /// <inheritdoc/>
-    internal class HealthClientWrapper : IHealthClientWrapper
+    internal class HealthClientWrapper : IHealthClientWrapper , IDisposable
     {
+        private readonly FabricClient _fabricClient;
         private readonly FabricClient.HealthClient _healthClient;
 
         public HealthClientWrapper()
         {
-            _healthClient = new FabricClient().HealthManager;
+            _fabricClient = new FabricClient();
+            _healthClient = _fabricClient.HealthManager;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _fabricClient.Dispose();
         }
 
         /// <inheritdoc/>

--- a/src/ReverseProxy.ServiceFabric/FabricWrapper/HealthClientWrapper.cs
+++ b/src/ReverseProxy.ServiceFabric/FabricWrapper/HealthClientWrapper.cs
@@ -1,28 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Fabric;
 using System.Fabric.Health;
 
 namespace Microsoft.ReverseProxy.ServiceFabric
 {
     /// <inheritdoc/>
-    internal class HealthClientWrapper : IHealthClientWrapper , IDisposable
+    internal class HealthClientWrapper : IHealthClientWrapper
     {
-        private readonly FabricClient _fabricClient;
         private readonly FabricClient.HealthClient _healthClient;
 
-        public HealthClientWrapper()
+        public HealthClientWrapper(IFabricClientWrapper fabricClientWrapper)
         {
-            _fabricClient = new FabricClient();
-            _healthClient = _fabricClient.HealthManager;
-        }
-
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            _fabricClient.Dispose();
+            _healthClient = fabricClientWrapper.FabricClient.HealthManager;
         }
 
         /// <inheritdoc/>

--- a/src/ReverseProxy.ServiceFabric/FabricWrapper/IFabricClientWrapper.cs
+++ b/src/ReverseProxy.ServiceFabric/FabricWrapper/IFabricClientWrapper.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Fabric;
+
+namespace Microsoft.ReverseProxy.ServiceFabric
+{
+    internal interface IFabricClientWrapper
+    {
+        FabricClient FabricClient { get; }
+    }
+}

--- a/src/ReverseProxy.ServiceFabric/FabricWrapper/PropertyManagementClientWrapper.cs
+++ b/src/ReverseProxy.ServiceFabric/FabricWrapper/PropertyManagementClientWrapper.cs
@@ -14,20 +14,17 @@ namespace Microsoft.ReverseProxy.ServiceFabric
     /// A wrapper class for the service fabric client SDK.
     /// See Microsoft documentation: https://docs.microsoft.com/en-us/dotnet/api/system.fabric.fabricclient.propertymanagementclient?view=azure-dotnet .
     /// </summary>
-    internal class PropertyManagementClientWrapper : IPropertyManagementClientWrapper, IDisposable
+    internal class PropertyManagementClientWrapper : IPropertyManagementClientWrapper
     {
-        private readonly FabricClient _fabricClient;
-
         // Represents the property management client used to perform management of names and properties.
         private readonly FabricClient.PropertyManagementClient _propertyManagementClient;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PropertyManagementClientWrapper"/> class.
         /// </summary>
-        public PropertyManagementClientWrapper()
+        public PropertyManagementClientWrapper(IFabricClientWrapper fabricClientWrapper)
         {
-            _fabricClient = new FabricClient();
-            _propertyManagementClient = _fabricClient.PropertyManager;
+            _propertyManagementClient = fabricClientWrapper.FabricClient.PropertyManager;
         }
 
         /// <summary>
@@ -88,12 +85,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric
             }
             while (previousResult.HasMoreData);
             return namedProperties;
-        }
-
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            _fabricClient.Dispose();
         }
     }
 }

--- a/src/ReverseProxy.ServiceFabric/FabricWrapper/PropertyManagementClientWrapper.cs
+++ b/src/ReverseProxy.ServiceFabric/FabricWrapper/PropertyManagementClientWrapper.cs
@@ -14,8 +14,10 @@ namespace Microsoft.ReverseProxy.ServiceFabric
     /// A wrapper class for the service fabric client SDK.
     /// See Microsoft documentation: https://docs.microsoft.com/en-us/dotnet/api/system.fabric.fabricclient.propertymanagementclient?view=azure-dotnet .
     /// </summary>
-    internal class PropertyManagementClientWrapper : IPropertyManagementClientWrapper
+    internal class PropertyManagementClientWrapper : IPropertyManagementClientWrapper, IDisposable
     {
+        private readonly FabricClient _fabricClient;
+
         // Represents the property management client used to perform management of names and properties.
         private readonly FabricClient.PropertyManagementClient _propertyManagementClient;
 
@@ -24,7 +26,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric
         /// </summary>
         public PropertyManagementClientWrapper()
         {
-            _propertyManagementClient = new FabricClient().PropertyManager;
+            _fabricClient = new FabricClient();
+            _propertyManagementClient = _fabricClient.PropertyManager;
         }
 
         /// <summary>
@@ -85,6 +88,12 @@ namespace Microsoft.ReverseProxy.ServiceFabric
             }
             while (previousResult.HasMoreData);
             return namedProperties;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _fabricClient.Dispose();
         }
     }
 }

--- a/src/ReverseProxy.ServiceFabric/FabricWrapper/QueryClientWrapper.cs
+++ b/src/ReverseProxy.ServiceFabric/FabricWrapper/QueryClientWrapper.cs
@@ -17,9 +17,10 @@ namespace Microsoft.ReverseProxy.ServiceFabric
     /// A wrapper class for the service fabric client SDK.
     /// Microsoft documentation: https://docs.microsoft.com/en-us/dotnet/api/system.fabric.fabricclient.queryclient?view=azure-dotnet .
     /// </summary>
-    internal class QueryClientWrapper : IQueryClientWrapper
+    internal class QueryClientWrapper : IQueryClientWrapper, IDisposable
     {
         private readonly ILogger<QueryClientWrapper> _logger;
+        private readonly FabricClient _fabricClient;
         private readonly FabricClient.QueryClient _queryClient;
 
         /// <summary>
@@ -29,7 +30,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-            _queryClient = new FabricClient().QueryManager;
+            _fabricClient = new FabricClient();
+            _queryClient = _fabricClient.QueryManager;
         }
 
         /// <summary>
@@ -254,6 +256,12 @@ namespace Microsoft.ReverseProxy.ServiceFabric
             while (!string.IsNullOrEmpty(previousResult?.ContinuationToken));
 
             return replicaList;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _fabricClient.Dispose();
         }
     }
 }

--- a/src/ReverseProxy.ServiceFabric/FabricWrapper/QueryClientWrapper.cs
+++ b/src/ReverseProxy.ServiceFabric/FabricWrapper/QueryClientWrapper.cs
@@ -17,21 +17,19 @@ namespace Microsoft.ReverseProxy.ServiceFabric
     /// A wrapper class for the service fabric client SDK.
     /// Microsoft documentation: https://docs.microsoft.com/en-us/dotnet/api/system.fabric.fabricclient.queryclient?view=azure-dotnet .
     /// </summary>
-    internal class QueryClientWrapper : IQueryClientWrapper, IDisposable
+    internal class QueryClientWrapper : IQueryClientWrapper
     {
         private readonly ILogger<QueryClientWrapper> _logger;
-        private readonly FabricClient _fabricClient;
         private readonly FabricClient.QueryClient _queryClient;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="QueryClientWrapper"/> class.
         /// </summary>
-        public QueryClientWrapper(ILogger<QueryClientWrapper> logger)
+        public QueryClientWrapper(ILogger<QueryClientWrapper> logger, IFabricClientWrapper fabricClientWrapper)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-            _fabricClient = new FabricClient();
-            _queryClient = _fabricClient.QueryManager;
+            _queryClient = fabricClientWrapper.FabricClient.QueryManager;
         }
 
         /// <summary>
@@ -256,12 +254,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric
             while (!string.IsNullOrEmpty(previousResult?.ContinuationToken));
 
             return replicaList;
-        }
-
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            _fabricClient.Dispose();
         }
     }
 }

--- a/src/ReverseProxy.ServiceFabric/FabricWrapper/ServiceManagementClientWrapper.cs
+++ b/src/ReverseProxy.ServiceFabric/FabricWrapper/ServiceManagementClientWrapper.cs
@@ -12,8 +12,10 @@ namespace Microsoft.ReverseProxy.ServiceFabric
     /// A wrapper class for the service fabric client SDK.
     /// See Microsoft documentation: https://docs.microsoft.com/en-us/dotnet/api/system.fabric.fabricclient.servicemanagementclient?view=azure-dotnet .
     /// </summary>
-    internal class ServiceManagementClientWrapper : IServiceManagementClientWrapper
+    internal class ServiceManagementClientWrapper : IServiceManagementClientWrapper, IDisposable
     {
+        private readonly FabricClient _fabricClient;
+
         // Represents the enabling of the services to be managed.
         private readonly FabricClient.ServiceManagementClient _serviceManagementClient;
 
@@ -23,7 +25,14 @@ namespace Microsoft.ReverseProxy.ServiceFabric
         /// </summary>
         public ServiceManagementClientWrapper()
         {
-            _serviceManagementClient = new FabricClient().ServiceManager;
+            _fabricClient = new FabricClient();
+            _serviceManagementClient = _fabricClient.ServiceManager;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _fabricClient.Dispose();
         }
 
         /// <summary>

--- a/src/ReverseProxy.ServiceFabric/FabricWrapper/ServiceManagementClientWrapper.cs
+++ b/src/ReverseProxy.ServiceFabric/FabricWrapper/ServiceManagementClientWrapper.cs
@@ -12,10 +12,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric
     /// A wrapper class for the service fabric client SDK.
     /// See Microsoft documentation: https://docs.microsoft.com/en-us/dotnet/api/system.fabric.fabricclient.servicemanagementclient?view=azure-dotnet .
     /// </summary>
-    internal class ServiceManagementClientWrapper : IServiceManagementClientWrapper, IDisposable
+    internal class ServiceManagementClientWrapper : IServiceManagementClientWrapper
     {
-        private readonly FabricClient _fabricClient;
-
         // Represents the enabling of the services to be managed.
         private readonly FabricClient.ServiceManagementClient _serviceManagementClient;
 
@@ -23,16 +21,9 @@ namespace Microsoft.ReverseProxy.ServiceFabric
         /// Initializes a new instance of the <see cref="ServiceManagementClientWrapper"/> class.
         /// Wraps QueryManager, PropertyManager and ServiceManager SF SDK.
         /// </summary>
-        public ServiceManagementClientWrapper()
+        public ServiceManagementClientWrapper(IFabricClientWrapper fabricClientWrapper)
         {
-            _fabricClient = new FabricClient();
-            _serviceManagementClient = _fabricClient.ServiceManager;
-        }
-
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            _fabricClient.Dispose();
+            _serviceManagementClient = fabricClientWrapper.FabricClient.ServiceManager;
         }
 
         /// <summary>


### PR DESCRIPTION
Does each one of these wrappers need their own instance of `FabricClient` or is it possible to create only one instance and share it?