### PR TITLE
String allocation-free label key matching in LabelsParser

### DIFF
--- a/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Util/LabelsParser.cs
+++ b/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Util/LabelsParser.cs
@@ -309,31 +309,30 @@ namespace Microsoft.ReverseProxy.ServiceFabric
         private static bool ContainsKey(string routeName, string expectedKeyName, string actualKey, out int keyNameEnd)
         {
             keyNameEnd = -1;
-            var prefixStart = actualKey.IndexOf(RoutesLabelsPrefix, StringComparison.Ordinal);
-            if (prefixStart < 0)
+            if (!actualKey.StartsWith(RoutesLabelsPrefix, StringComparison.Ordinal))
             {
                 return false;
             }
 
-            var routeNameStart = actualKey.IndexOf(routeName, prefixStart + RoutesLabelsPrefix.Length, StringComparison.Ordinal);
-            if (routeNameStart < 0)
+            var routeNamePart = actualKey.AsSpan().Slice(RoutesLabelsPrefix.Length);
+            if (!routeNamePart.StartsWith(routeName, StringComparison.Ordinal))
             {
                 return false;
             }
 
-            var routeNameEnd = routeNameStart + routeName.Length;
+            var routeNameEnd = RoutesLabelsPrefix.Length + routeName.Length;
             if (actualKey.Length == routeNameEnd || actualKey[routeNameEnd] != '.')
             {
                 return false;
             }
 
-            var keyNameStart = actualKey.IndexOf(expectedKeyName, routeNameEnd, StringComparison.Ordinal);
-            if (keyNameStart < 0)
+            var keyPart = routeNamePart.Slice(routeName.Length + 1);
+            if (!keyPart.StartsWith(expectedKeyName, StringComparison.Ordinal))
             {
                 return false;
             }
 
-            keyNameEnd = keyNameStart + expectedKeyName.Length;
+            keyNameEnd = routeNameEnd + 1 + expectedKeyName.Length;
 
             return true;
         }

--- a/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Util/LabelsParser.cs
+++ b/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Util/LabelsParser.cs
@@ -8,8 +8,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using Microsoft.ReverseProxy.Abstractions;
-using Microsoft.ReverseProxy.Utilities;
-using Microsoft.ReverseProxy.ServiceFabric.Utilities;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.ReverseProxy.ServiceFabric
@@ -20,10 +18,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric
     // TODO: this is probably something that can be used in other integration modules apart from Service Fabric. Consider extracting to a general class.
     internal static class LabelsParser
     {
-        // TODO: decide which labels are needed and which default table (and to what values)
-        // Also probably move these defaults to the corresponding config entities.
-        internal static readonly int? DefaultRouteOrder = null;
-
         private static readonly Regex _allowedRouteNamesRegex = new Regex("^[a-zA-Z0-9_-]+$");
 
         /// <summary>
@@ -73,7 +67,7 @@ namespace Microsoft.ReverseProxy.ServiceFabric
             {
                 if (kvp.Key.Length > RoutesLabelsPrefix.Length && kvp.Key.StartsWith(RoutesLabelsPrefix, StringComparison.Ordinal))
                 {
-                    var suffix = new StringSegment(kvp.Key, RoutesLabelsPrefix.Length, kvp.Key.Length - RoutesLabelsPrefix.Length);
+                    var suffix = new StringSegment(kvp.Key).Subsegment(RoutesLabelsPrefix.Length);
                     var routeNameLength = suffix.IndexOf('.');
                     if (routeNameLength == -1)
                     {
@@ -222,7 +216,7 @@ namespace Microsoft.ReverseProxy.ServiceFabric
                         Path = path,
                         Headers = headerMatches.Count > 0 ? headerMatches.Select(hm => hm.Value).ToArray() : null
                     },
-                    Order = order ?? DefaultRouteOrder,
+                    Order = order,
                     ClusterId = backendId,
                     Metadata = metadata,
                     Transforms = transforms.Count > 0 ? transforms.Select(tr => tr.Value).ToList() : null

--- a/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Util/LabelsParser.cs
+++ b/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Util/LabelsParser.cs
@@ -104,9 +104,9 @@ namespace Microsoft.ReverseProxy.ServiceFabric
                     {
                         metadata.Add(kvp.Key.Substring(keyNameEnd), kvp.Value);
                     }
-                    else if (kvp.Key.StartsWith($"{thisRoutePrefix}.MatchHeaders.", StringComparison.Ordinal)) 
+                    else if (ContainsKey(routeName, "MatchHeaders.", kvp.Key, out keyNameEnd)) 
                     {
-                        var suffix = kvp.Key.Substring($"{thisRoutePrefix}.MatchHeaders.".Length);
+                        var suffix = kvp.Key.Substring(keyNameEnd);
                         var headerIndexLength = suffix.IndexOf('.');
                         if (headerIndexLength == -1)
                         {
@@ -123,7 +123,7 @@ namespace Microsoft.ReverseProxy.ServiceFabric
                             headerMatches.Add(headerIndex, new RouteHeader());
                         }
 
-                        var propertyName = kvp.Key.Substring($"{thisRoutePrefix}.MatchHeaders.{headerIndex}.".Length);
+                        var propertyName = kvp.Key.Substring(keyNameEnd + headerIndexLength + 1);
                         if (propertyName.Equals("Name", StringComparison.Ordinal)) 
                         {
                             headerMatches[headerIndex].Name = kvp.Value;

--- a/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/Util/LabelsParserTests.cs
+++ b/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/Util/LabelsParserTests.cs
@@ -298,7 +298,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                     {
                         Hosts = new[] { "example.com" },
                     },
-                    Order = LabelsParser.DefaultRouteOrder,
                     ClusterId = "MyCoolClusterId",
                     Metadata = new Dictionary<string, string>(),
                 },
@@ -329,7 +328,6 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                     {
                         Hosts = new[] { "'this invalid thing" },
                     },
-                    Order = LabelsParser.DefaultRouteOrder,
                     ClusterId = "MyCoolClusterId",
                     Metadata = new Dictionary<string, string>(),
                 },


### PR DESCRIPTION
LablesParser doesn't allocate strings while trying to match label keys against known parameter names.

Fixes #586