### PR TITLE
Remove arrange, act, assert comments from service fabric tests

### DIFF
--- a/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/DiscovererTests.cs
+++ b/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/DiscovererTests.cs
@@ -60,14 +60,11 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void ExecuteAsync_NoAppsDiscovered_NoClusters()
         {
-            // Setup
             _scenarioOptions = new ServiceFabricDiscoveryOptions { ReportReplicasHealth = true };
             Mock_AppsResponse();
 
-            // Act
             var (routes, clusters) = await RunScenarioAsync();
 
-            // Assert
             routes.Should().BeEmpty();
             clusters.Should().BeEmpty();
             _healthReports.Should().BeEmpty();
@@ -76,16 +73,13 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void ExecuteAsync_NoExtensions_NoClusters()
         {
-            // Setup
             _scenarioOptions = new ServiceFabricDiscoveryOptions { ReportReplicasHealth = true };
             ApplicationWrapper application;
             Mock_AppsResponse(application = CreateApp_1Service_SingletonPartition_1Replica("MyCoolApp", "MyAwesomeService", out var service, out _));
             Mock_ServiceLabels(application, service, new Dictionary<string, string>());
 
-            // Act
             var (routes, clusters) = await RunScenarioAsync();
 
-            // Assert
             routes.Should().BeEmpty();
             clusters.Should().BeEmpty();
             _healthReports.Should().BeEmpty();
@@ -94,16 +88,13 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void ExecuteAsync_GatewayNotEnabled_NoClusters()
         {
-            // Setup
             _scenarioOptions = new ServiceFabricDiscoveryOptions { ReportReplicasHealth = true };
             ApplicationWrapper application;
             Mock_AppsResponse(application = CreateApp_1Service_SingletonPartition_1Replica("MyCoolApp", "MyAwesomeService", out var service, out _));
             Mock_ServiceLabels(application, service, new Dictionary<string, string>() { { "YARP.Enable", "false" } });
 
-            // Act
             var (routes, clusters) = await RunScenarioAsync();
 
-            // Assert
             routes.Should().BeEmpty();
             clusters.Should().BeEmpty();
             _healthReports.Should().BeEmpty();
@@ -112,7 +103,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void ExecuteAsync_SingleServiceWithGatewayEnabled_OneClusterFound()
         {
-            // Setup
             _scenarioOptions = new ServiceFabricDiscoveryOptions { ReportReplicasHealth = true };
             const string TestClusterId = "MyService123";
             var labels = SFTestHelpers.DummyLabels(TestClusterId);
@@ -123,10 +113,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
             Mock_ServiceLabels(application, service, labels);
             Mock_ServiceLabels(anotherApplication, anotherService, new Dictionary<string, string>());
 
-            // Act
             var (routes, clusters) = await RunScenarioAsync();
 
-            // Assert
             var expectedClusters = new[]
             {
                 ClusterWithDestinations(
@@ -151,7 +139,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void ExecuteAsync_SingleServiceWithGatewayEnabledAndActiveHealthCheck()
         {
-            // Setup
             _scenarioOptions = new ServiceFabricDiscoveryOptions();
             const string TestClusterId = "MyService123";
             var labels = SFTestHelpers.DummyLabels(TestClusterId, activeHealthChecks: true);
@@ -160,10 +147,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 application = CreateApp_1StatelessService_2Partition_2ReplicasEach("MyApp", "MYService", out var service, out var replicas));
             Mock_ServiceLabels(application, service, labels);
 
-            // Act
             var (routes, clusters) = await RunScenarioAsync();
 
-            // Assert
             var expectedClusters = new[]
             {
                 ClusterWithDestinations(
@@ -184,7 +169,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void ExecuteAsync_MultipleServicesWithGatewayEnabled_MultipleClustersFound()
         {
-            // Setup
             _scenarioOptions = new ServiceFabricDiscoveryOptions { ReportReplicasHealth = true };
             const string TestClusterIdApp1Sv1 = "MyService123";
             const string TestClusterIdApp1Sv2 = "MyService234";
@@ -201,10 +185,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
             Mock_ServiceLabels(application2, service2, labels2);
             Mock_ServiceLabels(application2, service3, labels3);
 
-            // Act
             var (routes, clusters) = await RunScenarioAsync();
 
-            // Assert
             var expectedClusters = new[]
             {
                 ClusterWithDestinations(
@@ -236,7 +218,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void ExecuteAsync_OneServiceWithGatewayEnabledAndOneNotEnabled_OnlyTheOneEnabledFound()
         {
-            // Setup
             _scenarioOptions = new ServiceFabricDiscoveryOptions { ReportReplicasHealth = true };
             const string TestClusterIdApp1Sv1 = "MyService123";
             const string TestClusterIdApp2Sv2 = "MyService234";
@@ -250,10 +231,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
             Mock_ServiceLabels(application1, service1, gatewayEnabledLabels);
             Mock_ServiceLabels(application2, service2, gatewayNotEnabledLabels);
 
-            // Act
             var (routes, clusters) = await RunScenarioAsync();
 
-            // Assert
             var expectedClusters = new[]
             {
                 ClusterWithDestinations(
@@ -273,7 +252,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void ExecuteAsync_GetLabelsFails_NoClustersAndBadHealthReported()
         {
-            // Setup
             _scenarioOptions = new ServiceFabricDiscoveryOptions { ReportReplicasHealth = true };
             ApplicationWrapper application;
             Mock_AppsResponse(
@@ -281,10 +259,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
 
             Mock_ServiceLabelsException(application, service, new ConfigException("foo"));
 
-            // Act
             var (routes, clusters) = await RunScenarioAsync();
 
-            // Assert
             clusters.Should().BeEmpty();
             routes.Should().BeEmpty();
             AssertServiceHealthReported(service, HealthState.Warning, (description) => description.Contains("foo"));
@@ -295,7 +271,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [InlineData("YARP.Backend.HealthCheck.Active.Interval", "not a number")]
         public async void ExecuteAsync_InvalidLabelsForCluster_NoClustersAndBadHealthReported(string keyToOverride, string value)
         {
-            // Setup
             _scenarioOptions = new ServiceFabricDiscoveryOptions { ReportReplicasHealth = true };
             var labels = SFTestHelpers.DummyLabels("SomeClusterId");
             labels[keyToOverride] = value;
@@ -305,10 +280,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
 
             Mock_ServiceLabels(application, service, labels);
 
-            // Act
             var (routes, clusters) = await RunScenarioAsync();
 
-            // Assert
             clusters.Should().BeEmpty();
             routes.Should().BeEmpty();
             AssertServiceHealthReported(service, HealthState.Warning, (description) =>
@@ -319,7 +292,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void ExecuteAsync_InvalidRouteOrder_NoRoutesAndBadHealthReported()
         {
-            // Setup
             _scenarioOptions = new ServiceFabricDiscoveryOptions { ReportReplicasHealth = true };
             var labels = new Dictionary<string, string>()
             {
@@ -334,10 +306,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
 
             Mock_ServiceLabels(application, service, labels);
 
-            // Act
             var (routes, clusters) = await RunScenarioAsync();
 
-            // Assert
             var expectedClusters = new[]
             {
                 ClusterWithDestinations(
@@ -356,7 +326,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void ExecuteAsync_InvalidListenerNameForStatefulService_NoEndpointsAndBadHealthReported()
         {
-            // Setup
             _scenarioOptions = new ServiceFabricDiscoveryOptions { ReportReplicasHealth = true };
             const string TestClusterId = "MyService123";
             var labels = SFTestHelpers.DummyLabels(TestClusterId);
@@ -367,10 +336,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
 
             Mock_ServiceLabels(application, service, labels);
 
-            // Act
             var (routes, clusters) = await RunScenarioAsync();
 
-            // Assert
             var expectedClusters = new[]
             {
                 LabelsParser.BuildCluster(_testServiceName, labels),
@@ -389,7 +356,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void ExecuteAsync_InvalidListenerNameForStatelessService_NoEndpointsAndBadHealthReported()
         {
-            // Setup
             _scenarioOptions = new ServiceFabricDiscoveryOptions { ReportReplicasHealth = true };
             const string TestClusterId = "MyService123";
             var labels = SFTestHelpers.DummyLabels(TestClusterId);
@@ -400,10 +366,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
 
             Mock_ServiceLabels(application, service, labels);
 
-            // Act
             var (routes, clusters) = await RunScenarioAsync();
 
-            // Assert
             var expectedClusters = new[]
             {
                 LabelsParser.BuildCluster(_testServiceName, labels),
@@ -422,7 +386,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void ExecuteAsync_NotHttpsSchemeForStatelessService_NoEndpointsAndBadHealthReported()
         {
-            // Setup
             _scenarioOptions = new ServiceFabricDiscoveryOptions { ReportReplicasHealth = true };
             const string TestClusterId = "MyService123";
             const string ServiceName = "fabric:/MyApp/MyService";
@@ -435,10 +398,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
             replica.ReplicaAddress = $"{{'Endpoints': {{'ExampleTeamEndpoint': '{nonHttpAddress}' }} }}".Replace("'", "\"");
             Mock_ServiceLabels(application, service, labels);
 
-            // Act
             var (routes, clusters) = await RunScenarioAsync();
 
-            // Assert
             var expectedClusters = new[]
             {
                 LabelsParser.BuildCluster(_testServiceName, labels),
@@ -457,7 +418,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void ExecuteAsync_ValidListenerNameForStatelessService_Work()
         {
-            // Setup
             _scenarioOptions = new ServiceFabricDiscoveryOptions { ReportReplicasHealth = true };
             const string TestClusterId = "MyService123";
             var labels = SFTestHelpers.DummyLabels(TestClusterId);
@@ -469,10 +429,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
             replica.ReplicaAddress = MockReplicaAdressWithListenerName("MyApp", "MyService", new string[] { "ExampleTeamEndpoint", "ExampleTeamHealthEndpoint" });
             Mock_ServiceLabels(application, service, labels);
 
-            // Act
             var (routes, clusters) = await RunScenarioAsync();
 
-            // Assert
             var expectedClusters = new[]
             {
                 ClusterWithDestinations(
@@ -492,7 +450,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void ExecuteAsync_SomeUnhealthyReplicas_OnlyHealthyReplicasAreUsed()
         {
-            // Setup
             _scenarioOptions = new ServiceFabricDiscoveryOptions { ReportReplicasHealth = true };
             const string TestClusterId = "MyService123";
             var labels = SFTestHelpers.DummyLabels(TestClusterId);
@@ -517,10 +474,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
             replicas[3].ReplicaStatus = ServiceReplicaStatus.Down; // Should be skipped because of status
             replicas[3].HealthState = HealthState.Ok;
 
-            // Act
             var (routes, clusters) = await RunScenarioAsync();
 
-            // Assert
             var expectedClusters = new[]
             {
                 ClusterWithDestinations(
@@ -543,7 +498,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void ExecuteAsync_ReplicaHealthReportDisabled_ReplicasHealthIsNotReported()
         {
-            // Setup
             _scenarioOptions = new ServiceFabricDiscoveryOptions { ReportReplicasHealth = false };
             const string TestClusterId = "MyService123";
             var labels = SFTestHelpers.DummyLabels(TestClusterId);
@@ -552,10 +506,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 application = CreateApp_1Service_SingletonPartition_1Replica("MyApp", "MYService", out var service, out var replica));
             Mock_ServiceLabels(application, service, labels);
 
-            // Act
             var (routes, clusters) = await RunScenarioAsync();
 
-            // Assert
             var expectedClusters = new[]
             {
                 ClusterWithDestinations(
@@ -580,7 +532,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [InlineData("All", null)]
         public async void ExecuteAsync_StatefulService_SelectReplicaWork(string selectionMode, ReplicaRole? replicaRole)
         {
-            // Setup
             _scenarioOptions = new ServiceFabricDiscoveryOptions { ReportReplicasHealth = true };
             const string TestClusterId = "MyService123";
             var labels = SFTestHelpers.DummyLabels(TestClusterId);
@@ -591,10 +542,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
             replica.ServiceKind = ServiceKind.Stateful;
             replica.Role = replicaRole;
 
-            // Act
             var (routes, clusters) = await RunScenarioAsync();
 
-            // Assert
             var expectedClusters = new[]
             {
                 ClusterWithDestinations(
@@ -617,7 +566,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [InlineData("SecondaryOnly", null)]
         public async void ExecuteAsync_StatefulService_SkipReplicaWork(string selectionMode, ReplicaRole? replicaRole)
         {
-            // Setup
             _scenarioOptions = new ServiceFabricDiscoveryOptions { ReportReplicasHealth = true };
             const string TestClusterId = "MyService123";
             var labels = SFTestHelpers.DummyLabels(TestClusterId);
@@ -628,10 +576,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
             replica.ServiceKind = ServiceKind.Stateful;
             replica.Role = replicaRole;
 
-            // Act
             var (routes, clusters) = await RunScenarioAsync();
 
-            // Assert
             var expectedClusters = new[]
             {
                 LabelsParser.BuildCluster(_testServiceName, labels),

--- a/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/ServiceExtensionLabelsProviderTests.cs
+++ b/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/ServiceExtensionLabelsProviderTests.cs
@@ -56,7 +56,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void GetExtensionLabels_UnexistingServiceTypeName_NoLabels()
         {
-            // Arrange
             _rawServiceManifest =
                 $@"<ServiceManifest xmlns='{ServiceExtensionLabelsProvider.XNSServiceManifest}'>
                   <ServiceTypes>
@@ -65,18 +64,15 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                   </ServiceTypes>
                 </ServiceManifest>";
 
-            // Act
             var labels = await RunScenarioAsync();
 
             // TODO: consider throwing if the servicetypename does not exist
-            // Assert
             labels.Should().Equal(new Dictionary<string, string>());
         }
 
         [Fact]
         public async void GetExtensionLabels_NoExtensions_NoLabels()
         {
-            // Arrange
             _rawServiceManifest =
                 $@"<ServiceManifest xmlns='{ServiceExtensionLabelsProvider.XNSServiceManifest}'>
                   <ServiceTypes>
@@ -85,17 +81,14 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                   </ServiceTypes>
                 </ServiceManifest>";
 
-            // Act
             var labels = await RunScenarioAsync();
 
-            // Assert
             labels.Should().Equal(new Dictionary<string, string>());
         }
 
         [Fact]
         public async void GetExtensionLabels_NoLabelsInExtensions_NoLabels()
         {
-            // Arrange
             _rawServiceManifest =
                 $@"<ServiceManifest xmlns='{ServiceExtensionLabelsProvider.XNSServiceManifest}'>
                 <ServiceTypes>
@@ -116,17 +109,14 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 </ServiceManifest>
                 ";
 
-            // Act
             var labels = await RunScenarioAsync();
 
-            // Assert
             labels.Should().Equal(new Dictionary<string, string>());
         }
 
         [Fact]
         public async void GetExtensionLabels_NoYarpExtensions_NoLabels()
         {
-            // Arrange
             _rawServiceManifest =
                 $@"<ServiceManifest xmlns='{ServiceExtensionLabelsProvider.XNSServiceManifest}'>
                 <ServiceTypes>
@@ -143,17 +133,14 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 </ServiceManifest>
                 ";
 
-            // Act
             var labels = await RunScenarioAsync();
 
-            // Assert
             labels.Should().Equal(new Dictionary<string, string>());
         }
 
         [Fact]
         public async void GetExtensionLabels_LabelsInManifestExtensions_GatheredCorrectly()
         {
-            // Arrange
             _rawServiceManifest =
                 $@"<ServiceManifest xmlns='{ServiceExtensionLabelsProvider.XNSServiceManifest}'>
                 <ServiceTypes>
@@ -171,10 +158,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 </ServiceManifest>
                 ";
 
-            // Act
             var labels = await RunScenarioAsync();
 
-            // Assert
             labels.Should().Equal(
                 new Dictionary<string, string>
                 {
@@ -186,7 +171,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void GetExtensionLabels_AppParamReplacements_Replaces()
         {
-            // Arrange
             _rawServiceManifest =
                 $@"<ServiceManifest xmlns='{ServiceExtensionLabelsProvider.XNSServiceManifest}'>
                   <ServiceTypes>
@@ -205,10 +189,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
 
             _appParams["someAppParam"] = "replaced successfully!";
 
-            // Act
             var labels = await RunScenarioAsync();
 
-            // Assert
             labels.Should().Equal(
                 new Dictionary<string, string>
                 {
@@ -220,7 +202,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void GetExtensionLabels_AppParamReplacements_MissingAppParams_ReplacesWithEmpty()
         {
-            // Arrange
             _rawServiceManifest =
                 $@"<ServiceManifest xmlns='{ServiceExtensionLabelsProvider.XNSServiceManifest}'>
                   <ServiceTypes>
@@ -237,10 +218,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                   </ServiceTypes>
                 </ServiceManifest>";
 
-            // Act
             var labels = await RunScenarioAsync();
 
-            // Assert
             labels.Should().Equal(
                 new Dictionary<string, string>
                 {
@@ -252,7 +231,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void GetExtensionLabels_MultipleExtensions_OnlyYarpLabelsAreGathered()
         {
-            // Arrange
             _rawServiceManifest =
                 $@"<ServiceManifest xmlns='{ServiceExtensionLabelsProvider.XNSServiceManifest}'>
                 <ServiceTypes>
@@ -275,10 +253,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 </ServiceManifest>
                 ";
 
-            // Act
             var labels = await RunScenarioAsync();
 
-            // Assert
             labels.Should().Equal(
                 new Dictionary<string, string>
                 {
@@ -290,7 +266,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void GetExtensionLabels_OverridesEnabled_NewLabelsFromPropertiesGatheredCorrectly()
         {
-            // Arrange
             _rawServiceManifest =
                 $@"<ServiceManifest xmlns='{ServiceExtensionLabelsProvider.XNSServiceManifest}'>
                 <ServiceTypes>
@@ -313,10 +288,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                     { "YARP.routes.route1.Hosts", "example.com" },
                 };
 
-            // Act
             var labels = await RunScenarioAsync();
 
-            // Assert
             labels.Should().Equal(
                 new Dictionary<string, string>
                 {
@@ -329,7 +302,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void GetExtensionLabels_OverridesEnabledValueCaseInsensitive_OverridesAreEnabled()
         {
-            // Arrange
             _rawServiceManifest =
                 $@"<ServiceManifest xmlns='{ServiceExtensionLabelsProvider.XNSServiceManifest}'>
                 <ServiceTypes>
@@ -352,10 +324,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                     { "YARP.routes.route1.Hosts", "example.com" },
                 };
 
-            // Act
             var labels = await RunScenarioAsync();
 
-            // Assert
             labels.Should().Equal(
                 new Dictionary<string, string>
                 {
@@ -368,7 +338,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void GetExtensionLabels_OverridesEnabled_OnlyYarpNamespacePropertiesGathered()
         {
-            // Arrange
             _rawServiceManifest =
                 $@"<ServiceManifest xmlns='{ServiceExtensionLabelsProvider.XNSServiceManifest}'>
                 <ServiceTypes>
@@ -392,10 +361,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                     { "WhatIsThisNamespace.value", "42" },
                 };
 
-            // Act
             var labels = await RunScenarioAsync();
 
-            // Assert
             labels.Should().Equal(
                 new Dictionary<string, string>
                 {
@@ -407,7 +374,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void GetExtensionLabels_OverridesEnabled_PropertiesOverrideManifestCorrectly()
         {
-            // Arrange
             _rawServiceManifest =
                 $@"<ServiceManifest xmlns='{ServiceExtensionLabelsProvider.XNSServiceManifest}'>
                 <ServiceTypes>
@@ -431,10 +397,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                     { "YARP.Enable", "false" },
                 };
 
-            // Act
             var labels = await RunScenarioAsync();
 
-            // Assert
             labels.Should().Equal(
                 new Dictionary<string, string>
                 {
@@ -447,7 +411,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void GetExtensionLabels_OverridesEnabled_LabelKeysAreCaseSensitive()
         {
-            // Arrange
             _rawServiceManifest =
                 $@"<ServiceManifest xmlns='{ServiceExtensionLabelsProvider.XNSServiceManifest}'>
                 <ServiceTypes>
@@ -471,10 +434,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                     { "YARP.Routes.route1.HOST", "another.example.com" },
                 };
 
-            // Act
             var labels = await RunScenarioAsync();
 
-            // Assert
             labels.Should().Equal(
                 new Dictionary<string, string>
                 {
@@ -488,7 +449,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void GetExtensionLabels_OverridesDisabiled_PropertiesNotQueried()
         {
-            // Arrange
             _rawServiceManifest =
                 $@"<ServiceManifest xmlns='{ServiceExtensionLabelsProvider.XNSServiceManifest}'>
                 <ServiceTypes>
@@ -512,10 +472,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                     { "YARP.Enable", "false" },
                 };
 
-            // Act
             var labels = await RunScenarioAsync();
 
-            // Assert
             labels.Should().Equal(
                 new Dictionary<string, string>
                 {
@@ -530,7 +488,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void GetExtensionLabels_CaseDifferingLabelKeys_LabelKeysAreCaseSensitive()
         {
-            // Arrange
             _rawServiceManifest =
                 $@"<ServiceManifest xmlns='{ServiceExtensionLabelsProvider.XNSServiceManifest}'>
                 <ServiceTypes>
@@ -555,10 +512,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                     { "YARP.routes.Route1.HOSTS", "etc.example.com" },
                 };
 
-            // Act
             var labels = await RunScenarioAsync();
 
-            // Assert
             labels.Should().Equal(
                 new Dictionary<string, string>
                 {
@@ -573,7 +528,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void GetExtensionLabels_OverridesNotExplicitlyDisabiled_PropertiesNotQueriedByDefault()
         {
-            // Arrange
             _rawServiceManifest =
                 $@"<ServiceManifest xmlns='{ServiceExtensionLabelsProvider.XNSServiceManifest}'>
                 <ServiceTypes>
@@ -596,10 +550,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                     { "YARP.Enable", "false" },
                 };
 
-            // Act
             var labels = await RunScenarioAsync();
 
-            // Assert
             labels.Should().Equal(
                 new Dictionary<string, string>
                 {
@@ -613,20 +565,16 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void GetExtensionLabels_InvalidManifestXml_Throws()
         {
-            // Arrange
             _rawServiceManifest = $@"<this is no xml my man";
 
-            // Act
             Func<Task> func = () => RunScenarioAsync();
 
-            // Assert
             await func.Should().ThrowAsync<ConfigException>();
         }
 
         [Fact]
         public async void GetExtensionLabels_DuplicatedLabelKeysInManifest_ShouldThrowException()
         {
-            // Arrange
             _rawServiceManifest =
                 $@"<ServiceManifest xmlns='{ServiceExtensionLabelsProvider.XNSServiceManifest}'>
                 <ServiceTypes>
@@ -645,17 +593,14 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 </ServiceManifest>
                 ";
 
-            // Act
             Func<Task> func = () => RunScenarioAsync();
 
-            // Assert
             await func.Should().ThrowAsync<ConfigException>();
         }
 
         [Fact]
         public async void GetExtensionLabels_OverSizeLimit_ShouldThrowException()
         {
-            // Arrange
             var longBadString = new string('*', 1024 * 1024);
             _rawServiceManifest =
             $@"<ServiceManifest xmlns='{ServiceExtensionLabelsProvider.XNSServiceManifest}'>
@@ -673,17 +618,14 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
             </ServiceManifest>
             ";
 
-            // Act
             Func<Task> func = () => RunScenarioAsync();
 
-            // Assert
             await func.Should().ThrowAsync<ConfigException>();
         }
 
         [Fact]
         public async void GetExtensionLabels_WithDTD_ShouldThrowException()
         {
-            // Arrange
             _rawServiceManifest =
                 $@"
                 <!DOCTYPE xxe [
@@ -704,10 +646,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 </ServiceManifest>
                 ";
 
-            // Act
             Func<Task> func = () => RunScenarioAsync();
 
-            // Assert
             await func.Should().ThrowAsync<ConfigException>();
         }
 

--- a/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/Util/CachedServiceFabricCallerTests.cs
+++ b/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/Util/CachedServiceFabricCallerTests.cs
@@ -32,7 +32,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public async void GetApplicationListAsync_ServiceFabricFails_ResultIsCached()
         {
-            // Arrange
             var caller = Create<CachedServiceFabricCaller>();
             var originalApps = new List<ApplicationWrapper> { SFTestHelpers.FakeApp("MyApp") };
 
@@ -44,13 +43,11 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 .ThrowsAsync(new Exception("the cake is a lie"))
                 .ThrowsAsync(new Exception("the cake is still a lie"));
 
-            // Act & Assert
             await CallThreeTimesAndAssertAsync(() => caller.GetApplicationListAsync(CancellationToken.None));
         }
         [Fact]
         public async void GetServiceListAsync_ServiceFabricFails_ResultIsCached()
         {
-            // Arrange
             var caller = Create<CachedServiceFabricCaller>();
             var originalServices = new List<ServiceWrapper> { SFTestHelpers.FakeService(new Uri("http://localhost/app1/sv1"), "MyServiceType") };
             Mock<IQueryClientWrapper>()
@@ -62,13 +59,11 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 .ThrowsAsync(new Exception("the cake is a lie"))
                 .ThrowsAsync(new Exception("the cake is still a lie"));
 
-            // Act
             await CallThreeTimesAndAssertAsync(() => caller.GetServiceListAsync(new Uri("http://localhost/app1"), CancellationToken.None));
         }
         [Fact]
         public async void GetPartitionListAsync_ServiceFabricFails_ResultIsCached()
         {
-            // Arrange
             var caller = Create<CachedServiceFabricCaller>();
             var originalPartitionIds = new List<Guid> { Guid.NewGuid() };
             Mock<IQueryClientWrapper>()
@@ -80,13 +75,11 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 .ThrowsAsync(new Exception("the cake is a lie"))
                 .ThrowsAsync(new Exception("the cake is still a lie"));
 
-            // Act & Assert
             await CallThreeTimesAndAssertAsync(() => caller.GetPartitionListAsync(new Uri("http://localhost/app1/sv1"), CancellationToken.None));
         }
         [Fact]
         public async void GetReplicaListAsync_ServiceFabricFails_ResultIsCached()
         {
-            // Arrange
             var caller = Create<CachedServiceFabricCaller>();
             var partitionId = Guid.NewGuid();
             var originalReplicas = new List<ReplicaWrapper> { SFTestHelpers.FakeReplica(new Uri("http://localhost/app1/sv1"), 1) };
@@ -99,14 +92,12 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 .ThrowsAsync(new Exception("the cake is a lie"))
                 .ThrowsAsync(new Exception("the cake is still a lie"));
 
-            // Act & Assert
             await CallThreeTimesAndAssertAsync(() => caller.GetReplicaListAsync(partitionId, CancellationToken.None));
         }
 
         [Fact]
         public async void GetServiceManifestName_ServiceFabricFails_ResultIsCached()
         {
-            // Arrange
             var caller = Create<CachedServiceFabricCaller>();
             var originalServiceManifestName = "MyCoolManifest";
             Mock<IQueryClientWrapper>()
@@ -121,13 +112,11 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 .ThrowsAsync(new Exception("the cake is a lie"))
                 .ThrowsAsync(new Exception("the cake is still a lie"));
 
-            // Act & Assert
             await CallThreeTimesAndAssertAsync(() => caller.GetServiceManifestName("AppName", "1.2.3", "MyServiceType", CancellationToken.None));
         }
         [Fact]
         public async void GetServiceManifestAsync_ServiceFabricFails_ResultIsCached()
         {
-            // Arrange
             var caller = Create<CachedServiceFabricCaller>();
             var originalRawServiceManifest = "<xml> </xml>";
             Mock<IServiceManagementClientWrapper>()
@@ -142,13 +131,11 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 .ThrowsAsync(new Exception("the cake is a lie"))
                 .ThrowsAsync(new Exception("the cake is still a lie"));
 
-            // Act & Assert
             await CallThreeTimesAndAssertAsync(() => caller.GetServiceManifestAsync("AppName", "1.2.3", "MyCoolManifest", CancellationToken.None));
         }
         [Fact]
         public async void EnumeratePropertiesAsync_ServiceFabricFails_ResultIsCached()
         {
-            // Arrange
             var caller = Create<CachedServiceFabricCaller>();
             var originalProperties = new Dictionary<string, string> { { "key", "value" } };
             Mock<IPropertyManagementClientWrapper>()
@@ -161,7 +148,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 .ThrowsAsync(new Exception("the cake is a lie"))
                 .ThrowsAsync(new Exception("the cake is still a lie"));
 
-            // Act & Assert
             await CallThreeTimesAndAssertAsync(() => caller.EnumeratePropertiesAsync(new Uri("http://localhost/app1/sv1"), CancellationToken.None));
         }
 
@@ -169,13 +155,11 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         {
             var almostExpirationOffset = CachedServiceFabricCaller.CacheExpirationOffset.Subtract(TimeSpan.FromTicks(1));
 
-            // Act
             var firstResult = await call(); // First call is successful
             _clock.AdvanceClockBy(almostExpirationOffset);
             var secondResult = await call(); // Second call should use last result from cache
             _clock.AdvanceClockBy(almostExpirationOffset);
 
-            // Assert
             secondResult.Should().BeEquivalentTo(firstResult);
             await call.Should().ThrowAsync<Exception>(); // Third call fails
         }

--- a/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/Util/FabricServiceEndpointSelectorTests.cs
+++ b/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/Util/FabricServiceEndpointSelectorTests.cs
@@ -14,7 +14,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public void FabricServiceEndpointSelector_SelectsNamedEndpoint()
         {
-            // Arrange
             var serviceName = new Uri("fabric:/Application/Service");
             var emptyStringMatchesAnyListener = true;
             var listenerName = "ServiceEndpoint";
@@ -37,7 +36,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 emptyStringMatchesAnyListener: emptyStringMatchesAnyListener);
             ServiceEndpointCollection.TryParseEndpointsString(endpoints, out var serviceEndpointCollection);
 
-            // Act + Assert
             FabricServiceEndpointSelector.TryGetEndpoint(fabricServiceEndpoint, serviceEndpointCollection, out var endpointUri)
                 .Should().BeTrue("There should be a matching endpoint");
             endpointUri.ToString().Should().BeEquivalentTo(endpointAddress);
@@ -46,7 +44,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public void FabricServiceEndpointSelector_SelectsEndpointInOrdinalStringOrder_EmptyListenerName()
         {
-            // Arrange
             var serviceName = new Uri("fabric:/Application/Service");
             var emptyStringMatchesAnyListener = true;
             var allowedScheme = "https";
@@ -65,7 +62,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 emptyStringMatchesAnyListener: emptyStringMatchesAnyListener);
             ServiceEndpointCollection.TryParseEndpointsString(endpoints, out var serviceEndpointCollection);
 
-            // Act + Assert
             FabricServiceEndpointSelector.TryGetEndpoint(fabricServiceEndpoint, serviceEndpointCollection, out var endpointUri)
                 .Should().BeTrue("There should be a matching endpoint");
             endpointUri.ToString().Should().BeEquivalentTo("https://localhost:123/selected");
@@ -74,7 +70,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public void FabricServiceEndpointSelector_SelectsEmptyListenerEndpoint_EmptyListenerName()
         {
-            // Arrange
             var serviceName = new Uri("fabric:/Application/Service");
             var emptyStringMatchesAnyListener = false;
             var listenerName = string.Empty;
@@ -97,7 +92,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 emptyStringMatchesAnyListener: emptyStringMatchesAnyListener);
             ServiceEndpointCollection.TryParseEndpointsString(endpoints, out var serviceEndpointCollection);
 
-            // Act + Assert
             FabricServiceEndpointSelector.TryGetEndpoint(fabricServiceEndpoint, serviceEndpointCollection, out var endpointUri)
                 .Should().BeTrue("There should be a matching endpoint");
             endpointUri.ToString().Should().BeEquivalentTo(endpointAddress);
@@ -106,7 +100,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public void FabricServiceEndpointSelector_NoMatchingListenerName()
         {
-            // Arrange
             var serviceName = new Uri("fabric:/Application/Service");
             var emptyStringMatchesAnyListener = true;
             var listenerName = "ServiceEndpoint";
@@ -127,7 +120,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 emptyStringMatchesAnyListener: emptyStringMatchesAnyListener);
             ServiceEndpointCollection.TryParseEndpointsString(endpoints, out var serviceEndpointCollection);
 
-            // Act + Assert
             FabricServiceEndpointSelector.TryGetEndpoint(fabricServiceEndpoint, serviceEndpointCollection, out var endpointUri)
                 .Should().BeFalse("No matching named endpoint.");
             endpointUri.Should().BeNull();
@@ -136,7 +128,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public void FabricServiceEndpointSelector_NoMatchingEndpointScheme()
         {
-            // Arrange
             var serviceName = new Uri("fabric:/Application/Service");
             var emptyStringMatchesAnyListener = true;
             var listenerName = "ServiceEndpoint";
@@ -159,7 +150,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 emptyStringMatchesAnyListener: emptyStringMatchesAnyListener);
             ServiceEndpointCollection.TryParseEndpointsString(endpoints, out var serviceEndpointCollection);
 
-            // Act + Assert
             FabricServiceEndpointSelector.TryGetEndpoint(fabricServiceEndpoint, serviceEndpointCollection, out var endpointUri)
                 .Should().BeFalse("No matching endpoint with specified scheme.");
             endpointUri.Should().BeNull();
@@ -168,7 +158,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public void FabricServiceEndpointSelector_NoExceptionOnMalformedUri_NamedListener()
         {
-            // Arrange
             var serviceName = new Uri("fabric:/Application/Service");
             var emptyStringMatchesAnyListener = true;
             var listenerName = "ServiceEndpoint";
@@ -191,7 +180,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 emptyStringMatchesAnyListener: emptyStringMatchesAnyListener);
             ServiceEndpointCollection.TryParseEndpointsString(endpoints, out var serviceEndpointCollection);
 
-            // Act + Assert
             FabricServiceEndpointSelector.TryGetEndpoint(fabricServiceEndpoint, serviceEndpointCollection, out var endpointUri)
                 .Should().BeTrue("There should be a matching endpoint");
             endpointUri.ToString().Should().BeEquivalentTo(endpointAddress);
@@ -200,7 +188,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public void FabricServiceEndpointSelector_NoExceptionOnMalformedUri_EmptyListener()
         {
-            // Arrange
             var serviceName = new Uri("fabric:/Application/Service");
             var emptyStringMatchesAnyListener = true;
             var listenerName = string.Empty;
@@ -223,7 +210,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 emptyStringMatchesAnyListener: emptyStringMatchesAnyListener);
             ServiceEndpointCollection.TryParseEndpointsString(endpoints, out var serviceEndpointCollection);
 
-            // Act + Assert
             FabricServiceEndpointSelector.TryGetEndpoint(fabricServiceEndpoint, serviceEndpointCollection, out var endpointUri)
                 .Should().BeTrue("There should be a matching endpoint");
             endpointUri.ToString().Should().BeEquivalentTo(endpointAddress);
@@ -232,7 +218,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public void FabricServiceEndpointSelector_SelectsEndpointBasedOnScheme_MultipleRequestedListeners()
         {
-            // Arrange
             var serviceName = new Uri("fabric:/Application/Service");
             var emptyStringMatchesAnyListener = true;
             var listenerNames = new[] { "ServiceEndpointSecure", string.Empty };
@@ -253,7 +238,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 emptyStringMatchesAnyListener: emptyStringMatchesAnyListener);
             ServiceEndpointCollection.TryParseEndpointsString(endpoints, out var serviceEndpointCollection);
 
-            // Act + Assert
             FabricServiceEndpointSelector.TryGetEndpoint(fabricServiceEndpoint, serviceEndpointCollection, out var endpointUri)
                 .Should().BeTrue("There should be a matching endpoint");
             endpointUri.ToString().Should().BeEquivalentTo(endpointAddress);
@@ -262,7 +246,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public void FabricServiceEndpointSelector_NoValidEndpointBasedOnScheme_NamedListener()
         {
-            // Arrange
             var serviceName = new Uri("fabric:/Application/Service");
             var emptyStringMatchesAnyListener = true;
             var listenerName = "ServiceEndpointSecure";
@@ -281,7 +264,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 emptyStringMatchesAnyListener: emptyStringMatchesAnyListener);
             ServiceEndpointCollection.TryParseEndpointsString(endpoints, out var serviceEndpointCollection);
 
-            // Act + Assert
             FabricServiceEndpointSelector.TryGetEndpoint(fabricServiceEndpoint, serviceEndpointCollection, out var endpointUri)
                 .Should().BeFalse("There should be no matching endpoint because of scheme mismatch.");
             endpointUri.Should().BeNull();
@@ -290,7 +272,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public void FabricServiceEndpointSelector_ReturnsFalseOnMalformedUri_NamedListener()
         {
-            // Arrange
             var serviceName = new Uri("fabric:/Application/Service");
             var emptyStringMatchesAnyListener = true;
             var listenerName = "ServiceEndpoint";
@@ -313,7 +294,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 emptyStringMatchesAnyListener: emptyStringMatchesAnyListener);
             ServiceEndpointCollection.TryParseEndpointsString(endpoints, out var serviceEndpointCollection);
 
-            // Act + Assert
             FabricServiceEndpointSelector.TryGetEndpoint(fabricServiceEndpoint, serviceEndpointCollection, out var endpointUri)
                 .Should().BeFalse("There should be no matching endpoint");
             endpointUri.Should().BeNull();
@@ -322,7 +302,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public void FabricServiceEndpointSelector_ReturnsFalseOnMalformedUri_EmptyListenerName()
         {
-            // Arrange
             var serviceName = new Uri("fabric:/Application/Service");
             var emptyStringMatchesAnyListener = true;
             var listenerName = string.Empty;
@@ -345,7 +324,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 emptyStringMatchesAnyListener: emptyStringMatchesAnyListener);
             ServiceEndpointCollection.TryParseEndpointsString(endpoints, out var serviceEndpointCollection);
 
-            // Act + Assert
             FabricServiceEndpointSelector.TryGetEndpoint(fabricServiceEndpoint, serviceEndpointCollection, out var endpointUri)
                 .Should().BeFalse("There should be no matching endpoint");
             endpointUri.Should().BeNull();

--- a/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/Util/LabelsParserTests.cs
+++ b/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/Util/LabelsParserTests.cs
@@ -18,7 +18,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public void BuildCluster_CompleteLabels_Works()
         {
-            // Arrange
             var labels = new Dictionary<string, string>()
             {
                 { "YARP.Enable", "true" },
@@ -45,10 +44,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 { "YARP.Backend.Metadata.Foo", "Bar" },
             };
 
-            // Act
             var cluster = LabelsParser.BuildCluster(_testServiceName, labels);
 
-            // Assert
             var expectedCluster = new Cluster
             {
                 Id = "MyCoolClusterId",
@@ -103,16 +100,13 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public void BuildCluster_IncompleteLabels_UsesDefaultValues()
         {
-            // Arrange
             var labels = new Dictionary<string, string>()
             {
                 { "YARP.Backend.BackendId", "MyCoolClusterId" },
             };
 
-            // Act
             var cluster = LabelsParser.BuildCluster(_testServiceName, labels);
 
-            // Assert
             var expectedCluster = new Cluster
             {
                 Id = "MyCoolClusterId",
@@ -137,17 +131,14 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [InlineData("FALSE", false)]
         public void BuildCluster_HealthCheckOptions_Enabled_Valid(string label, bool expected)
         {
-            // Arrange
             var labels = new Dictionary<string, string>()
             {
                 { "YARP.Backend.BackendId", "MyCoolClusterId" },
                 { "YARP.Backend.HealthCheck.Active.Enabled", label },
             };
 
-            // Act
             var cluster = LabelsParser.BuildCluster(_testServiceName, labels);
 
-            // Assert
             cluster.HealthCheck.Active.Enabled.Should().Be(expected);
         }
 
@@ -156,24 +147,20 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [InlineData("")]
         public void BuildCluster_HealthCheckOptions_Enabled_Invalid(string label)
         {
-            // Arrange
             var labels = new Dictionary<string, string>()
             {
                 { "YARP.Backend.BackendId", "MyCoolClusterId" },
                 { "YARP.Backend.HealthCheck.Active.Enabled", label },
             };
 
-            // Act
             Action action = () => LabelsParser.BuildCluster(_testServiceName, labels);
 
-            // Assert
             action.Should().Throw<ConfigException>();
         }
 
         [Fact]
         public void BuildCluster_MissingBackendId_UsesServiceName()
         {
-            // Arrange
             var labels = new Dictionary<string, string>()
             {
                 { "YARP.Backend.Quota.Burst", "2.3" },
@@ -183,10 +170,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 { "YARP.Backend.HealthCheck.Active.Interval", "5" },
             };
 
-            // Act
             var cluster = LabelsParser.BuildCluster(_testServiceName, labels);
 
-            // Assert
             cluster.Id.Should().Be(_testServiceName.ToString());
         }
 
@@ -195,24 +180,20 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [InlineData("YARP.Backend.HealthCheck.Active.Timeout", "foobar")]
         public void BuildCluster_InvalidValues_Throws(string key, string invalidValue)
         {
-            // Arrange
             var labels = new Dictionary<string, string>()
             {
                 { "YARP.Backend.BackendId", "MyCoolClusterId" },
                 { key, invalidValue },
             };
 
-            // Act
             Func<Cluster> func = () => LabelsParser.BuildCluster(_testServiceName, labels);
 
-            // Assert
             func.Should().Throw<ConfigException>().WithMessage($"Could not convert label {key}='{invalidValue}' *");
         }
 
         [Fact]
         public void BuildRoutes_SingleRoute_Works()
         {
-            // Arrange
             var labels = new Dictionary<string, string>()
             {
                 { "YARP.Backend.BackendId", "MyCoolClusterId" },
@@ -227,10 +208,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 { "YARP.Routes.MyRoute.Transforms.[1].When", "Success" },
             };
 
-            // Act
             var routes = LabelsParser.BuildRoutes(_testServiceName, labels);
 
-            // Assert
             var expectedRoutes = new List<ProxyRoute>
             {
                 new ProxyRoute
@@ -269,17 +248,14 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public void BuildRoutes_IncompleteRoute_UsesDefaults()
         {
-            // Arrange
             var labels = new Dictionary<string, string>()
             {
                 { "YARP.Backend.BackendId", "MyCoolClusterId" },
                 { "YARP.Routes.MyRoute.Hosts", "example.com" },
             };
 
-            // Act
             var routes = LabelsParser.BuildRoutes(_testServiceName, labels);
 
-            // Assert
             var expectedRoutes = new List<ProxyRoute>
             {
                 new ProxyRoute
@@ -303,17 +279,14 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public void BuildRoutes_SingleRouteWithSemanticallyInvalidRule_WorksAndDoesNotThrow()
         {
-            // Arrange
             var labels = new Dictionary<string, string>()
             {
                 { "YARP.Backend.BackendId", "MyCoolClusterId" },
                 { "YARP.Routes.MyRoute.Hosts", "'this invalid thing" },
             };
 
-            // Act
             var routes = LabelsParser.BuildRoutes(_testServiceName, labels);
 
-            // Assert
             var expectedRoutes = new List<ProxyRoute>
             {
                 new ProxyRoute
@@ -336,7 +309,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [InlineData(1)]
         public void BuildRoutes_MissingBackendId_UsesServiceName(int scenario)
         {
-            // Arrange
             var labels = new Dictionary<string, string>()
             {
                 { "YARP.Routes.MyRoute.Hosts", "example.com" },
@@ -348,10 +320,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 labels.Add("YARP.Backend.BackendId", string.Empty);
             }
 
-            // Act
             var routes = LabelsParser.BuildRoutes(_testServiceName, labels);
 
-            // Assert
             var expectedRoutes = new List<ProxyRoute>
             {
                 new ProxyRoute
@@ -372,16 +342,13 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public void BuildRoutes_MissingHost_Works()
         {
-            // Arrange
             var labels = new Dictionary<string, string>()
             {
                 { "YARP.Routes.MyRoute.Path", "/{**catchall}" },
             };
 
-            // Act
             var routes = LabelsParser.BuildRoutes(_testServiceName, labels);
 
-            // Assert
             var expectedRoutes = new List<ProxyRoute>
             {
                 new ProxyRoute
@@ -401,7 +368,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public void BuildRoutes_InvalidOrder_Throws()
         {
-            // Arrange
             var labels = new Dictionary<string, string>()
             {
                 { "YARP.Backend.BackendId", "MyCoolClusterId" },
@@ -409,10 +375,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 { "YARP.Routes.MyRoute.Order", "this is no number" },
             };
 
-            // Act
             Func<List<ProxyRoute>> func = () => LabelsParser.BuildRoutes(_testServiceName, labels);
 
-            // Assert
             func.Should()
                 .Throw<ConfigException>()
                 .WithMessage("Could not convert label YARP.Routes.MyRoute.Order='this is no number' *");
@@ -426,7 +390,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [InlineData("Hyphen-Hyphen")]
         public void BuildRoutes_ValidRouteName_Works(string routeName)
         {
-            // Arrange
             var labels = new Dictionary<string, string>()
             {
                 { "YARP.Backend.BackendId", "MyCoolClusterId" },
@@ -434,10 +397,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 { $"YARP.Routes.{routeName}.Order", "2" },
             };
 
-            // Act
             var routes = LabelsParser.BuildRoutes(_testServiceName, labels);
 
-            // Assert
             var expectedRoutes = new List<ProxyRoute>
             {
                 new ProxyRoute
@@ -467,7 +428,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [InlineData("YARP.Routes.Funny+Chars.Hosts", "some value")]
         public void BuildRoutes_InvalidRouteName_Throws(string invalidKey, string value)
         {
-            // Arrange
             var labels = new Dictionary<string, string>()
             {
                 { "YARP.Backend.BackendId", "MyCoolClusterId" },
@@ -477,10 +437,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
             };
             labels[invalidKey] = value;
 
-            // Act
             Func<List<ProxyRoute>> func = () => LabelsParser.BuildRoutes(_testServiceName, labels);
 
-            // Assert
             func.Should()
                 .Throw<ConfigException>()
                 .WithMessage($"Invalid route name '*', should only contain alphanumerical characters, underscores or hyphens.");
@@ -492,7 +450,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [InlineData("YARP.Routes.MyRoute.Transforms.1.Response", "needs square brackets")]
         public void BuildRoutes_InvalidTransformIndex_Throws(string invalidKey, string value)
         {
-            // Arrange
             var labels = new Dictionary<string, string>()
             {
                 { "YARP.Backend.BackendId", "MyCoolClusterId" },
@@ -502,10 +459,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
             };
             labels[invalidKey] = value;
 
-            // Act
             Func<List<ProxyRoute>> func = () => LabelsParser.BuildRoutes(_testServiceName, labels);
 
-            // Assert
             func.Should()
                 .Throw<ConfigException>()
                 .WithMessage($"Invalid transform index '*', should be transform index wrapped in square brackets.");
@@ -526,7 +481,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [InlineData("YARP.....Routes.", "some value")]
         public void BuildRoutes_InvalidLabelKeys_IgnoresAndDoesNotThrow(string invalidKey, string value)
         {
-            // Arrange
             var labels = new Dictionary<string, string>()
             {
                 { "YARP.Backend.BackendId", "MyCoolClusterId" },
@@ -536,10 +490,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
             };
             labels[invalidKey] = value;
 
-            // Act
             var routes = LabelsParser.BuildRoutes(_testServiceName, labels);
 
-            // Assert
             var expectedRoutes = new List<ProxyRoute>
             {
                 new ProxyRoute
@@ -563,7 +515,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
         [Fact]
         public void BuildRoutes_MultipleRoutes_Works()
         {
-            // Arrange
             var labels = new Dictionary<string, string>()
             {
                 { "YARP.Backend.BackendId", "MyCoolClusterId" },
@@ -577,10 +528,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 { "YARP.Routes.EvenCoolerRoute.Order", "3" },
             };
 
-            // Act
             var routes = LabelsParser.BuildRoutes(_testServiceName, labels);
 
-            // Assert
             var expectedRoutes = new List<ProxyRoute>
             {
                 new ProxyRoute


### PR DESCRIPTION
Fixes https://github.com/microsoft/reverse-proxy/issues/527