### PR TITLE
Change IAffinityFailurePolicy to public

### DIFF
--- a/src/ReverseProxy/Service/SessionAffinity/IAffinityFailurePolicy.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/IAffinityFailurePolicy.cs
@@ -10,7 +10,7 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
     /// <summary>
     /// Affinity failures handling policy.
     /// </summary>
-    internal interface IAffinityFailurePolicy
+    public interface IAffinityFailurePolicy
     {
         /// <summary>
         ///  A unique identifier for this failure policy. This will be referenced from config.


### PR DESCRIPTION
Allows implementation of custom failure policies, which fixes #595