### PR TITLE
Discoverer cleans up caches by removing expired entries before each iteration

### DIFF
--- a/src/ReverseProxy.ServiceFabric/Configuration/ServiceFabricServiceCollectionExtensions.cs
+++ b/src/ReverseProxy.ServiceFabric/Configuration/ServiceFabricServiceCollectionExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.ReverseProxy.ServiceFabric
             builder.Services.AddSingleton<IPropertyManagementClientWrapper, PropertyManagementClientWrapper>();
             builder.Services.AddSingleton<IServiceManagementClientWrapper, ServiceManagementClientWrapper>();
             builder.Services.AddSingleton<IHealthClientWrapper, HealthClientWrapper>();
-            builder.Services.AddSingleton<IServiceFabricCaller, CachedServiceFabricCaller>();
+            builder.Services.AddSingleton<ICachedServiceFabricCaller, CachedServiceFabricCaller>();
             builder.Services.AddSingleton<IServiceExtensionLabelsProvider, ServiceExtensionLabelsProvider>();
             builder.Services.AddSingleton<IDiscoverer, Discoverer>();
             builder.Services.AddSingleton<IProxyConfigProvider, ServiceFabricConfigProvider>();

--- a/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Discoverer.cs
+++ b/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Discoverer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ReverseProxy.ServiceFabric
         public static readonly string HealthReportProperty = "DynamicConfig";
 
         private readonly ILogger<Discoverer> _logger;
-        private readonly IServiceFabricCaller _serviceFabricCaller;
+        private readonly ICachedServiceFabricCaller _serviceFabricCaller;
         private readonly IServiceExtensionLabelsProvider _serviceFabricExtensionConfigProvider;
         private readonly IConfigValidator _configValidator;
         private readonly IOptionsMonitor<ServiceFabricDiscoveryOptions> _optionsMonitor;
@@ -35,7 +35,7 @@ namespace Microsoft.ReverseProxy.ServiceFabric
         /// </summary>
         public Discoverer(
             ILogger<Discoverer> logger,
-            IServiceFabricCaller serviceFabricCaller,
+            ICachedServiceFabricCaller serviceFabricCaller,
             IServiceExtensionLabelsProvider serviceFabricExtensionConfigProvider,
             IConfigValidator configValidator,
             IOptionsMonitor<ServiceFabricDiscoveryOptions> optionsMonitor)
@@ -52,6 +52,8 @@ namespace Microsoft.ReverseProxy.ServiceFabric
         {
             // Take a snapshot of current options and use that consistently for this execution.
             var options = _optionsMonitor.CurrentValue;
+
+            _serviceFabricCaller.CleanUpExpired();
 
             var discoveredBackends = new Dictionary<string, Cluster>(StringComparer.Ordinal);
             var discoveredRoutes = new List<ProxyRoute>();

--- a/src/ReverseProxy.ServiceFabric/ServiceDiscovery/ServiceExtensionLabelsProvider.cs
+++ b/src/ReverseProxy.ServiceFabric/ServiceDiscovery/ServiceExtensionLabelsProvider.cs
@@ -24,14 +24,14 @@ namespace Microsoft.ReverseProxy.ServiceFabric
         private const string ExtensionName = "YARP-preview";
 
         private readonly ILogger<ServiceExtensionLabelsProvider> _logger;
-        private readonly IServiceFabricCaller _serviceFabricCaller;
+        private readonly ICachedServiceFabricCaller _serviceFabricCaller;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceExtensionLabelsProvider"/> class.
         /// </summary>
         public ServiceExtensionLabelsProvider(
             ILogger<ServiceExtensionLabelsProvider> logger,
-            IServiceFabricCaller serviceFabricCaller)
+            ICachedServiceFabricCaller serviceFabricCaller)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _serviceFabricCaller = serviceFabricCaller ?? throw new ArgumentNullException(nameof(serviceFabricCaller));

