### PR TITLE
Consistently use InvariantCulture for doubles

### DIFF
--- a/test/ReverseProxy.Tests/Service/HealthChecks/TransportFailureRateHealthPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/TransportFailureRateHealthPolicyTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using Microsoft.ReverseProxy.Abstractions;
@@ -206,7 +207,7 @@ namespace Microsoft.ReverseProxy.Service.HealthChecks
         private ClusterInfo GetClusterInfo(string id, int destinationCount, double? failureRateLimit = null, TimeSpan? reactivationPeriod = null)
         {
             var metadata = failureRateLimit != null
-                ? new Dictionary<string, string> { { TransportFailureRateHealthPolicyOptions.FailureRateLimitMetadataName, failureRateLimit.ToString() } }
+                ? new Dictionary<string, string> { { TransportFailureRateHealthPolicyOptions.FailureRateLimitMetadataName, failureRateLimit?.ToString(CultureInfo.InvariantCulture) } }
                 : null;
             var clusterConfig = new ClusterConfig(
                 new Cluster { Id = id },


### PR DESCRIPTION
We're using invariant culture when parsing the rate limit for health checks, but serializing it with the current culture (`.` vs `,` for floats).
This leads to a spceific test failing on machines with a different culture.