--- a/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Util/CachedServiceFabricCaller.cs
+++ b/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Util/CachedServiceFabricCaller.cs
@@ -12,7 +12,7 @@ using Microsoft.ReverseProxy.Utilities;
 
 namespace Microsoft.ReverseProxy.ServiceFabric
 {
-    internal sealed class CachedServiceFabricCaller : IServiceFabricCaller
+    internal sealed class CachedServiceFabricCaller : ICachedServiceFabricCaller
     {
         public static readonly TimeSpan CacheExpirationOffset = TimeSpan.FromMinutes(30);
         private static readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(60);
@@ -148,6 +148,17 @@ namespace Microsoft.ReverseProxy.ServiceFabric
             Log.ReportHealth(_logger, healthReport.Kind, healthReport.HealthInformation.HealthState, healthReport.GetType().FullName, serviceName);
 
             _healthClientWrapper.ReportHealth(healthReport, sendOptions);
+        }
+
+        public void CleanUpExpired()
+        {
+            _applicationListCache.Cleanup();
+            _serviceListCache.Cleanup();
+            _partitionListCache.Cleanup();
+            _replicaListCache.Cleanup();
+            _serviceManifestCache.Cleanup();
+            _serviceManifestNameCache.Cleanup();
+            _propertiesCache.Cleanup();
         }
 
         private async Task<T> TryWithCacheFallbackAsync<T>(string operationName, Func<Task<T>> func, Cache<T> cache, string key, CancellationToken cancellation)

--- a/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Util/ICachedServiceFabricCaller.cs
+++ b/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Util/ICachedServiceFabricCaller.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ReverseProxy.ServiceFabric
     /// </summary>
     // TODO: think of a better name. Suggestions?
     // TODO: should we make this a singleton? Or make sure it is created just once?
-    internal interface IServiceFabricCaller
+    internal interface ICachedServiceFabricCaller
     {
         /// <summary>
         /// TODO.
@@ -55,5 +55,10 @@ namespace Microsoft.ReverseProxy.ServiceFabric
         /// Reports health on a Service Fabric entity.
         /// </summary>
         void ReportHealth(HealthReport healthReport, HealthReportSendOptions sendOptions);
+
+        /// <summary>
+        /// Cleans up the cache by removing expired entries.
+        /// </summary>
+        void CleanUpExpired();
     }
 }

--- a/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/ServiceExtensionLabelsProviderTests.cs
+++ b/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/ServiceExtensionLabelsProviderTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
 
         public ServiceExtensionLabelsProviderTests()
         {
-            Mock<IServiceFabricCaller>()
+            Mock<ICachedServiceFabricCaller>()
                 .Setup(
                     m => m.GetServiceManifestName(
                         ApplicationTypeName,
@@ -36,7 +36,7 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() => ServiceManifestName);
 
-            Mock<IServiceFabricCaller>()
+            Mock<ICachedServiceFabricCaller>()
                 .Setup(
                     m => m.GetServiceManifestAsync(
                         ApplicationTypeName,
@@ -45,7 +45,7 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() => _rawServiceManifest);
 
-            Mock<IServiceFabricCaller>()
+            Mock<ICachedServiceFabricCaller>()
                 .Setup(
                     m => m.EnumeratePropertiesAsync(
                         It.Is<Uri>(name => name.ToString() == ServiceFabricName),
@@ -482,7 +482,7 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                     { "YARP.EnableDynamicOverrides", "false" },
                 });
 
-            Mock<IServiceFabricCaller>().Verify(m => m.EnumeratePropertiesAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>()), Times.Never());
+            Mock<ICachedServiceFabricCaller>().Verify(m => m.EnumeratePropertiesAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>()), Times.Never());
         }
 
         [Fact]
@@ -559,7 +559,7 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                     { "YARP.routes.route1.host", "example.com" },
                 });
 
-            Mock<IServiceFabricCaller>().Verify(m => m.EnumeratePropertiesAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>()), Times.Never());
+            Mock<ICachedServiceFabricCaller>().Verify(m => m.EnumeratePropertiesAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>()), Times.Never());
         }
 
         [Fact]


### PR DESCRIPTION
Discoverer calls a new `ICachedServiceFabricCaller.CleanUpExpired` method before each discovery cycle to remove expired cached entries. This PR also renames `IServiceFabricCaller` to `ICachedServiceFabricCaller`.