### PR TITLE
Relayer transfroms

### DIFF
--- a/samples/ReverseProxy.Direct.Sample/Startup.cs
+++ b/samples/ReverseProxy.Direct.Sample/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.ReverseProxy.Service.Proxy;
 using Microsoft.ReverseProxy.Service.RuntimeModel.Transforms;
 using Microsoft.Net.Http.Headers;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Microsoft.ReverseProxy.Sample
 {
@@ -42,15 +43,14 @@ namespace Microsoft.ReverseProxy.Sample
 
             // Copy all request headers except Host
             var transforms =
-                new Transforms(
-                    copyRequestHeaders: true,
-                    requestTransforms: Array.Empty<RequestParametersTransform>(),
-                    requestHeaderTransforms: new Dictionary<string, RequestHeaderTransform>()
+                new HttpTransforms()
+                {
+                    OnRequest = (context, request, destination) =>
                     {
-                        { HeaderNames.Host, new RequestHeaderValueTransform(string.Empty, append: false) }
-                    },
-                    responseHeaderTransforms: new Dictionary<string, ResponseHeaderTransform>(),
-                    responseTrailerTransforms: new Dictionary<string, ResponseHeaderTransform>());
+                        request.Headers.Host = null;
+                        return Task.CompletedTask;
+                    }
+                };
             var requestOptions = new RequestProxyOptions(TimeSpan.FromSeconds(100), null);
 
             app.UseRouting();

--- a/samples/ReverseProxy.Direct.Sample/Startup.cs
+++ b/samples/ReverseProxy.Direct.Sample/Startup.cs
@@ -50,7 +50,7 @@ namespace Microsoft.ReverseProxy.Sample
                 endpoints.MapControllers();
                 endpoints.Map("/{**catch-all}", async httpContext =>
                 {
-                    await httpProxy.ProxyAsync(httpContext, "https://localhost:10000/", httpClient, transformer, requestOptions);
+                    await httpProxy.ProxyAsync(httpContext, "https://localhost:10000/", httpClient, requestOptions, transformer);
                     var errorFeature = httpContext.Features.Get<IProxyErrorFeature>();
                     if (errorFeature != null)
                     {

--- a/samples/ReverseProxy.Direct.Sample/Startup.cs
+++ b/samples/ReverseProxy.Direct.Sample/Startup.cs
@@ -40,7 +40,7 @@ namespace Microsoft.ReverseProxy.Sample
             });
 
             // Copy all request headers except Host
-            var transforms = new CustomTransforms();
+            var transformer = new CustomTransformer(); // or HttpTransformer.Default;
             var requestOptions = new RequestProxyOptions(TimeSpan.FromSeconds(100), null);
 
             app.UseRouting();
@@ -50,7 +50,7 @@ namespace Microsoft.ReverseProxy.Sample
                 endpoints.MapControllers();
                 endpoints.Map("/{**catch-all}", async httpContext =>
                 {
-                    await httpProxy.ProxyAsync(httpContext, "https://localhost:10000/", httpClient, transforms, requestOptions);
+                    await httpProxy.ProxyAsync(httpContext, "https://localhost:10000/", httpClient, transformer, requestOptions);
                     var errorFeature = httpContext.Features.Get<IProxyErrorFeature>();
                     if (errorFeature != null)
                     {
@@ -61,7 +61,7 @@ namespace Microsoft.ReverseProxy.Sample
             });
         }
 
-        private class CustomTransforms : HttpTransforms
+        private class CustomTransformer : HttpTransformer
         {
             public override async Task TransformRequestAsync(HttpContext httpContext, HttpRequestMessage proxyRequest, string destinationPrefix)
             {

--- a/src/ReverseProxy/Abstractions/Config/ITransformBuilder.cs
+++ b/src/ReverseProxy/Abstractions/Config/ITransformBuilder.cs
@@ -21,6 +21,6 @@ namespace Microsoft.ReverseProxy.Service
         /// <summary>
         /// Builds the given transforms into executable rules.
         /// </summary>
-        HttpTransforms Build(IList<IDictionary<string, string>> rawTransforms);
+        HttpTransformer Build(IList<IDictionary<string, string>> rawTransforms);
     }
 }

--- a/src/ReverseProxy/Abstractions/Config/ITransformBuilder.cs
+++ b/src/ReverseProxy/Abstractions/Config/ITransformBuilder.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.ReverseProxy.Service.RuntimeModel.Transforms;
+using Microsoft.ReverseProxy.Service.Proxy;
 
 namespace Microsoft.ReverseProxy.Service
 {
@@ -21,6 +21,6 @@ namespace Microsoft.ReverseProxy.Service
         /// <summary>
         /// Builds the given transforms into executable rules.
         /// </summary>
-        Transforms Build(IList<IDictionary<string, string>> rawTransforms);
+        HttpTransforms Build(IList<IDictionary<string, string>> rawTransforms);
     }
 }

--- a/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
+++ b/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
@@ -77,7 +77,7 @@ namespace Microsoft.ReverseProxy.Middleware
 
                 ProxyTelemetry.Log.ProxyInvoke(cluster.ClusterId, routeConfig.Route.RouteId, destination.DestinationId);
 
-                await _httpProxy.ProxyAsync(context, destinationConfig.Address, reverseProxyFeature.ClusterConfig.HttpClient, routeConfig.Transforms, reverseProxyFeature.ClusterConfig.HttpRequestOptions);
+                await _httpProxy.ProxyAsync(context, destinationConfig.Address, reverseProxyFeature.ClusterConfig.HttpClient, routeConfig.Transformer, reverseProxyFeature.ClusterConfig.HttpRequestOptions);
             }
             finally
             {

--- a/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
+++ b/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
@@ -77,7 +77,7 @@ namespace Microsoft.ReverseProxy.Middleware
 
                 ProxyTelemetry.Log.ProxyInvoke(cluster.ClusterId, routeConfig.Route.RouteId, destination.DestinationId);
 
-                await _httpProxy.ProxyAsync(context, destinationConfig.Address, reverseProxyFeature.ClusterConfig.HttpClient, routeConfig.Transformer, reverseProxyFeature.ClusterConfig.HttpRequestOptions);
+                await _httpProxy.ProxyAsync(context, destinationConfig.Address, reverseProxyFeature.ClusterConfig.HttpClient, reverseProxyFeature.ClusterConfig.HttpRequestOptions, routeConfig.Transformer);
             }
             finally
             {

--- a/src/ReverseProxy/Service/Config/TransformBuilder.cs
+++ b/src/ReverseProxy/Service/Config/TransformBuilder.cs
@@ -247,13 +247,13 @@ namespace Microsoft.ReverseProxy.Service.Config
         }
 
         /// <inheritdoc/>
-        public HttpTransforms Build(IList<IDictionary<string, string>> rawTransforms)
+        public HttpTransformer Build(IList<IDictionary<string, string>> rawTransforms)
         {
             return BuildInternal(rawTransforms);
         }
 
         // This is separate from Build for testing purposes.
-        internal Transforms BuildInternal(IList<IDictionary<string, string>> rawTransforms)
+        internal StructuredTransformer BuildInternal(IList<IDictionary<string, string>> rawTransforms)
         {
             bool? copyRequestHeaders = null;
             bool? useOriginalHost = null;
@@ -566,7 +566,7 @@ namespace Microsoft.ReverseProxy.Service.Config
                 }
             }
 
-            return new Transforms(copyRequestHeaders, requestTransforms, requestHeaderTransforms, responseHeaderTransforms, responseTrailerTransforms);
+            return new StructuredTransformer(copyRequestHeaders, requestTransforms, requestHeaderTransforms, responseHeaderTransforms, responseTrailerTransforms);
         }
 
         private void TryCheckTooManyParameters(Action<Exception> onError, IDictionary<string, string> rawTransform, int expected)

--- a/src/ReverseProxy/Service/Config/TransformBuilder.cs
+++ b/src/ReverseProxy/Service/Config/TransformBuilder.cs
@@ -249,7 +249,7 @@ namespace Microsoft.ReverseProxy.Service.Config
         /// <inheritdoc/>
         public HttpTransforms Build(IList<IDictionary<string, string>> rawTransforms)
         {
-            return BuildInternal(rawTransforms).AdaptedTransforms;
+            return BuildInternal(rawTransforms);
         }
 
         // This is separate from Build for testing purposes.

--- a/src/ReverseProxy/Service/Config/TransformBuilder.cs
+++ b/src/ReverseProxy/Service/Config/TransformBuilder.cs
@@ -6,8 +6,8 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Routing.Template;
-using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
+using Microsoft.ReverseProxy.Service.Proxy;
 using Microsoft.ReverseProxy.Service.RuntimeModel.Transforms;
 using Microsoft.ReverseProxy.Utilities;
 
@@ -247,7 +247,13 @@ namespace Microsoft.ReverseProxy.Service.Config
         }
 
         /// <inheritdoc/>
-        public Transforms Build(IList<IDictionary<string, string>> rawTransforms)
+        public HttpTransforms Build(IList<IDictionary<string, string>> rawTransforms)
+        {
+            return BuildInternal(rawTransforms).AdaptedTransforms;
+        }
+
+        // This is separate from Build for testing purposes.
+        internal Transforms BuildInternal(IList<IDictionary<string, string>> rawTransforms)
         {
             bool? copyRequestHeaders = null;
             bool? useOriginalHost = null;

--- a/src/ReverseProxy/Service/Proxy/HttpProxy.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpProxy.cs
@@ -88,8 +88,8 @@ namespace Microsoft.ReverseProxy.Service.Proxy
             HttpContext context,
             string destinationPrefix,
             HttpMessageInvoker httpClient,
-            HttpTransformer transformer,
-            RequestProxyOptions requestOptions)
+            RequestProxyOptions requestOptions,
+            HttpTransformer transformer)
         {
             _ = context ?? throw new ArgumentNullException(nameof(context));
             _ = destinationPrefix ?? throw new ArgumentNullException(nameof(destinationPrefix));

--- a/src/ReverseProxy/Service/Proxy/HttpProxy.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpProxy.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -11,13 +10,11 @@ using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
-using Microsoft.ReverseProxy.Service.RuntimeModel.Transforms;
 using Microsoft.ReverseProxy.Telemetry;
 using Microsoft.ReverseProxy.Utilities;
 
@@ -33,12 +30,6 @@ namespace Microsoft.ReverseProxy.Service.Proxy
 #if NET
         private static readonly HttpVersionPolicy DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
 #endif
-
-        private static readonly HashSet<string> _responseHeadersToSkip = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            HeaderNames.TransferEncoding
-        };
-
         private readonly ILogger _logger;
         private readonly IClock _clock;
 
@@ -97,14 +88,14 @@ namespace Microsoft.ReverseProxy.Service.Proxy
             HttpContext context,
             string destinationPrefix,
             HttpMessageInvoker httpClient,
-            Transforms transforms,
+            HttpTransforms transforms,
             RequestProxyOptions requestOptions)
         {
             _ = context ?? throw new ArgumentNullException(nameof(context));
             _ = destinationPrefix ?? throw new ArgumentNullException(nameof(destinationPrefix));
             _ = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
 
-            transforms ??= Transforms.Empty;
+            transforms ??= HttpTransforms.Empty;
 
             // HttpClient overload for SendAsync changes response behavior to fully buffered which impacts performance
             // See discussion in https://github.com/microsoft/reverse-proxy/issues/458
@@ -118,21 +109,15 @@ namespace Microsoft.ReverseProxy.Service.Proxy
             {
                 var requestAborted = context.RequestAborted;
 
-                // :: Step 1: Create outgoing HttpRequestMessage
-                var destinationRequest = CreateRequestMessage(context, destinationPrefix, transforms.RequestTransforms, requestOptions);
-
                 var isClientHttp2 = ProtocolHelper.IsHttp2(context.Request.Protocol);
 
                 // NOTE: We heuristically assume gRPC-looking requests may require streaming semantics.
                 // See https://github.com/microsoft/reverse-proxy/issues/118 for design discussion.
                 var isStreamingRequest = isClientHttp2 && ProtocolHelper.IsGrpcContentType(context.Request.ContentType);
 
-                // :: Step 2: Setup copy of request body (background) Client --► Proxy --► Destination
-                // Note that we must do this before step (3) because step (3) may also add headers to the HttpContent that we set up here.
-                var requestContent = SetupRequestBodyCopy(context.Request, destinationRequest, isStreamingRequest, requestAborted);
-
-                // :: Step 3: Copy request headers Client --► Proxy --► Destination
-                CopyRequestHeaders(context, destinationRequest, transforms);
+                // :: Step 1-3: Create outgoing HttpRequestMessage
+                var (destinationRequest, requestContent) = await CreateRequestMessageAsync(
+                    context, destinationPrefix, transforms, requestOptions, isStreamingRequest, requestAborted);
 
                 // :: Step 4: Send the outgoing request using HttpClient
                 HttpResponseMessage destinationResponse;
@@ -182,12 +167,13 @@ namespace Microsoft.ReverseProxy.Service.Proxy
                 if (requestContent != null && !requestContent.Started)
                 {
                     // TODO: HttpClient might not need to read the body in some scenarios, such as an early auth failure with Expect: 100-continue.
+                    // https://github.com/microsoft/reverse-proxy/issues/617
                     throw new InvalidOperationException("Proxying the Client request body to the Destination server hasn't started. This is a coding defect.");
                 }
 
                 // :: Step 5: Copy response status line Client ◄-- Proxy ◄-- Destination
                 // :: Step 6: Copy response headers Client ◄-- Proxy ◄-- Destination
-                CopyResponseStatusAndHeaders(destinationResponse, context, transforms.ResponseHeaderTransforms);
+                await CopyResponseStatusAndHeadersAsync(destinationResponse, context, transforms);
 
                 // :: Step 7-A: Check for a 101 upgrade response, this takes care of WebSockets as well as any other upgradeable protocol.
                 if (destinationResponse.StatusCode == HttpStatusCode.SwitchingProtocols)
@@ -216,7 +202,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy
                 }
 
                 // :: Step 8: Copy response trailer headers and finish response Client ◄-- Proxy ◄-- Destination
-                CopyResponseTrailingHeaders(destinationResponse, context, transforms.ResponseTrailerTransforms);
+                await CopyResponseTrailingHeadersAsync(destinationResponse, context, transforms);
 
                 if (isStreamingRequest)
                 {
@@ -256,14 +242,18 @@ namespace Microsoft.ReverseProxy.Service.Proxy
             }
         }
 
-        private HttpRequestMessage CreateRequestMessage(HttpContext context, string destinationAddress,
-            IReadOnlyList<RequestParametersTransform> requestTransforms, RequestProxyOptions requestOptions)
+        private async Task<(HttpRequestMessage, StreamCopyHttpContent)> CreateRequestMessageAsync(HttpContext context, string destinationPrefix,
+            HttpTransforms transforms, RequestProxyOptions requestOptions, bool isStreamingRequest, CancellationToken requestAborted)
         {
             // "http://a".Length = 8
-            if (destinationAddress == null || destinationAddress.Length < 8)
+            if (destinationPrefix == null || destinationPrefix.Length < 8)
             {
-                throw new ArgumentException(nameof(destinationAddress));
+                throw new ArgumentException(nameof(destinationPrefix));
             }
+
+            var destinationRequest = new HttpRequestMessage();
+
+            destinationRequest.Method = HttpUtilities.GetHttpMethod(context.Request.Method);
 
             var upgradeFeature = context.Features.Get<IHttpUpgradeFeature>();
             var upgradeHeader = context.Request.Headers[HeaderNames.Upgrade].ToString();
@@ -278,59 +268,38 @@ namespace Microsoft.ReverseProxy.Service.Proxy
             // based on VersionPolicy (for .NET 5 and higher). For example, downgrading to HTTP/1.1 if it cannot establish HTTP/2 with the target.
             // This is done without extra round-trips thanks to ALPN. We can detect a downgrade after calling HttpClient.SendAsync
             // (see Step 3 below). TBD how this will change when HTTP/3 is supported.
-            var httpVersion = isUpgradeRequest ? ProtocolHelper.Http11Version : (requestOptions.Version ?? DefaultVersion);
+            destinationRequest.Version = isUpgradeRequest ? ProtocolHelper.Http11Version : (requestOptions.Version ?? DefaultVersion);
 #if NET
-            var httpVersionPolicy = isUpgradeRequest ? HttpVersionPolicy.RequestVersionOrLower : (requestOptions.VersionPolicy ?? DefaultVersionPolicy);
+            destinationRequest.VersionPolicy = isUpgradeRequest ? HttpVersionPolicy.RequestVersionOrLower : (requestOptions.VersionPolicy ?? DefaultVersionPolicy);
 #endif
 
-            // TODO Perf: We could probably avoid splitting this and just append the final path and query
-            UriHelper.FromAbsolute(destinationAddress, out var destinationScheme, out var destinationHost, out var destinationPathBase, out _, out _); // Query and Fragment are not supported here.
+            // :: Step 2: Setup copy of request body (background) Client --► Proxy --► Destination
+            // Note that we must do this before step (3) because step (3) may also add headers to the HttpContent that we set up here.
+            var requestContent = SetupRequestBodyCopy(context.Request, isStreamingRequest, requestAborted);
+            destinationRequest.Content = requestContent;
+
+            if (transforms.CopyRequestHeaders)
+            {
+                // :: Step 3: Copy request headers Client --► Proxy --► Destination
+                CopyRequestHeaders(context, destinationRequest);
+            }
 
             var request = context.Request;
-            if (requestTransforms.Count == 0)
+            if (transforms.OnRequest != null)
             {
-                var url = UriHelper.BuildAbsolute(destinationScheme, destinationHost, destinationPathBase, request.Path, request.QueryString);
-                Log.Proxying(_logger, url);
-                var uri = new Uri(url, UriKind.Absolute);
-                return new HttpRequestMessage(HttpUtilities.GetHttpMethod(context.Request.Method), uri)
-                {
-                    Version = httpVersion,
-#if NET
-                    VersionPolicy = httpVersionPolicy,
-#endif
-                };
+                await transforms.OnRequest(context, destinationRequest, destinationPrefix);
             }
 
-            var transformContext = new RequestParametersTransformContext()
-            {
-                HttpContext = context,
-                Version = httpVersion,
-                Method = request.Method,
-                Path = request.Path,
-                Query = new QueryTransformContext(request),
-#if NET
-                VersionPolicy = httpVersionPolicy,
-#endif
-            };
-            foreach (var requestTransform in requestTransforms)
-            {
-                requestTransform.Apply(transformContext);
-            }
+            // Allow someone to custom build the request uri, otherwise provide a default for them.
+            destinationRequest.RequestUri ??= RequestUtilities.MakeDestinationAddress(destinationPrefix, request.Path, request.QueryString);
+            
+            Log.Proxying(_logger, destinationRequest.RequestUri.AbsoluteUri);
 
-            var targetUrl = UriHelper.BuildAbsolute(destinationScheme, destinationHost, destinationPathBase, transformContext.Path, transformContext.Query.QueryString);
-            Log.Proxying(_logger, targetUrl);
-            var targetUri = new Uri(targetUrl, UriKind.Absolute);
-            return new HttpRequestMessage(HttpUtilities.GetHttpMethod(transformContext.Method), targetUri)
-            {
-                Version = transformContext.Version,
-#if NET
-                VersionPolicy = transformContext.VersionPolicy,
-#endif
-            };
+            // TODO: What if they replace the HttpContent object? That would mess with our tracking and error handling.
+            return (destinationRequest, requestContent);
         }
 
-        private StreamCopyHttpContent SetupRequestBodyCopy(HttpRequest request, HttpRequestMessage destinationRequest,
-            bool isStreamingRequest, CancellationToken cancellation)
+        private StreamCopyHttpContent SetupRequestBodyCopy(HttpRequest request, bool isStreamingRequest, CancellationToken cancellation)
         {
             // If we generate an HttpContent without a Content-Length then for HTTP/1.1 HttpClient will add a Transfer-Encoding: chunked header
             // even if it's a GET request. Some servers reject requests containing a Transfer-Encoding header if they're not expecting a body.
@@ -408,92 +377,29 @@ namespace Microsoft.ReverseProxy.Service.Proxy
                     autoFlushHttpClientOutgoingStream: isStreamingRequest,
                     clock: _clock,
                     cancellation: cancellation);
-                destinationRequest.Content = requestContent;
             }
 
             return requestContent;
         }
 
-        private static void CopyRequestHeaders(HttpContext context, HttpRequestMessage destination, Transforms transforms)
+        private static void CopyRequestHeaders(HttpContext context, HttpRequestMessage destination)
         {
-            // Transforms that were run in the first pass.
-            HashSet<string> transformsRun = null;
-            if (transforms.CopyRequestHeaders ?? true)
+            foreach (var header in context.Request.Headers)
             {
-                foreach (var header in context.Request.Headers)
+                var headerName = header.Key;
+                var headerValue = header.Value;
+                if (StringValues.IsNullOrEmpty(headerValue))
                 {
-                    var headerName = header.Key;
-                    var headerValue = header.Value;
-                    if (StringValues.IsNullOrEmpty(headerValue))
-                    {
-                        continue;
-                    }
-
-                    // Filter out HTTP/2 pseudo headers like ":method" and ":path", those go into other fields.
-                    if (headerName.Length > 0 && headerName[0] == ':')
-                    {
-                        continue;
-                    }
-
-                    if (transforms.RequestHeaderTransforms.TryGetValue(headerName, out var transform))
-                    {
-                        (transformsRun ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase)).Add(headerName);
-                        headerValue = transform.Apply(context, headerValue);
-                        if (StringValues.IsNullOrEmpty(headerValue))
-                        {
-                            continue;
-                        }
-                    }
-
-                    AddHeader(destination, headerName, headerValue);
-                }
-            }
-
-            // Run any transforms that weren't run yet.
-            foreach (var (headerName, transform) in transforms.RequestHeaderTransforms)
-            {
-                if (!(transformsRun?.Contains(headerName) ?? false))
-                {
-                    var headerValue = context.Request.Headers[headerName];
-                    headerValue = transform.Apply(context, headerValue);
-                    if (!StringValues.IsNullOrEmpty(headerValue))
-                    {
-                        AddHeader(destination, headerName, headerValue);
-                    }
-                }
-            }
-
-            // Note: HttpClient.SendAsync will end up sending the union of
-            // HttpRequestMessage.Headers and HttpRequestMessage.Content.Headers.
-            // We don't really care where the proxied headers appear among those 2,
-            // as long as they appear in one (and only one, otherwise they would be duplicated).
-            static void AddHeader(HttpRequestMessage request, string headerName, StringValues value)
-            {
-                // HttpClient wrongly uses comma (",") instead of semi-colon (";") as a separator for Cookie headers.
-                // To mitigate this, we concatenate them manually and put them back as a single header value.
-                // A multi-header cookie header is invalid, but we get one because of
-                // https://github.com/dotnet/aspnetcore/issues/26461
-                if (string.Equals(headerName, HeaderNames.Cookie, StringComparison.OrdinalIgnoreCase) && value.Count > 1)
-                {
-                    value = string.Join("; ", value);
+                    continue;
                 }
 
-                if (value.Count == 1)
+                // Filter out HTTP/2 pseudo headers like ":method" and ":path", those go into other fields.
+                if (headerName.Length > 0 && headerName[0] == ':')
                 {
-                    string headerValue = value;
-                    if (!request.Headers.TryAddWithoutValidation(headerName, headerValue))
-                    {
-                        request.Content?.Headers.TryAddWithoutValidation(headerName, headerValue);
-                    }
+                    continue;
                 }
-                else
-                {
-                    string[] headerValues = value;
-                    if (!request.Headers.TryAddWithoutValidation(headerName, headerValues))
-                    {
-                        request.Content?.Headers.TryAddWithoutValidation(headerName, headerValues);
-                    }
-                }
+
+                RequestUtilities.AddHeader(destination, headerName, headerValue);
             }
         }
 
@@ -557,20 +463,27 @@ namespace Microsoft.ReverseProxy.Service.Proxy
             context.Response.StatusCode = StatusCodes.Status502BadGateway;
         }
 
-        private static void CopyResponseStatusAndHeaders(HttpResponseMessage source, HttpContext context, IReadOnlyDictionary<string, ResponseHeaderTransform> transforms)
+        private static Task CopyResponseStatusAndHeadersAsync(HttpResponseMessage source, HttpContext context, HttpTransforms transforms)
         {
             context.Response.StatusCode = (int)source.StatusCode;
             context.Features.Get<IHttpResponseFeature>().ReasonPhrase = source.ReasonPhrase;
 
-            // Transforms that were run in the first pass.
-            HashSet<string> transformsRun = null;
             var responseHeaders = context.Response.Headers;
-            CopyHeaders(source, source.Headers, context, responseHeaders, transforms, ref transformsRun);
-            if (source.Content != null)
+            if (transforms.CopyResponseHeaders)
             {
-                CopyHeaders(source, source.Content.Headers, context, responseHeaders, transforms, ref transformsRun);
+                CopyResponseHeaders(source.Headers, responseHeaders);
+                if (source.Content != null)
+                {
+                    CopyResponseHeaders(source.Content.Headers, responseHeaders);
+                }
             }
-            RunRemainingResponseTransforms(source, context, responseHeaders, transforms, transformsRun);
+
+            if (transforms.OnResponse != null)
+            {
+                return transforms.OnResponse(context, source);
+            }
+
+            return Task.CompletedTask;
         }
 
         private async Task HandleUpgradedResponse(HttpContext context, HttpResponseMessage destinationResponse,
@@ -697,7 +610,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy
             ResetOrAbort(context, isCancelled: responseBodyCopyResult == StreamCopyResult.Canceled);
         }
 
-        private static void CopyResponseTrailingHeaders(HttpResponseMessage source, HttpContext context, IReadOnlyDictionary<string, ResponseHeaderTransform> transforms)
+        private static Task CopyResponseTrailingHeadersAsync(HttpResponseMessage source, HttpContext context, HttpTransforms transforms)
         {
             // NOTE: Deliberately not using `context.Response.SupportsTrailers()`, `context.Response.AppendTrailer(...)`
             // because they lookup `IHttpResponseTrailersFeature` for every call. Here we do it just once instead.
@@ -707,53 +620,30 @@ namespace Microsoft.ReverseProxy.Service.Proxy
             {
                 // Note that trailers, if any, should already have been declared in Proxy's response
                 // by virtue of us having proxied all response headers in step 6.
-                HashSet<string> transformsRun = null;
-                CopyHeaders(source, source.TrailingHeaders, context, outgoingTrailers, transforms, ref transformsRun);
-                RunRemainingResponseTransforms(source, context, outgoingTrailers, transforms, transformsRun);
+                if (transforms.CopyResponseTrailers)
+                {
+                    CopyResponseHeaders(source.TrailingHeaders, outgoingTrailers);
+                }
+
+                if (transforms.OnResponseTrailers != null)
+                {
+                    return transforms.OnResponseTrailers.Invoke(context, source);
+                }
             }
+
+            return Task.CompletedTask;
         }
 
-        private static void CopyHeaders(HttpResponseMessage response, HttpHeaders source, HttpContext context, IHeaderDictionary destination,
-            IReadOnlyDictionary<string, ResponseHeaderTransform> transforms, ref HashSet<string> transformsRun)
+        private static void CopyResponseHeaders(HttpHeaders source, IHeaderDictionary destination)
         {
             foreach (var header in source)
             {
                 var headerName = header.Key;
-                // TODO: this list only contains "Transfer-Encoding" because that messes up Kestrel. If we don't need to add any more here then it would be more efficient to
-                // check for the single value directly.
-                if (_responseHeadersToSkip.Contains(headerName))
+                if (RequestUtilities.ResponseHeadersToSkip.Contains(headerName))
                 {
                     continue;
                 }
-                var headerValue = new StringValues(header.Value.ToArray());
-
-                if (transforms.TryGetValue(headerName, out var transform))
-                {
-                    (transformsRun ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase)).Add(headerName);
-                    headerValue = transform.Apply(context, response, headerValue);
-                }
-                if (!StringValues.IsNullOrEmpty(headerValue))
-                {
-                    destination.Append(headerName, headerValue);
-                }
-            }
-        }
-
-        private static void RunRemainingResponseTransforms(HttpResponseMessage response, HttpContext context, IHeaderDictionary destination,
-            IReadOnlyDictionary<string, ResponseHeaderTransform> transforms, HashSet<string> transformsRun)
-        {
-            // Run any transforms that weren't run yet.
-            foreach (var (headerName, transform) in transforms) // TODO: What about multiple transforms per header? Last wins?
-            {
-                if (!(transformsRun?.Contains(headerName) ?? false))
-                {
-                    var headerValue = StringValues.Empty;
-                    headerValue = transform.Apply(context, response, headerValue);
-                    if (!StringValues.IsNullOrEmpty(headerValue))
-                    {
-                        destination.Append(headerName, headerValue);
-                    }
-                }
+                destination.Append(headerName, header.Value.ToArray());
             }
         }
 

--- a/src/ReverseProxy/Service/Proxy/HttpTransformer.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpTransformer.cs
@@ -12,18 +12,18 @@ using Microsoft.ReverseProxy.Utilities;
 
 namespace Microsoft.ReverseProxy.Service.Proxy
 {
-    public class HttpTransforms
+    public class HttpTransformer
     {
         /// <summary>
         /// A default set of transforms that copies all request and response fields and headers, except for some
         /// protocol specific values.
         /// </summary>
-        public static readonly HttpTransforms Default = new HttpTransforms();
+        public static readonly HttpTransformer Default = new HttpTransformer();
 
         /// <summary>
         /// Used to create derived instances.
         /// </summary>
-        protected HttpTransforms() { }
+        protected HttpTransformer() { }
 
         /// <summary>
         /// A callback that is invoked prior to sending the proxied request. All HttpRequestMessage fields are

--- a/src/ReverseProxy/Service/Proxy/HttpTransforms.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpTransforms.cs
@@ -21,6 +21,11 @@ namespace Microsoft.ReverseProxy.Service.Proxy
         public static readonly HttpTransforms Default = new HttpTransforms();
 
         /// <summary>
+        /// Used to create derived instances.
+        /// </summary>
+        protected HttpTransforms() { }
+
+        /// <summary>
         /// A callback that is invoked prior to sending the proxied request. All HttpRequestMessage fields are
         /// initialized except RequestUri, which will be initialized after the callback if no value is provided.
         /// The string parameter represents the destination URI prefix that should be used when constructing the RequestUri.

--- a/src/ReverseProxy/Service/Proxy/HttpTransforms.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpTransforms.cs
@@ -1,56 +1,104 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
+using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Primitives;
+using Microsoft.ReverseProxy.Utilities;
 
 namespace Microsoft.ReverseProxy.Service.Proxy
 {
-    public record HttpTransforms
+    public class HttpTransforms
     {
-        public static readonly HttpTransforms Empty = new HttpTransforms();
-
         /// <summary>
-        /// Indicates if all request headers should be copied to the outgoing HttpRequestMessage before invoking
-        /// OnRequest. Disable this if you want to manually control which headers are copied.
-        /// Note this copy excludes certain protocol headers like HTTP/2 pseudo headers (":authority").
+        /// A default set of transforms that copies all request and response fields and headers, except for some
+        /// protocol specific values.
         /// </summary>
-        public bool CopyRequestHeaders { get; init; } = true;
-
-        /// <summary>
-        /// Indicates if all response headers should be copied from the received HttpResponseMessage before invoking
-        /// OnResponse. Disable this if you want to manually control which headers are copied.
-        /// Note this copy excludes certain protocol headers like `Transfer-Encoding: chunked`.
-        /// </summary>
-        public bool CopyResponseHeaders { get; init; } = true;
-
-        /// <summary>
-        /// Indicates if all response trailers should be copied from the received HttpResponseMessage before invoking
-        /// OnResponseTrailers. Disable this if you want to manually control which headers are copied.
-        /// </summary>
-        public bool CopyResponseTrailers { get; init; } = true;
+        public static readonly HttpTransforms Default = new HttpTransforms();
 
         /// <summary>
         /// A callback that is invoked prior to sending the proxied request. All HttpRequestMessage fields are
         /// initialized except RequestUri, which will be initialized after the callback if no value is provided.
         /// The string parameter represents the destination URI prefix that should be used when constructing the RequestUri.
-        /// The headers will be copied before the callback if CopyRequestHeaders is enabled.
+        /// The headers are copied by the base implementation, excluding some protocol headers like HTTP/2 pseudo headers (":authority").
         /// </summary>
-        public Func<HttpContext, HttpRequestMessage, string, Task> OnRequest { get; init; }
+        public virtual Task TransformRequestAsync(HttpContext httpContext, HttpRequestMessage proxyRequest, string destinationPrefix)
+        {
+            foreach (var header in httpContext.Request.Headers)
+            {
+                var headerName = header.Key;
+                var headerValue = header.Value;
+                if (StringValues.IsNullOrEmpty(headerValue))
+                {
+                    continue;
+                }
+
+                // Filter out HTTP/2 pseudo headers like ":method" and ":path", those go into other fields.
+                if (headerName.Length > 0 && headerName[0] == ':')
+                {
+                    continue;
+                }
+
+                RequestUtilities.AddHeader(proxyRequest, headerName, headerValue);
+            }
+
+            return Task.CompletedTask;
+        }
 
         /// <summary>
         /// A callback that is invoked when the proxied response is received. The status code and reason phrase will be copied
         /// to the HttpContext.Response before the callback is invoked, but may still be modified there. The headers will be
-        /// copied to HttpContext.Response.Headers before the callback if CopyResponseHeaders is enabled.
+        /// copied to HttpContext.Response.Headers by the base implementation, excludes certain protocol headers like
+        /// `Transfer-Encoding: chunked`.
         /// </summary>
-        public Func<HttpContext, HttpResponseMessage, Task> OnResponse { get; init; }
+        public virtual Task TransformResponseAsync(HttpContext httpContext, HttpResponseMessage proxyResponse)
+        {
+            var responseHeaders = httpContext.Response.Headers;
+            CopyResponseHeaders(proxyResponse.Headers, responseHeaders);
+            if (proxyResponse.Content != null)
+            {
+                CopyResponseHeaders(proxyResponse.Content.Headers, responseHeaders);
+            }
+
+            return Task.CompletedTask;
+        }
 
         /// <summary>
         /// A callback that is invoked after the response body to modify trailers, if supported. The trailers will be
-        /// copied to the HttpContext.Response before the callback if CopyResponseTrailers is enabled.
+        /// copied to the HttpContext.Response by the base implementation.
         /// </summary>
-        public Func<HttpContext, HttpResponseMessage, Task> OnResponseTrailers { get; init; }
+        public virtual Task TransformResponseTrailersAsync(HttpContext httpContext, HttpResponseMessage proxyResponse)
+        {
+            // NOTE: Deliberately not using `context.Response.SupportsTrailers()`, `context.Response.AppendTrailer(...)`
+            // because they lookup `IHttpResponseTrailersFeature` for every call. Here we do it just once instead.
+            var responseTrailersFeature = httpContext.Features.Get<IHttpResponseTrailersFeature>();
+            var outgoingTrailers = responseTrailersFeature?.Trailers;
+            if (outgoingTrailers != null && !outgoingTrailers.IsReadOnly)
+            {
+                // Note that trailers, if any, should already have been declared in Proxy's response
+                // by virtue of us having proxied all response headers in step 6.
+                CopyResponseHeaders(proxyResponse.TrailingHeaders, outgoingTrailers);
+            }
+
+            return Task.CompletedTask;
+        }
+
+
+        private static void CopyResponseHeaders(HttpHeaders source, IHeaderDictionary destination)
+        {
+            foreach (var header in source)
+            {
+                var headerName = header.Key;
+                if (RequestUtilities.ResponseHeadersToSkip.Contains(headerName))
+                {
+                    continue;
+                }
+                destination.Append(headerName, header.Value.ToArray());
+            }
+        }
     }
 }

--- a/src/ReverseProxy/Service/Proxy/HttpTransforms.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpTransforms.cs
@@ -26,6 +26,9 @@ namespace Microsoft.ReverseProxy.Service.Proxy
         /// The string parameter represents the destination URI prefix that should be used when constructing the RequestUri.
         /// The headers are copied by the base implementation, excluding some protocol headers like HTTP/2 pseudo headers (":authority").
         /// </summary>
+        /// <param name="httpContext">The incoming request.</param>
+        /// <param name="proxyRequest">The outgoing proxy request.</param>
+        /// <param name="destinationPrefix">The uri prefix for the selected destination server which can be used to create the RequestUri.</param>
         public virtual Task TransformRequestAsync(HttpContext httpContext, HttpRequestMessage proxyRequest, string destinationPrefix)
         {
             foreach (var header in httpContext.Request.Headers)
@@ -55,6 +58,8 @@ namespace Microsoft.ReverseProxy.Service.Proxy
         /// copied to HttpContext.Response.Headers by the base implementation, excludes certain protocol headers like
         /// `Transfer-Encoding: chunked`.
         /// </summary>
+        /// <param name="httpContext">The incoming request.</param>
+        /// <param name="proxyResponse">The response from the destination.</param>
         public virtual Task TransformResponseAsync(HttpContext httpContext, HttpResponseMessage proxyResponse)
         {
             var responseHeaders = httpContext.Response.Headers;
@@ -71,6 +76,8 @@ namespace Microsoft.ReverseProxy.Service.Proxy
         /// A callback that is invoked after the response body to modify trailers, if supported. The trailers will be
         /// copied to the HttpContext.Response by the base implementation.
         /// </summary>
+        /// <param name="httpContext">The incoming request.</param>
+        /// <param name="proxyResponse">The response from the destination.</param>
         public virtual Task TransformResponseTrailersAsync(HttpContext httpContext, HttpResponseMessage proxyResponse)
         {
             // NOTE: Deliberately not using `context.Response.SupportsTrailers()`, `context.Response.AppendTrailer(...)`

--- a/src/ReverseProxy/Service/Proxy/HttpTransforms.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpTransforms.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.ReverseProxy.Service.Proxy
+{
+    public record HttpTransforms
+    {
+        public static readonly HttpTransforms Empty = new HttpTransforms();
+
+        /// <summary>
+        /// Indicates if all request headers should be copied to the outgoing HttpRequestMessage before invoking
+        /// OnRequest. Disable this if you want to manually control which headers are copied.
+        /// Note this copy excludes certain protocol headers like HTTP/2 pseudo headers (":authority").
+        /// </summary>
+        public bool CopyRequestHeaders { get; init; } = true;
+
+        /// <summary>
+        /// Indicates if all response headers should be copied from the received HttpResponseMessage before invoking
+        /// OnResponse. Disable this if you want to manually control which headers are copied.
+        /// Note this copy excludes certain protocol headers like `Transfer-Encoding: chunked`.
+        /// </summary>
+        public bool CopyResponseHeaders { get; init; } = true;
+
+        /// <summary>
+        /// Indicates if all response trailers should be copied from the received HttpResponseMessage before invoking
+        /// OnResponseTrailers. Disable this if you want to manually control which headers are copied.
+        /// </summary>
+        public bool CopyResponseTrailers { get; init; } = true;
+
+        /// <summary>
+        /// A callback that is invoked prior to sending the proxied request. All HttpRequestMessage fields are
+        /// initialized except RequestUri, which will be initialized after the callback if no value is provided.
+        /// The string parameter represents the destination URI prefix that should be used when constructing the RequestUri.
+        /// The headers will be copied before the callback if CopyRequestHeaders is enabled.
+        /// </summary>
+        public Func<HttpContext, HttpRequestMessage, string, Task> OnRequest { get; init; }
+
+        /// <summary>
+        /// A callback that is invoked when the proxied response is received. The status code and reason phrase will be copied
+        /// to the HttpContext.Response before the callback is invoked, but may still be modified there. The headers will be
+        /// copied to HttpContext.Response.Headers before the callback if CopyResponseHeaders is enabled.
+        /// </summary>
+        public Func<HttpContext, HttpResponseMessage, Task> OnResponse { get; init; }
+
+        /// <summary>
+        /// A callback that is invoked after the response body to modify trailers, if supported. The trailers will be
+        /// copied to the HttpContext.Response before the callback if CopyResponseTrailers is enabled.
+        /// </summary>
+        public Func<HttpContext, HttpResponseMessage, Task> OnResponseTrailers { get; init; }
+    }
+}

--- a/src/ReverseProxy/Service/Proxy/IHttpProxy.cs
+++ b/src/ReverseProxy/Service/Proxy/IHttpProxy.cs
@@ -19,7 +19,8 @@ namespace Microsoft.ReverseProxy.Service.Proxy
         /// <param name="context">The HttpContent to proxy from.</param>
         /// <param name="destinationPrefix">The url prefix for where to proxy the request to.</param>
         /// <param name="httpClient">The HTTP client used to send the proxy request.</param>
-        /// <param name="transformer">Request and response transforms.</param>
+        /// <param name="transformer">Request and response transforms. Use <see cref="HttpTransformer.Default"/> if
+        /// custom transformations are not needed.</param>
         /// <param name="requestOptions">Options for the outgoing request.</param>
         Task ProxyAsync(
             HttpContext context,

--- a/src/ReverseProxy/Service/Proxy/IHttpProxy.cs
+++ b/src/ReverseProxy/Service/Proxy/IHttpProxy.cs
@@ -19,13 +19,13 @@ namespace Microsoft.ReverseProxy.Service.Proxy
         /// <param name="context">The HttpContent to proxy from.</param>
         /// <param name="destinationPrefix">The url prefix for where to proxy the request to.</param>
         /// <param name="httpClient">The HTTP client used to send the proxy request.</param>
-        /// <param name="transforms">Request and response transforms.</param>
+        /// <param name="transformer">Request and response transforms.</param>
         /// <param name="requestOptions">Options for the outgoing request.</param>
         Task ProxyAsync(
             HttpContext context,
             string destinationPrefix,
             HttpMessageInvoker httpClient,
-            HttpTransforms transforms,
+            HttpTransformer transformer,
             RequestProxyOptions requestOptions);
     }
 }

--- a/src/ReverseProxy/Service/Proxy/IHttpProxy.cs
+++ b/src/ReverseProxy/Service/Proxy/IHttpProxy.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy
             HttpContext context,
             string destinationPrefix,
             HttpMessageInvoker httpClient,
-            Transforms transforms,
+            HttpTransforms transforms,
             RequestProxyOptions requestOptions);
     }
 }

--- a/src/ReverseProxy/Service/Proxy/IHttpProxy.cs
+++ b/src/ReverseProxy/Service/Proxy/IHttpProxy.cs
@@ -4,7 +4,6 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.ReverseProxy.Service.RuntimeModel.Transforms;
 
 namespace Microsoft.ReverseProxy.Service.Proxy
 {
@@ -19,14 +18,14 @@ namespace Microsoft.ReverseProxy.Service.Proxy
         /// <param name="context">The HttpContent to proxy from.</param>
         /// <param name="destinationPrefix">The url prefix for where to proxy the request to.</param>
         /// <param name="httpClient">The HTTP client used to send the proxy request.</param>
+        /// <param name="requestOptions">Options for the outgoing request.</param>
         /// <param name="transformer">Request and response transforms. Use <see cref="HttpTransformer.Default"/> if
         /// custom transformations are not needed.</param>
-        /// <param name="requestOptions">Options for the outgoing request.</param>
         Task ProxyAsync(
             HttpContext context,
             string destinationPrefix,
             HttpMessageInvoker httpClient,
-            HttpTransformer transformer,
-            RequestProxyOptions requestOptions);
+            RequestProxyOptions requestOptions,
+            HttpTransformer transformer);
     }
 }

--- a/src/ReverseProxy/Service/Proxy/IHttpProxyExtensions.cs
+++ b/src/ReverseProxy/Service/Proxy/IHttpProxyExtensions.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.ReverseProxy.Service.Proxy
+{
+    public static class IHttpProxyExtensions
+    {
+        /// <summary>
+        /// Proxies the incoming request to the destination server, and the response back to the client.
+        /// </summary>
+        /// <param name="context">The HttpContent to proxy from.</param>
+        /// <param name="destinationPrefix">The url prefix for where to proxy the request to.</param>
+        /// <param name="httpClient">The HTTP client used to send the proxy request.</param>
+        public static Task ProxyAsync(
+            this IHttpProxy proxy,
+            HttpContext context,
+            string destinationPrefix,
+            HttpMessageInvoker httpClient)
+        {
+            return proxy.ProxyAsync(context, destinationPrefix, httpClient, requestOptions: default, HttpTransformer.Default);
+        }
+
+        /// <summary>
+        /// Proxies the incoming request to the destination server, and the response back to the client.
+        /// </summary>
+        /// <param name="context">The HttpContent to proxy from.</param>
+        /// <param name="destinationPrefix">The url prefix for where to proxy the request to.</param>
+        /// <param name="httpClient">The HTTP client used to send the proxy request.</param>
+        /// <param name="requestOptions">Options for the outgoing request.</param>
+        public static Task ProxyAsync(
+            this IHttpProxy proxy,
+            HttpContext context,
+            string destinationPrefix,
+            HttpMessageInvoker httpClient,
+            RequestProxyOptions requestOptions)
+        {
+            return proxy.ProxyAsync(context, destinationPrefix, httpClient, requestOptions, HttpTransformer.Default);
+        }
+    }
+}

--- a/src/ReverseProxy/Service/RuntimeModel/RouteConfig.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/RouteConfig.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.ReverseProxy.Abstractions;
+using Microsoft.ReverseProxy.Service.Proxy;
 using Microsoft.ReverseProxy.Service.RuntimeModel.Transforms;
 
 namespace Microsoft.ReverseProxy.RuntimeModel
@@ -25,7 +26,7 @@ namespace Microsoft.ReverseProxy.RuntimeModel
             RouteInfo route,
             ProxyRoute proxyRoute,
             ClusterInfo cluster,
-            Transforms transforms)
+            HttpTransforms transforms)
         {
             Route = route ?? throw new ArgumentNullException(nameof(route));
 
@@ -42,7 +43,7 @@ namespace Microsoft.ReverseProxy.RuntimeModel
         // May not be populated if the cluster config is missing.
         public ClusterInfo Cluster { get; }
 
-        public Transforms Transforms { get; }
+        public HttpTransforms Transforms { get; }
 
         internal ProxyRoute ProxyRoute { get; }
 

--- a/src/ReverseProxy/Service/RuntimeModel/RouteConfig.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/RouteConfig.cs
@@ -26,14 +26,14 @@ namespace Microsoft.ReverseProxy.RuntimeModel
             RouteInfo route,
             ProxyRoute proxyRoute,
             ClusterInfo cluster,
-            HttpTransforms transforms)
+            HttpTransformer transformer)
         {
             Route = route ?? throw new ArgumentNullException(nameof(route));
 
             ProxyRoute = proxyRoute;
             Order = proxyRoute.Order;
             Cluster = cluster;
-            Transforms = transforms;
+            Transformer = transformer;
         }
 
         public RouteInfo Route { get; }
@@ -43,7 +43,7 @@ namespace Microsoft.ReverseProxy.RuntimeModel
         // May not be populated if the cluster config is missing.
         public ClusterInfo Cluster { get; }
 
-        public HttpTransforms Transforms { get; }
+        public HttpTransformer Transformer { get; }
 
         internal ProxyRoute ProxyRoute { get; }
 

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/HttpMethodTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/HttpMethodTransform.cs
@@ -20,9 +20,9 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
 
         public override void Apply(RequestParametersTransformContext context)
         {
-            if (FromMethod.Equals(context.Request.Method))
+            if (FromMethod.Equals(context.ProxyRequest.Method))
             {
-                context.Request.Method = ToMethod;
+                context.ProxyRequest.Method = ToMethod;
             }
         }
 

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/HttpMethodTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/HttpMethodTransform.cs
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
+using System.Net.Http;
 using Microsoft.AspNetCore.Http;
+using Microsoft.ReverseProxy.Service.Proxy;
 
 namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
 {
@@ -11,18 +12,18 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         public HttpMethodTransform(string fromMethod, string toMethod)
         {
             FromMethod = GetCanonicalizedValue(fromMethod);
-            ToMethod = GetCanonicalizedValue(toMethod);
+            ToMethod = HttpUtilities.GetHttpMethod(toMethod);
         }
 
-        internal string ToMethod { get; }
+        internal HttpMethod ToMethod { get; }
 
         internal string FromMethod { get; }
 
         public override void Apply(RequestParametersTransformContext context)
         {
-            if (HttpMethodEquals(FromMethod, context.Method))
+            if (HttpMethodEquals(FromMethod, context.Request.Method.Method))
             {
-                context.Method = ToMethod;
+                context.Request.Method = ToMethod;
             }
         }
 
@@ -54,7 +55,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
 #if NET5_0
             return HttpMethods.Equals(methodA, methodB);
 #elif NETCOREAPP3_1
-            return object.ReferenceEquals(methodA, methodB) || StringComparer.OrdinalIgnoreCase.Equals(methodA, methodB);
+            return object.ReferenceEquals(methodA, methodB) || System.StringComparer.OrdinalIgnoreCase.Equals(methodA, methodB);
 #else
 #error A target framework was added to the project and needs to be added to this condition.
 #endif

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderClientCertTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderClientCertTransform.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 
@@ -13,7 +14,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
     public class RequestHeaderClientCertTransform : RequestHeaderTransform
     {
         /// <inheritdoc/>
-        public override StringValues Apply(HttpContext context, StringValues values)
+        public override StringValues Apply(HttpContext context, HttpRequestMessage request, StringValues values)
         {
             if (context is null)
             {

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderClientCertTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderClientCertTransform.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
     public class RequestHeaderClientCertTransform : RequestHeaderTransform
     {
         /// <inheritdoc/>
-        public override StringValues Apply(HttpContext context, HttpRequestMessage request, StringValues values)
+        public override StringValues Apply(HttpContext context, HttpRequestMessage proxyRequest, StringValues values)
         {
             if (context is null)
             {

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderForwardedTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderForwardedTransform.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         {
             if (context is null)
             {
-                throw new System.ArgumentNullException(nameof(context));
+                throw new ArgumentNullException(nameof(context));
             }
 
             var builder = new StringBuilder();

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderForwardedTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderForwardedTransform.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net;
+using System.Net.Http;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
@@ -41,7 +42,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         internal bool Append { get; }
 
         /// <inheritdoc/>
-        public override StringValues Apply(HttpContext context, StringValues values)
+        public override StringValues Apply(HttpContext context, HttpRequestMessage request, StringValues values)
         {
             if (context is null)
             {

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderForwardedTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderForwardedTransform.cs
@@ -42,7 +42,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         internal bool Append { get; }
 
         /// <inheritdoc/>
-        public override StringValues Apply(HttpContext context, HttpRequestMessage request, StringValues values)
+        public override StringValues Apply(HttpContext context, HttpRequestMessage proxyRequest, StringValues values)
         {
             if (context is null)
             {

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderTransform.cs
@@ -16,10 +16,10 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         /// Transforms the given value and returns the result.
         /// </summary>
         /// <param name="context">The original <see cref="HttpContext"/> for accessing other state.</param>
-        /// <param name="request">The outgoing <see cref="HttpRequestMessage"/> for reference.</param>
+        /// <param name="proxyRequest">The outgoing <see cref="HttpRequestMessage"/> for reference.</param>
         /// <param name="values">The original header value(s) from the incoming request, or StringValues.Empty if the header
         /// was not present.</param>
         /// <returns>The transformed result, or StringValues.Empty if the header should be suppressed.</returns>
-        public abstract StringValues Apply(HttpContext context, HttpRequestMessage request, StringValues values);
+        public abstract StringValues Apply(HttpContext context, HttpRequestMessage proxyRequest, StringValues values);
     }
 }

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderTransform.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 
@@ -15,8 +16,10 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         /// Transforms the given value and returns the result.
         /// </summary>
         /// <param name="context">The original <see cref="HttpContext"/> for accessing other state.</param>
-        /// <param name="values">The original header value(s).</param>
-        /// <returns>The transformed result.</returns>
-        public abstract StringValues Apply(HttpContext context, StringValues values);
+        /// <param name="request">The outgoing <see cref="HttpRequestMessage"/> for reference.</param>
+        /// <param name="values">The original header value(s) from the incoming request, or StringValues.Empty if the header
+        /// was not present.</param>
+        /// <returns>The transformed result, or StringValues.Empty if the header should be suppressed.</returns>
+        public abstract StringValues Apply(HttpContext context, HttpRequestMessage request, StringValues values);
     }
 }

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderValueTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderValueTransform.cs
@@ -28,7 +28,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         {
             if (context is null)
             {
-                throw new System.ArgumentNullException(nameof(context));
+                throw new ArgumentNullException(nameof(context));
             }
 
             if (Append)

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderValueTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderValueTransform.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         internal bool Append { get; }
 
         /// <inheritdoc/>
-        public override StringValues Apply(HttpContext context, HttpRequestMessage request, StringValues values)
+        public override StringValues Apply(HttpContext context, HttpRequestMessage proxyRequest, StringValues values)
         {
             if (context is null)
             {

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderValueTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderValueTransform.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 
@@ -23,7 +24,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         internal bool Append { get; }
 
         /// <inheritdoc/>
-        public override StringValues Apply(HttpContext context, StringValues values)
+        public override StringValues Apply(HttpContext context, HttpRequestMessage request, StringValues values)
         {
             if (context is null)
             {

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedForTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedForTransform.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 
@@ -23,7 +24,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         internal bool Append { get; }
 
         /// <inheritdoc/>
-        public override StringValues Apply(HttpContext context, StringValues values)
+        public override StringValues Apply(HttpContext context, HttpRequestMessage request, StringValues values)
         {
             if (context is null)
             {

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedForTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedForTransform.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         internal bool Append { get; }
 
         /// <inheritdoc/>
-        public override StringValues Apply(HttpContext context, HttpRequestMessage request, StringValues values)
+        public override StringValues Apply(HttpContext context, HttpRequestMessage proxyRequest, StringValues values)
         {
             if (context is null)
             {

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedHostTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedHostTransform.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 
@@ -23,7 +24,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         internal bool Append { get; }
 
         /// <inheritdoc/>
-        public override StringValues Apply(HttpContext context, StringValues values)
+        public override StringValues Apply(HttpContext context, HttpRequestMessage request, StringValues values)
         {
             if (context is null)
             {

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedHostTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedHostTransform.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         internal bool Append { get; }
 
         /// <inheritdoc/>
-        public override StringValues Apply(HttpContext context, HttpRequestMessage request, StringValues values)
+        public override StringValues Apply(HttpContext context, HttpRequestMessage proxyRequest, StringValues values)
         {
             if (context is null)
             {

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedPathBaseTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedPathBaseTransform.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 
@@ -20,7 +21,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         internal bool Append { get; }
 
         /// <inheritdoc/>
-        public override StringValues Apply(HttpContext context, StringValues values)
+        public override StringValues Apply(HttpContext context, HttpRequestMessage request, StringValues values)
         {
             if (context is null)
             {

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedPathBaseTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedPathBaseTransform.cs
@@ -21,7 +21,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         internal bool Append { get; }
 
         /// <inheritdoc/>
-        public override StringValues Apply(HttpContext context, HttpRequestMessage request, StringValues values)
+        public override StringValues Apply(HttpContext context, HttpRequestMessage proxyRequest, StringValues values)
         {
             if (context is null)
             {

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedProtoTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedProtoTransform.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 
@@ -20,7 +21,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         internal bool Append { get; }
 
         /// <inheritdoc/>
-        public override StringValues Apply(HttpContext context, StringValues values)
+        public override StringValues Apply(HttpContext context, HttpRequestMessage request, StringValues values)
         {
             if (context is null)
             {

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedProtoTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedProtoTransform.cs
@@ -21,7 +21,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         internal bool Append { get; }
 
         /// <inheritdoc/>
-        public override StringValues Apply(HttpContext context, HttpRequestMessage request, StringValues values)
+        public override StringValues Apply(HttpContext context, HttpRequestMessage proxyRequest, StringValues values)
         {
             if (context is null)
             {

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestParametersTransformContext.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestParametersTransformContext.cs
@@ -23,7 +23,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         /// 'Path', and 'Query' properties after the transforms have run. The headers will be copied later when
         /// applying header transforms.
         /// </summary>
-        public HttpRequestMessage Request { get; internal set; }
+        public HttpRequestMessage ProxyRequest { get; internal set; }
 
         /// <summary>
         /// The path to use for the proxy request.

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestParametersTransformContext.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestParametersTransformContext.cs
@@ -20,8 +20,8 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         /// <summary>
         /// The outgoing proxy request. All field are initialized except for the 'RequestUri' and headers.
         /// If no value is provided then the 'RequestUri' will be initialized using the updated 'DestinationPrefix',
-        /// 'Path', 'Query' properties after the transforms have run.
-        /// The headers will be copied later when applying header transforms.
+        /// 'Path', and 'Query' properties after the transforms have run. The headers will be copied later when
+        /// applying header transforms.
         /// </summary>
         public HttpRequestMessage Request { get; internal set; }
 

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestParametersTransformContext.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestParametersTransformContext.cs
@@ -18,21 +18,12 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         public HttpContext HttpContext { get; set; }
 
         /// <summary>
-        /// The HTTP version to use for the proxy request.
+        /// The outgoing proxy request. All field are initialized except for the 'RequestUri' and headers.
+        /// If no value is provided then the 'RequestUri' will be initialized using the updated 'DestinationPrefix',
+        /// 'Path', 'Query' properties after the transforms have run.
+        /// The headers will be copied later when applying header transforms.
         /// </summary>
-        public Version Version { get; set; }
-
-#if NET
-        /// <summary>
-        /// The HTTP version policy to use for the proxy request.
-        /// </summary>
-        public HttpVersionPolicy VersionPolicy { get; set; }
-#endif
-
-        /// <summary>
-        /// The HTTP method to use for the proxy request.
-        /// </summary>
-        public string Method { get; set; }
+        public HttpRequestMessage Request { get; internal set; }
 
         /// <summary>
         /// The path to use for the proxy request.
@@ -46,5 +37,11 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         /// The query used for the proxy request.
         /// </summary>
         public QueryTransformContext Query { get; set; }
+
+        /// <summary>
+        /// The URI prefix for the proxy request. This includes the scheme and host and can optionally include a
+        /// port and path base. The 'Path' and 'Query' properties will be appended to this after the transforms have run.
+        /// </summary>
+        public string DestinationPrefix { get; set; }
     }
 }

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/ResponseHeaderTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/ResponseHeaderTransform.cs
@@ -17,8 +17,8 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         /// </summary>
         /// <param name="context">The current request context.</param>
         /// <param name="response">The proxied response.</param>
-        /// <param name="values">The header value to transform.</param>
-        /// <returns>The transformed value.</returns>
+        /// <param name="values">The header value from the response, or StringValues.Empty if the header was absent.</param>
+        /// <returns>The transformed result, or StringValues.Empty if the header should be suppressed.</returns>
         public abstract StringValues Apply(HttpContext context, HttpResponseMessage response, StringValues values);
     }
 }

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/ResponseHeaderTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/ResponseHeaderTransform.cs
@@ -16,9 +16,9 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         /// Transforms the given response header value and returns the result.
         /// </summary>
         /// <param name="context">The current request context.</param>
-        /// <param name="response">The proxied response.</param>
+        /// <param name="proxyResponse">The proxied response.</param>
         /// <param name="values">The header value from the response, or StringValues.Empty if the header was absent.</param>
         /// <returns>The transformed result, or StringValues.Empty if the header should be suppressed.</returns>
-        public abstract StringValues Apply(HttpContext context, HttpResponseMessage response, StringValues values);
+        public abstract StringValues Apply(HttpContext context, HttpResponseMessage proxyResponse, StringValues values);
     }
 }

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/ResponseHeaderValueTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/ResponseHeaderValueTransform.cs
@@ -34,9 +34,9 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
                 throw new System.ArgumentNullException(nameof(context));
             }
 
-            if (response is null)
+            if (proxyResponse is null)
             {
-                throw new System.ArgumentNullException(nameof(response));
+                throw new System.ArgumentNullException(nameof(proxyResponse));
             }
 
             var result = values;

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/ResponseHeaderValueTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/ResponseHeaderValueTransform.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
 
         // Assumes the response status code has been set on the HttpContext already.
         /// <inheritdoc/>
-        public override StringValues Apply(HttpContext context, HttpResponseMessage response, StringValues values)
+        public override StringValues Apply(HttpContext context, HttpResponseMessage proxyResponse, StringValues values)
         {
             if (context is null)
             {

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/StructuredTransformer.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/StructuredTransformer.cs
@@ -18,12 +18,12 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
     /// <summary>
     /// Transforms for a given route.
     /// </summary>
-    internal class Transforms : HttpTransforms
+    internal class StructuredTransformer : HttpTransformer
     {
         /// <summary>
-        /// Creates a new <see cref="Transforms"/> instance.
+        /// Creates a new <see cref="StructuredTransformer"/> instance.
         /// </summary>
-        internal Transforms(bool? copyRequestHeaders, IList<RequestParametersTransform> requestTransforms,
+        internal StructuredTransformer(bool? copyRequestHeaders, IList<RequestParametersTransform> requestTransforms,
             Dictionary<string, RequestHeaderTransform> requestHeaderTransforms,
             Dictionary<string, ResponseHeaderTransform> responseHeaderTransforms,
             Dictionary<string, ResponseHeaderTransform> responseTrailerTransforms)

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/Transforms.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/Transforms.cs
@@ -127,7 +127,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
                     if (RequestHeaderTransforms.TryGetValue(headerName, out var transform))
                     {
                         (transformsRun ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase)).Add(headerName);
-                        headerValue = transform.Apply(context, headerValue);
+                        headerValue = transform.Apply(context, destination, headerValue);
                         if (StringValues.IsNullOrEmpty(headerValue))
                         {
                             continue;
@@ -143,7 +143,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
             {
                 if (!(transformsRun?.Contains(headerName) ?? false))
                 {
-                    var headerValue = transform.Apply(context, StringValues.Empty);
+                    var headerValue = transform.Apply(context, destination, StringValues.Empty);
                     if (!StringValues.IsNullOrEmpty(headerValue))
                     {
                         RequestUtilities.AddHeader(destination, headerName, headerValue);

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/Transforms.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/Transforms.cs
@@ -3,60 +3,220 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Primitives;
+using Microsoft.ReverseProxy.Service.Proxy;
+using Microsoft.ReverseProxy.Utilities;
 
 namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
 {
     /// <summary>
     /// Transforms for a given route.
     /// </summary>
-    public class Transforms
+    internal class Transforms
     {
-        // For tests
-        internal static Transforms Empty { get; } = new Transforms(
-            copyRequestHeaders: null,
-            requestTransforms: Array.Empty<RequestParametersTransform>(),
-            requestHeaderTransforms: new Dictionary<string, RequestHeaderTransform>(),
-            responseHeaderTransforms: new Dictionary<string, ResponseHeaderTransform>(),
-            responseTrailerTransforms: new Dictionary<string, ResponseHeaderTransform>());
-
         /// <summary>
         /// Creates a new <see cref="Transforms"/> instance.
         /// </summary>
-        public Transforms(bool? copyRequestHeaders, IReadOnlyList<RequestParametersTransform> requestTransforms,
-            IReadOnlyDictionary<string, RequestHeaderTransform> requestHeaderTransforms,
-            IReadOnlyDictionary<string, ResponseHeaderTransform> responseHeaderTransforms,
-            IReadOnlyDictionary<string, ResponseHeaderTransform> responseTrailerTransforms)
+        internal Transforms(bool? copyRequestHeaders, IList<RequestParametersTransform> requestTransforms,
+            Dictionary<string, RequestHeaderTransform> requestHeaderTransforms,
+            Dictionary<string, ResponseHeaderTransform> responseHeaderTransforms,
+            Dictionary<string, ResponseHeaderTransform> responseTrailerTransforms)
         {
-            CopyRequestHeaders = copyRequestHeaders;
+            ShouldCopyRequestHeaders = copyRequestHeaders;
             RequestTransforms = requestTransforms ?? throw new ArgumentNullException(nameof(requestTransforms));
             RequestHeaderTransforms = requestHeaderTransforms ?? throw new ArgumentNullException(nameof(requestHeaderTransforms));
             ResponseHeaderTransforms = responseHeaderTransforms ?? throw new ArgumentNullException(nameof(responseHeaderTransforms));
             ResponseTrailerTransforms = responseTrailerTransforms ?? throw new ArgumentNullException(nameof(responseTrailerTransforms));
+
+            AdaptedTransforms = new HttpTransforms()
+            {
+                // Use the default copy logic only if we don't have any transforms.
+                CopyRequestHeaders = RequestHeaderTransforms.Count == 0 && (ShouldCopyRequestHeaders ?? true),
+                OnRequest = RequestTransforms.Count == 0 && RequestHeaderTransforms.Count == 0 ? null : TransformRequestAsync,
+
+                CopyResponseHeaders = ResponseHeaderTransforms.Count == 0,
+                OnResponse = ResponseHeaderTransforms.Count == 0 ? null : TransformResponseHeadersAsync,
+
+                CopyResponseTrailers = ResponseTrailerTransforms.Count == 0,
+                OnResponseTrailers = ResponseTrailerTransforms.Count == 0 ? null : TransformResponseTralersAsync
+            };
         }
 
         /// <summary>
         /// Indicates if all request headers should be proxied in absence of other transforms.
         /// </summary>
-        public bool? CopyRequestHeaders { get; }
+        internal bool? ShouldCopyRequestHeaders { get; }
 
         /// <summary>
         /// Request parameter transforms.
         /// </summary>
-        public IReadOnlyList<RequestParametersTransform> RequestTransforms { get; }
+        internal IList<RequestParametersTransform> RequestTransforms { get; }
 
         /// <summary>
         /// Request header transforms.
         /// </summary>
-        public IReadOnlyDictionary<string, RequestHeaderTransform> RequestHeaderTransforms { get; }
+        internal Dictionary<string, RequestHeaderTransform> RequestHeaderTransforms { get; }
 
         /// <summary>
         /// Response header transforms.
         /// </summary>
-        public IReadOnlyDictionary<string, ResponseHeaderTransform> ResponseHeaderTransforms { get; }
+        internal Dictionary<string, ResponseHeaderTransform> ResponseHeaderTransforms { get; }
 
         /// <summary>
         /// Response trailer transforms.
         /// </summary>
-        public IReadOnlyDictionary<string, ResponseHeaderTransform> ResponseTrailerTransforms { get; }
+        internal Dictionary<string, ResponseHeaderTransform> ResponseTrailerTransforms { get; }
+
+        /// <summary>
+        /// This is the structure used by IHttpProxy transforms.
+        /// </summary>
+        internal HttpTransforms AdaptedTransforms { get; }
+
+        private Task TransformRequestAsync(HttpContext context, HttpRequestMessage request, string destinationPrefix)
+        {
+            var transformContext = new RequestParametersTransformContext()
+            {
+                DestinationPrefix = destinationPrefix,
+                HttpContext = context,
+                Request = request,
+                Path = context.Request.Path,
+                Query = new QueryTransformContext(context.Request),
+            };
+
+            foreach (var requestTransform in RequestTransforms)
+            {
+                requestTransform.Apply(transformContext);
+            }
+
+            // Allow a transform to directly set a custom RequestUri.
+            request.RequestUri ??= RequestUtilities.MakeDestinationAddress(
+                transformContext.DestinationPrefix, transformContext.Path, transformContext.Query.QueryString);
+
+            CopyRequestHeaders(context, request);
+
+            return Task.CompletedTask;
+        }
+
+        private void CopyRequestHeaders(HttpContext context, HttpRequestMessage destination)
+        {
+            // Transforms that were run in the first pass.
+            HashSet<string> transformsRun = null;
+            if (ShouldCopyRequestHeaders ?? true)
+            {
+                foreach (var header in context.Request.Headers)
+                {
+                    var headerName = header.Key;
+                    var headerValue = header.Value;
+                    if (StringValues.IsNullOrEmpty(headerValue))
+                    {
+                        continue;
+                    }
+
+                    // Filter out HTTP/2 pseudo headers like ":method" and ":path", those go into other fields.
+                    if (headerName.Length > 0 && headerName[0] == ':')
+                    {
+                        continue;
+                    }
+
+                    if (RequestHeaderTransforms.TryGetValue(headerName, out var transform))
+                    {
+                        (transformsRun ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase)).Add(headerName);
+                        headerValue = transform.Apply(context, headerValue);
+                        if (StringValues.IsNullOrEmpty(headerValue))
+                        {
+                            continue;
+                        }
+                    }
+
+                    RequestUtilities.AddHeader(destination, headerName, headerValue);
+                }
+            }
+
+            // Run any transforms that weren't run yet.
+            foreach (var (headerName, transform) in RequestHeaderTransforms)
+            {
+                if (!(transformsRun?.Contains(headerName) ?? false))
+                {
+                    var headerValue = transform.Apply(context, StringValues.Empty);
+                    if (!StringValues.IsNullOrEmpty(headerValue))
+                    {
+                        RequestUtilities.AddHeader(destination, headerName, headerValue);
+                    }
+                }
+            }
+        }
+
+        private Task TransformResponseHeadersAsync(HttpContext context, HttpResponseMessage source)
+        {
+            HashSet<string> transformsRun = null;
+            var responseHeaders = context.Response.Headers;
+            CopyResponseHeaders(source, source.Headers, context, responseHeaders, ResponseHeaderTransforms, ref transformsRun);
+            if (source.Content != null)
+            {
+                CopyResponseHeaders(source, source.Content.Headers, context, responseHeaders, ResponseHeaderTransforms, ref transformsRun);
+            }
+            RunRemainingResponseTransforms(source, context, responseHeaders, ResponseHeaderTransforms, transformsRun);
+            return Task.CompletedTask;
+        }
+
+        private Task TransformResponseTralersAsync(HttpContext context, HttpResponseMessage source)
+        {
+            // Trailers support was already verified by the caller.
+            var responseTrailersFeature = context.Features.Get<IHttpResponseTrailersFeature>();
+            var outgoingTrailers = responseTrailersFeature?.Trailers;
+            HashSet<string> transformsRun = null;
+            CopyResponseHeaders(source, source.TrailingHeaders, context, outgoingTrailers, ResponseTrailerTransforms, ref transformsRun);
+            RunRemainingResponseTransforms(source, context, outgoingTrailers, ResponseTrailerTransforms, transformsRun);
+            return Task.CompletedTask;
+        }
+
+        private static void CopyResponseHeaders(HttpResponseMessage response, HttpHeaders source, HttpContext context, IHeaderDictionary destination,
+            IReadOnlyDictionary<string, ResponseHeaderTransform> transforms, ref HashSet<string> transformsRun)
+        {
+            foreach (var header in source)
+            {
+                var headerName = header.Key;
+                if (RequestUtilities.ResponseHeadersToSkip.Contains(headerName))
+                {
+                    continue;
+                }
+
+                var headerValue = new StringValues(header.Value.ToArray());
+
+                if (transforms.TryGetValue(headerName, out var transform))
+                {
+                    (transformsRun ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase)).Add(headerName);
+                    headerValue = transform.Apply(context, response, headerValue);
+                }
+                if (!StringValues.IsNullOrEmpty(headerValue))
+                {
+                    destination.Append(headerName, headerValue);
+                }
+            }
+        }
+
+        private static void RunRemainingResponseTransforms(HttpResponseMessage response, HttpContext context, IHeaderDictionary destination,
+            IReadOnlyDictionary<string, ResponseHeaderTransform> transforms, HashSet<string> transformsRun)
+        {
+            // Run any transforms that weren't run yet.
+            foreach (var (headerName, transform) in transforms) // TODO: What about multiple transforms per header? Last wins?
+            {
+                if (!(transformsRun?.Contains(headerName) ?? false))
+                {
+                    var headerValue = StringValues.Empty;
+                    headerValue = transform.Apply(context, response, headerValue);
+                    if (!StringValues.IsNullOrEmpty(headerValue))
+                    {
+                        destination.Append(headerName, headerValue);
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/ReverseProxy/Utilities/IsExternalInit.cs
+++ b/src/ReverseProxy/Utilities/IsExternalInit.cs
@@ -1,9 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
-// 3.1 workaround for records
-// https://tooslowexception.com/6-less-popular-facts-about-c-9-records/
-namespace System.Runtime.CompilerServices
-{
-    internal class IsExternalInit { }
-}

--- a/src/ReverseProxy/Utilities/IsExternalInit.cs
+++ b/src/ReverseProxy/Utilities/IsExternalInit.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// 3.1 workaround for records
+// https://tooslowexception.com/6-less-popular-facts-about-c-9-records/
+namespace System.Runtime.CompilerServices
+{
+    internal class IsExternalInit { }
+}

--- a/src/ReverseProxy/Utilities/RequestUtilities.cs
+++ b/src/ReverseProxy/Utilities/RequestUtilities.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
+
+namespace Microsoft.ReverseProxy.Utilities
+{
+    internal static class RequestUtilities
+    {
+        // TODO: this list only contains "Transfer-Encoding" because that messes up Kestrel. If we don't need to add any more here then it would be more efficient to
+        // check for the single value directly. What about connection headers?
+        internal static readonly HashSet<string> ResponseHeadersToSkip = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            HeaderNames.TransferEncoding
+        };
+
+        /// <summary>
+        /// Appends the given path and query to the destination prefix while avoiding duplicate '/'.
+        /// </summary>
+        /// <param name="destinationPrefix">The scheme, host, port, and possibly path base for the destination server.</param>
+        /// <param name="path">The path to append.</param>
+        /// <param name="query">The query to append</param>
+        internal static Uri MakeDestinationAddress(string destinationPrefix, PathString path, QueryString query)
+        {
+            var builder = new StringBuilder(destinationPrefix);
+            if (path.HasValue)
+            {
+                // When PathString has a value it always starts with a '/'. Avoid double slashes when concatenating.
+                if (builder.Length > 0 && builder[^1] == '/')
+                {
+                    builder.Length--;
+                }
+
+                builder.Append(path.ToUriComponent());
+            }
+            if (query.HasValue)
+            {
+                builder.Append(query.ToUriComponent());
+            }
+
+            var targetAddress = builder.ToString();
+            return new Uri(targetAddress, UriKind.Absolute);
+        }
+
+        // Note: HttpClient.SendAsync will end up sending the union of
+        // HttpRequestMessage.Headers and HttpRequestMessage.Content.Headers.
+        // We don't really care where the proxied headers appear among those 2,
+        // as long as they appear in one (and only one, otherwise they would be duplicated).
+        internal static void AddHeader(HttpRequestMessage request, string headerName, StringValues value)
+        {
+            // HttpClient wrongly uses comma (",") instead of semi-colon (";") as a separator for Cookie headers.
+            // To mitigate this, we concatenate them manually and put them back as a single header value.
+            // A multi-header cookie header is invalid, but we get one because of
+            // https://github.com/dotnet/aspnetcore/issues/26461
+            if (string.Equals(headerName, HeaderNames.Cookie, StringComparison.OrdinalIgnoreCase) && value.Count > 1)
+            {
+                value = string.Join("; ", value);
+            }
+
+            if (value.Count == 1)
+            {
+                string headerValue = value;
+                if (!request.Headers.TryAddWithoutValidation(headerName, headerValue))
+                {
+                    var added = request.Content?.Headers.TryAddWithoutValidation(headerName, headerValue);
+                    Debug.Assert(added.GetValueOrDefault(), $"A header was dropped; {headerName}: {headerValue}");
+                }
+            }
+            else
+            {
+                string[] headerValues = value;
+                if (!request.Headers.TryAddWithoutValidation(headerName, headerValues))
+                {
+                    var added = request.Content?.Headers.TryAddWithoutValidation(headerName, headerValues);
+                    Debug.Assert(added.GetValueOrDefault(), $"A header was dropped; {headerName}: {string.Join(", ", headerValues)}");
+                }
+            }
+        }
+    }
+}

--- a/src/ReverseProxy/Utilities/RequestUtilities.cs
+++ b/src/ReverseProxy/Utilities/RequestUtilities.cs
@@ -70,7 +70,9 @@ namespace Microsoft.ReverseProxy.Utilities
                 if (!request.Headers.TryAddWithoutValidation(headerName, headerValue))
                 {
                     var added = request.Content?.Headers.TryAddWithoutValidation(headerName, headerValue);
-                    Debug.Assert(added.GetValueOrDefault(), $"A header was dropped; {headerName}: {headerValue}");
+                    // TODO: Log. Today this assert fails for a POST request with Content-Length: 0 header which is valid.
+                    // https://github.com/microsoft/reverse-proxy/issues/618
+                    // Debug.Assert(added.GetValueOrDefault(), $"A header was dropped; {headerName}: {headerValue}");
                 }
             }
             else
@@ -79,7 +81,9 @@ namespace Microsoft.ReverseProxy.Utilities
                 if (!request.Headers.TryAddWithoutValidation(headerName, headerValues))
                 {
                     var added = request.Content?.Headers.TryAddWithoutValidation(headerName, headerValues);
-                    Debug.Assert(added.GetValueOrDefault(), $"A header was dropped; {headerName}: {string.Join(", ", headerValues)}");
+                    // TODO: Log. Today this assert fails for a POST request with Content-Length: 0 header which is valid.
+                    // https://github.com/microsoft/reverse-proxy/issues/618
+                    // Debug.Assert(added.GetValueOrDefault(), $"A header was dropped; {headerName}: {string.Join(", ", headerValues)}");
                 }
             }
         }

--- a/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
+++ b/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.ReverseProxy.DynamicEndpoint
                 {
                     Config = new ClusterConfig(cluster, default, default, default, default, default, default, default)
                 },
-                HttpTransforms.Default);
+                HttpTransformer.Default);
 
             endpointBuilder.Metadata.Add(routeConfig);
 

--- a/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
+++ b/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.ReverseProxy.Abstractions;
 using Microsoft.ReverseProxy.RuntimeModel;
 using Microsoft.ReverseProxy.Service.Management;
+using Microsoft.ReverseProxy.Service.Proxy;
 using Microsoft.ReverseProxy.Service.RuntimeModel.Transforms;
 using Xunit;
 
@@ -95,7 +96,7 @@ namespace Microsoft.ReverseProxy.DynamicEndpoint
                 {
                     Config = new ClusterConfig(cluster, default, default, default, default, default, default, default)
                 },
-                Transforms.Empty);
+                HttpTransforms.Default);
 
             endpointBuilder.Metadata.Add(routeConfig);
 

--- a/test/ReverseProxy.Tests/Microsoft.ReverseProxy.Tests.csproj
+++ b/test/ReverseProxy.Tests/Microsoft.ReverseProxy.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.ReverseProxy</RootNamespace>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/ReverseProxy.Tests/Middleware/AffinityMiddlewareTestBase.cs
+++ b/test/ReverseProxy.Tests/Middleware/AffinityMiddlewareTestBase.cs
@@ -94,7 +94,7 @@ namespace Microsoft.ReverseProxy.Middleware
         internal Endpoint GetEndpoint(ClusterInfo cluster)
         {
             var proxyRoute = new ProxyRoute();
-            var routeConfig = new RouteConfig(new RouteInfo("route-1"), proxyRoute, cluster, HttpTransforms.Default);
+            var routeConfig = new RouteConfig(new RouteInfo("route-1"), proxyRoute, cluster, HttpTransformer.Default);
             var endpoint = new Endpoint(default, new EndpointMetadataCollection(routeConfig), string.Empty);
             return endpoint;
         }

--- a/test/ReverseProxy.Tests/Middleware/AffinityMiddlewareTestBase.cs
+++ b/test/ReverseProxy.Tests/Middleware/AffinityMiddlewareTestBase.cs
@@ -94,7 +94,7 @@ namespace Microsoft.ReverseProxy.Middleware
         internal Endpoint GetEndpoint(ClusterInfo cluster)
         {
             var proxyRoute = new ProxyRoute();
-            var routeConfig = new RouteConfig(new RouteInfo("route-1"), proxyRoute, cluster, HttpTransforms.Empty);
+            var routeConfig = new RouteConfig(new RouteInfo("route-1"), proxyRoute, cluster, HttpTransforms.Default);
             var endpoint = new Endpoint(default, new EndpointMetadataCollection(routeConfig), string.Empty);
             return endpoint;
         }

--- a/test/ReverseProxy.Tests/Middleware/AffinityMiddlewareTestBase.cs
+++ b/test/ReverseProxy.Tests/Middleware/AffinityMiddlewareTestBase.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.ReverseProxy.Abstractions;
 using Microsoft.ReverseProxy.RuntimeModel;
 using Microsoft.ReverseProxy.Service.Management;
+using Microsoft.ReverseProxy.Service.Proxy;
 using Microsoft.ReverseProxy.Service.RuntimeModel.Transforms;
 using Microsoft.ReverseProxy.Service.SessionAffinity;
 using Moq;
@@ -93,7 +94,7 @@ namespace Microsoft.ReverseProxy.Middleware
         internal Endpoint GetEndpoint(ClusterInfo cluster)
         {
             var proxyRoute = new ProxyRoute();
-            var routeConfig = new RouteConfig(new RouteInfo("route-1"), proxyRoute, cluster, Transforms.Empty);
+            var routeConfig = new RouteConfig(new RouteInfo("route-1"), proxyRoute, cluster, HttpTransforms.Empty);
             var endpoint = new Endpoint(default, new EndpointMetadataCollection(routeConfig), string.Empty);
             return endpoint;
         }

--- a/test/ReverseProxy.Tests/Middleware/DestinationInitializerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/DestinationInitializerMiddlewareTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
                 new RouteInfo("route1"),
                 proxyRoute: new ProxyRoute(),
                 cluster1,
-                transforms: null);
+                transformer: null);
             var aspNetCoreEndpoint = CreateAspNetCoreEndpoint(routeConfig);
             aspNetCoreEndpoints.Add(aspNetCoreEndpoint);
             var httpContext = new DefaultHttpContext();
@@ -101,7 +101,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
                 route: new RouteInfo("route1"),
                 proxyRoute: new ProxyRoute(),
                 cluster: cluster1,
-                transforms: null);
+                transformer: null);
             var aspNetCoreEndpoint = CreateAspNetCoreEndpoint(routeConfig);
             aspNetCoreEndpoints.Add(aspNetCoreEndpoint);
             var httpContext = new DefaultHttpContext();

--- a/test/ReverseProxy.Tests/Middleware/LoadBalancerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/LoadBalancerMiddlewareTests.cs
@@ -186,7 +186,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
                 });
             context.Features.Set(cluster);
 
-            var routeConfig = new RouteConfig(new RouteInfo("route-1"), new ProxyRoute(), cluster, transforms: null);
+            var routeConfig = new RouteConfig(new RouteInfo("route-1"), new ProxyRoute(), cluster, transformer: null);
             var endpoint = new Endpoint(default, new EndpointMetadataCollection(routeConfig), string.Empty);
             context.SetEndpoint(endpoint);
 

--- a/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.ReverseProxy.Middleware
         private Endpoint GetEndpoint(ClusterInfo cluster)
         {
             var endpoints = new List<Endpoint>(1);
-            var routeConfig = new RouteConfig(new RouteInfo("route-1"), new ProxyRoute(), cluster, Transforms.Empty);
+            var routeConfig = new RouteConfig(new RouteInfo("route-1"), new ProxyRoute(), cluster, HttpTransforms.Empty);
             var endpoint = new Endpoint(default, new EndpointMetadataCollection(routeConfig), string.Empty);
             endpoints.Add(endpoint);
             return endpoint;

--- a/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.ReverseProxy.Middleware
         private Endpoint GetEndpoint(ClusterInfo cluster)
         {
             var endpoints = new List<Endpoint>(1);
-            var routeConfig = new RouteConfig(new RouteInfo("route-1"), new ProxyRoute(), cluster, HttpTransforms.Default);
+            var routeConfig = new RouteConfig(new RouteInfo("route-1"), new ProxyRoute(), cluster, HttpTransformer.Default);
             var endpoint = new Endpoint(default, new EndpointMetadataCollection(routeConfig), string.Empty);
             endpoints.Add(endpoint);
             return endpoint;

--- a/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.ReverseProxy.Middleware
         private Endpoint GetEndpoint(ClusterInfo cluster)
         {
             var endpoints = new List<Endpoint>(1);
-            var routeConfig = new RouteConfig(new RouteInfo("route-1"), new ProxyRoute(), cluster, HttpTransforms.Empty);
+            var routeConfig = new RouteConfig(new RouteInfo("route-1"), new ProxyRoute(), cluster, HttpTransforms.Default);
             var endpoint = new Endpoint(default, new EndpointMetadataCollection(routeConfig), string.Empty);
             endpoints.Add(endpoint);
             return endpoint;

--- a/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
@@ -78,14 +78,14 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
                     httpContext,
                     It.Is<string>(uri => uri == "https://localhost:123/a/b/"),
                     httpClient,
-                    It.Is<HttpTransformer>(transformer => transformer == null),
                     It.Is<RequestProxyOptions>(requestOptions =>
                         requestOptions.Timeout == httpRequestOptions.Timeout
                         && requestOptions.Version == httpRequestOptions.Version
 #if NET
                         && requestOptions.VersionPolicy == httpRequestOptions.VersionPolicy
 #endif
-                        )))
+                        ),
+                    It.Is<HttpTransformer>(transformer => transformer == null)))
                 .Returns(
                     async () =>
                     {
@@ -158,8 +158,8 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
                     httpContext,
                     It.IsAny<string>(),
                     httpClient,
-                    It.IsAny<HttpTransformer>(),
-                    It.IsAny<RequestProxyOptions>()))
+                    It.IsAny<RequestProxyOptions>(),
+                    It.IsAny<HttpTransformer>()))
                 .Returns(() => throw new NotImplementedException());
 
             var sut = Create<ProxyInvokerMiddleware>();

--- a/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
@@ -14,7 +14,6 @@ using Microsoft.ReverseProxy.Common.Tests;
 using Microsoft.ReverseProxy.RuntimeModel;
 using Microsoft.ReverseProxy.Service.Management;
 using Microsoft.ReverseProxy.Service.Proxy;
-using Microsoft.ReverseProxy.Service.RuntimeModel.Transforms;
 using Moq;
 using Xunit;
 
@@ -67,7 +66,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
                 route: new RouteInfo("route1"),
                 proxyRoute: new ProxyRoute(),
                 cluster: cluster1,
-                transforms: null);
+                transformer: null);
             var aspNetCoreEndpoint = CreateAspNetCoreEndpoint(routeConfig);
             aspNetCoreEndpoints.Add(aspNetCoreEndpoint);
             httpContext.SetEndpoint(aspNetCoreEndpoint);
@@ -79,7 +78,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
                     httpContext,
                     It.Is<string>(uri => uri == "https://localhost:123/a/b/"),
                     httpClient,
-                    It.Is<HttpTransforms>(transforms => transforms == null),
+                    It.Is<HttpTransformer>(transformer => transformer == null),
                     It.Is<RequestProxyOptions>(requestOptions =>
                         requestOptions.Timeout == httpRequestOptions.Timeout
                         && requestOptions.Version == httpRequestOptions.Version
@@ -149,7 +148,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
                 route: new RouteInfo("route1"),
                 proxyRoute: new ProxyRoute(),
                 cluster: cluster1,
-                transforms: null);
+                transformer: null);
             var aspNetCoreEndpoint = CreateAspNetCoreEndpoint(routeConfig);
             aspNetCoreEndpoints.Add(aspNetCoreEndpoint);
             httpContext.SetEndpoint(aspNetCoreEndpoint);
@@ -159,7 +158,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
                     httpContext,
                     It.IsAny<string>(),
                     httpClient,
-                    It.IsAny<HttpTransforms>(),
+                    It.IsAny<HttpTransformer>(),
                     It.IsAny<RequestProxyOptions>()))
                 .Returns(() => throw new NotImplementedException());
 

--- a/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
                     httpContext,
                     It.Is<string>(uri => uri == "https://localhost:123/a/b/"),
                     httpClient,
-                    It.Is<Transforms>(transforms => transforms == null),
+                    It.Is<HttpTransforms>(transforms => transforms == null),
                     It.Is<RequestProxyOptions>(requestOptions =>
                         requestOptions.Timeout == httpRequestOptions.Timeout
                         && requestOptions.Version == httpRequestOptions.Version
@@ -159,7 +159,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
                     httpContext,
                     It.IsAny<string>(),
                     httpClient,
-                    It.IsAny<Transforms>(),
+                    It.IsAny<HttpTransforms>(),
                     It.IsAny<RequestProxyOptions>()))
                 .Returns(() => throw new NotImplementedException());
 

--- a/test/ReverseProxy.Tests/Service/Config/ProxyRouteTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Service/Config/ProxyRouteTransformExtensionsTests.cs
@@ -294,7 +294,7 @@ namespace Microsoft.ReverseProxy.Service.Config
 
             var requestTransform = Assert.Single(transform.RequestTransforms);
             var httpMethodTransform = Assert.IsType<HttpMethodTransform>(requestTransform);
-            Assert.Equal(HttpMethods.Put, httpMethodTransform.FromMethod);
+            Assert.Equal(HttpMethod.Put, httpMethodTransform.FromMethod);
             Assert.Equal(HttpMethod.Post, httpMethodTransform.ToMethod);
         }
 

--- a/test/ReverseProxy.Tests/Service/Config/ProxyRouteTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Service/Config/ProxyRouteTransformExtensionsTests.cs
@@ -350,7 +350,7 @@ namespace Microsoft.ReverseProxy.Service.Config
             Assert.Equal("key", removeQueryParameterTransform.Key);
         }
 
-        private static Transforms BuildTransform(ProxyRoute proxyRoute)
+        private static StructuredTransformer BuildTransform(ProxyRoute proxyRoute)
         {
             var builder = new TransformBuilder(NullTemplateBinderFactory.Instance, new TestRandomFactory());
 

--- a/test/ReverseProxy.Tests/Service/Config/ProxyRouteTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Service/Config/ProxyRouteTransformExtensionsTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
@@ -10,6 +11,7 @@ using Microsoft.AspNetCore.Routing.Template;
 using Microsoft.Net.Http.Headers;
 using Microsoft.ReverseProxy.Abstractions;
 using Microsoft.ReverseProxy.Common.Tests;
+using Microsoft.ReverseProxy.Service.Proxy;
 using Microsoft.ReverseProxy.Service.RuntimeModel.Transforms;
 using Xunit;
 
@@ -85,7 +87,7 @@ namespace Microsoft.ReverseProxy.Service.Config
 
             var transform = BuildTransform(proxyRoute);
 
-            Assert.False(transform.CopyRequestHeaders);
+            Assert.False(transform.ShouldCopyRequestHeaders);
         }
 
         [Fact]
@@ -293,7 +295,7 @@ namespace Microsoft.ReverseProxy.Service.Config
             var requestTransform = Assert.Single(transform.RequestTransforms);
             var httpMethodTransform = Assert.IsType<HttpMethodTransform>(requestTransform);
             Assert.Equal(HttpMethods.Put, httpMethodTransform.FromMethod);
-            Assert.Equal(HttpMethods.Post, httpMethodTransform.ToMethod);
+            Assert.Equal(HttpMethod.Post, httpMethodTransform.ToMethod);
         }
 
         [Theory]
@@ -352,8 +354,7 @@ namespace Microsoft.ReverseProxy.Service.Config
         {
             var builder = new TransformBuilder(NullTemplateBinderFactory.Instance, new TestRandomFactory());
 
-            var transform = builder.Build(proxyRoute.Transforms);
-            return transform;
+            return builder.BuildInternal(proxyRoute.Transforms);
         }
 
         private static ProxyRoute CreateProxyRoute()

--- a/test/ReverseProxy.Tests/Service/Config/TransformBuilderTests.cs
+++ b/test/ReverseProxy.Tests/Service/Config/TransformBuilderTests.cs
@@ -47,13 +47,6 @@ namespace Microsoft.ReverseProxy.Service.Config
             Assert.IsType<RequestHeaderXForwardedHostTransform>(results.RequestHeaderTransforms[ForwardedHeadersDefaults.XForwardedHostHeaderName]);
             Assert.IsType<RequestHeaderXForwardedPathBaseTransform>(results.RequestHeaderTransforms["X-Forwarded-PathBase"]);
             Assert.IsType<RequestHeaderXForwardedProtoTransform>(results.RequestHeaderTransforms[ForwardedHeadersDefaults.XForwardedProtoHeaderName]);
-
-            var adaptedResults = results.AdaptedTransforms;
-            Assert.NotNull(adaptedResults);
-            Assert.False(adaptedResults.CopyRequestHeaders); // Manual copy
-            Assert.NotNull(adaptedResults.OnRequest);
-            Assert.Null(adaptedResults.OnResponse);
-            Assert.Null(adaptedResults.OnResponseTrailers);
         }
 
         [Fact]
@@ -75,12 +68,11 @@ namespace Microsoft.ReverseProxy.Service.Config
             var errors = transformBuilder.Validate(transforms);
             Assert.Empty(errors);
 
-            var results = transformBuilder.Build(transforms);
+            var results = transformBuilder.BuildInternal(transforms);
             Assert.NotNull(results);
-            Assert.True(results.CopyRequestHeaders);
-            Assert.Null(results.OnRequest);
-            Assert.Null(results.OnResponse);
-            Assert.Null(results.OnResponseTrailers);
+            Assert.Empty(results.RequestTransforms);
+            Assert.Empty(results.ResponseHeaderTransforms);
+            Assert.Empty(results.ResponseTrailerTransforms);
         }
 
         [Fact]
@@ -105,13 +97,6 @@ namespace Microsoft.ReverseProxy.Service.Config
             var results = transformBuilder.BuildInternal(transforms);
             Assert.Single(results.RequestHeaderTransforms);
             Assert.IsType<RequestHeaderForwardedTransform>(results.RequestHeaderTransforms["Forwarded"]);
-
-            var adaptedResults = results.AdaptedTransforms;
-            Assert.NotNull(adaptedResults);
-            Assert.False(adaptedResults.CopyRequestHeaders);
-            Assert.NotNull(adaptedResults.OnRequest);
-            Assert.Null(adaptedResults.OnResponse);
-            Assert.Null(adaptedResults.OnResponseTrailers);
         }
 
         [Theory]
@@ -134,15 +119,6 @@ namespace Microsoft.ReverseProxy.Service.Config
             var results = transformBuilder.BuildInternal(transforms);
             Assert.NotNull(results);
             Assert.Equal(copyRequestHeaders, results.ShouldCopyRequestHeaders);
-
-
-            var adaptedResults = results.AdaptedTransforms;
-            // Only matches the input so long as there are no transforms (including defaults).
-            // Always disabled when there are transforms because the copy is managed internally.
-            Assert.False(adaptedResults.CopyRequestHeaders);
-            Assert.NotNull(adaptedResults.OnRequest);
-            Assert.Null(adaptedResults.OnResponse);
-            Assert.Null(adaptedResults.OnResponseTrailers);
         }
 
         [Fact]
@@ -213,12 +189,6 @@ namespace Microsoft.ReverseProxy.Service.Config
             var results = transformBuilder.BuildInternal(transforms);
             Assert.IsType<RequestHeaderValueTransform>(results.RequestHeaderTransforms["heaDerName"]);
             // TODO: How to check Append/Set and the value?
-
-            var adaptedResults = results.AdaptedTransforms;
-            Assert.False(adaptedResults.CopyRequestHeaders);
-            Assert.NotNull(adaptedResults.OnRequest);
-            Assert.Null(adaptedResults.OnResponse);
-            Assert.Null(adaptedResults.OnResponseTrailers);
         }
 
         private TransformBuilder CreateTransformBuilder()

--- a/test/ReverseProxy.Tests/Service/Config/TransformBuilderTests.cs
+++ b/test/ReverseProxy.Tests/Service/Config/TransformBuilderTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.ReverseProxy.Service.Config
             Assert.IsType<RequestHeaderXForwardedPathBaseTransform>(results.RequestHeaderTransforms["X-Forwarded-PathBase"]);
             Assert.IsType<RequestHeaderXForwardedProtoTransform>(results.RequestHeaderTransforms[ForwardedHeadersDefaults.XForwardedProtoHeaderName]);
 
-            var adaptedResults = transformBuilder.Build(transforms);
+            var adaptedResults = results.AdaptedTransforms;
             Assert.NotNull(adaptedResults);
             Assert.False(adaptedResults.CopyRequestHeaders); // Manual copy
             Assert.NotNull(adaptedResults.OnRequest);
@@ -106,7 +106,7 @@ namespace Microsoft.ReverseProxy.Service.Config
             Assert.Single(results.RequestHeaderTransforms);
             Assert.IsType<RequestHeaderForwardedTransform>(results.RequestHeaderTransforms["Forwarded"]);
 
-            var adaptedResults = transformBuilder.Build(transforms);
+            var adaptedResults = results.AdaptedTransforms;
             Assert.NotNull(adaptedResults);
             Assert.False(adaptedResults.CopyRequestHeaders);
             Assert.NotNull(adaptedResults.OnRequest);
@@ -136,7 +136,7 @@ namespace Microsoft.ReverseProxy.Service.Config
             Assert.Equal(copyRequestHeaders, results.ShouldCopyRequestHeaders);
 
 
-            var adaptedResults = transformBuilder.Build(transforms);
+            var adaptedResults = results.AdaptedTransforms;
             // Only matches the input so long as there are no transforms (including defaults).
             // Always disabled when there are transforms because the copy is managed internally.
             Assert.False(adaptedResults.CopyRequestHeaders);
@@ -214,7 +214,7 @@ namespace Microsoft.ReverseProxy.Service.Config
             Assert.IsType<RequestHeaderValueTransform>(results.RequestHeaderTransforms["heaDerName"]);
             // TODO: How to check Append/Set and the value?
 
-            var adaptedResults = transformBuilder.Build(transforms);
+            var adaptedResults = results.AdaptedTransforms;
             Assert.False(adaptedResults.CopyRequestHeaders);
             Assert.NotNull(adaptedResults.OnRequest);
             Assert.Null(adaptedResults.OnResponse);

--- a/test/ReverseProxy.Tests/Service/Config/TransformBuilderTests.cs
+++ b/test/ReverseProxy.Tests/Service/Config/TransformBuilderTests.cs
@@ -41,6 +41,12 @@ namespace Microsoft.ReverseProxy.Service.Config
             Assert.Empty(errors);
 
             var results = transformBuilder.BuildInternal(transforms);
+            Assert.NotNull(results);
+            Assert.Null(results.ShouldCopyRequestHeaders);
+            Assert.Empty(results.ResponseHeaderTransforms);
+            Assert.Empty(results.ResponseTrailerTransforms);
+            Assert.Empty(results.RequestTransforms);
+
             Assert.Equal(5, results.RequestHeaderTransforms.Count);
             Assert.IsType<RequestHeaderValueTransform>(results.RequestHeaderTransforms[HeaderNames.Host]);
             Assert.IsType<RequestHeaderXForwardedForTransform>(results.RequestHeaderTransforms[ForwardedHeadersDefaults.XForwardedForHeaderName]);
@@ -70,7 +76,9 @@ namespace Microsoft.ReverseProxy.Service.Config
 
             var results = transformBuilder.BuildInternal(transforms);
             Assert.NotNull(results);
+            Assert.Null(results.ShouldCopyRequestHeaders);
             Assert.Empty(results.RequestTransforms);
+            Assert.Empty(results.RequestHeaderTransforms);
             Assert.Empty(results.ResponseHeaderTransforms);
             Assert.Empty(results.ResponseTrailerTransforms);
         }

--- a/test/ReverseProxy.Tests/Service/DynamicEndpoint/ProxyEndpointFactorTests.cs
+++ b/test/ReverseProxy.Tests/Service/DynamicEndpoint/ProxyEndpointFactorTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.ReverseProxy.Abstractions;
 using Microsoft.ReverseProxy.RuntimeModel;
 using Microsoft.ReverseProxy.Service.Management;
+using Microsoft.ReverseProxy.Service.Proxy;
 using Microsoft.ReverseProxy.Service.Routing;
 using Microsoft.ReverseProxy.Service.RuntimeModel.Transforms;
 using Xunit;
@@ -73,7 +74,7 @@ namespace Microsoft.ReverseProxy.Service.DynamicEndpoint
 
         private (RouteEndpoint routeEndpoint, RouteConfig routeConfig) CreateEndpoint(ProxyEndpointFactory factory, RouteInfo routeInfo, ProxyRoute proxyRoute, ClusterInfo clusterInfo)
         {
-            var routeConfig = new RouteConfig(routeInfo, proxyRoute, clusterInfo, Transforms.Empty);
+            var routeConfig = new RouteConfig(routeInfo, proxyRoute, clusterInfo, HttpTransforms.Default);
 
             var endpoint = factory.CreateEndpoint(routeConfig, Array.Empty<Action<EndpointBuilder>>());
 

--- a/test/ReverseProxy.Tests/Service/DynamicEndpoint/ProxyEndpointFactorTests.cs
+++ b/test/ReverseProxy.Tests/Service/DynamicEndpoint/ProxyEndpointFactorTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.ReverseProxy.Service.DynamicEndpoint
 
         private (RouteEndpoint routeEndpoint, RouteConfig routeConfig) CreateEndpoint(ProxyEndpointFactory factory, RouteInfo routeInfo, ProxyRoute proxyRoute, ClusterInfo clusterInfo)
         {
-            var routeConfig = new RouteConfig(routeInfo, proxyRoute, clusterInfo, HttpTransforms.Default);
+            var routeConfig = new RouteConfig(routeInfo, proxyRoute, clusterInfo, HttpTransformer.Default);
 
             var endpoint = factory.CreateEndpoint(routeConfig, Array.Empty<Action<EndpointBuilder>>());
 

--- a/test/ReverseProxy.Tests/Service/Proxy/HttpProxyTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/HttpProxyTests.cs
@@ -1530,7 +1530,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
             var httpClient = new HttpClient();
             var httpContext = new DefaultHttpContext();
             var destinationPrefix = "";
-            var transforms = HttpTransforms.Default;
+            var transforms = HttpTransformer.Default;
             var requestOptions = default(RequestProxyOptions);
             var proxy = CreateProxy();
 
@@ -1835,7 +1835,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
             }
         }
 
-        private class DelegateHttpTransforms : HttpTransforms
+        private class DelegateHttpTransforms : HttpTransformer
         {
             public bool CopyRequestHeaders { get; set; } = true;
 

--- a/test/ReverseProxy.Tests/Service/Proxy/HttpProxyTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/HttpProxyTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return response;
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(234, httpContext.Response.StatusCode);
             var reasonPhrase = httpContext.Features.Get<IHttpResponseFeature>().ReasonPhrase;
@@ -199,7 +199,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return response;
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, transforms, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client, default, transforms);
 
             Assert.Equal(234, httpContext.Response.StatusCode);
             var reasonPhrase = httpContext.Features.Get<IHttpResponseFeature>().ReasonPhrase;
@@ -282,7 +282,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return response;
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, transforms, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client, default, transforms);
 
             Assert.Equal(234, httpContext.Response.StatusCode);
             var reasonPhrase = httpContext.Features.Get<IHttpResponseFeature>().ReasonPhrase;
@@ -356,7 +356,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return response;
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status101SwitchingProtocols, httpContext.Response.StatusCode);
             Assert.Contains("response", httpContext.Response.Headers["x-ms-response-test"].ToArray());
@@ -423,7 +423,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return response;
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(234, httpContext.Response.StatusCode);
             var reasonPhrase = httpContext.Features.Get<IHttpResponseFeature>().ReasonPhrase;
@@ -486,7 +486,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return Task.FromResult(response);
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
 
@@ -535,7 +535,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(Array.Empty<byte>()) };
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
 
@@ -565,7 +565,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return Task.FromResult(response);
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
 
@@ -597,7 +597,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(Array.Empty<byte>()) };
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
 
@@ -641,7 +641,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return Task.FromResult(response);
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Null(httpContext.Features.Get<IProxyErrorFeature>());
             Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
@@ -685,7 +685,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
 #else
             var options = new RequestProxyOptions(null, version);
 #endif
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, options);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client, options);
 
             Assert.Null(httpContext.Features.Get<IProxyErrorFeature>());
             Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
@@ -745,7 +745,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
 #else
             var requestOptions = new RequestProxyOptions(null, version);
 #endif
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, transforms, requestOptions);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client, requestOptions, transforms);
 
             Assert.Null(httpContext.Features.Get<IProxyErrorFeature>());
             Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
@@ -774,7 +774,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     throw new HttpRequestException("No connection could be made because the target machine actively refused it.");
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status502BadGateway, httpContext.Response.StatusCode);
             Assert.Equal(0, proxyResponseStream.Length);
@@ -808,7 +808,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     throw new HttpRequestException("No connection could be made because the target machine actively refused it.");
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status502BadGateway, httpContext.Response.StatusCode);
             Assert.Equal(0, proxyResponseStream.Length);
@@ -845,7 +845,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
             // Time out immediately
             var requestOptions = new RequestProxyOptions(TimeSpan.FromTicks(1), null);
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, requestOptions);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client, requestOptions);
 
             Assert.Equal(StatusCodes.Status504GatewayTimeout, httpContext.Response.StatusCode);
             Assert.Equal(0, proxyResponseStream.Length);
@@ -879,7 +879,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return Task.FromResult(new HttpResponseMessage());
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status502BadGateway, httpContext.Response.StatusCode);
             Assert.Equal(0, proxyResponseStream.Length);
@@ -918,7 +918,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
             // Time out immediately
             var requestOptions = new RequestProxyOptions(TimeSpan.FromTicks(1), null);
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, requestOptions);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client, requestOptions);
 
             Assert.Equal(StatusCodes.Status504GatewayTimeout, httpContext.Response.StatusCode);
             Assert.Equal(0, proxyResponseStream.Length);
@@ -954,7 +954,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return Task.FromResult(new HttpResponseMessage());
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status502BadGateway, httpContext.Response.StatusCode);
             Assert.Equal(0, proxyResponseStream.Length);
@@ -990,7 +990,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return new HttpResponseMessage();
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status400BadRequest, httpContext.Response.StatusCode);
             Assert.Equal(0, proxyResponseStream.Length);
@@ -1029,7 +1029,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     throw new HttpRequestException();
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status502BadGateway, httpContext.Response.StatusCode);
             Assert.Equal(0, proxyResponseStream.Length);
@@ -1073,7 +1073,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     throw new HttpRequestException();
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status502BadGateway, httpContext.Response.StatusCode);
             Assert.Equal(0, proxyResponseStream.Length);
@@ -1110,7 +1110,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return Task.FromResult(message);
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status502BadGateway, httpContext.Response.StatusCode);
             Assert.Equal(0, proxyResponseStream.Length);
@@ -1149,7 +1149,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return Task.FromResult(message);
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
             Assert.Equal(1, responseBody.InnerStream.Length);
@@ -1189,7 +1189,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return Task.FromResult(message);
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
             Assert.True(responseBody.Aborted);
@@ -1229,7 +1229,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return Task.FromResult(message);
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status502BadGateway, httpContext.Response.StatusCode);
             Assert.False(responseBody.Aborted);
@@ -1269,7 +1269,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return Task.FromResult(message);
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
             Assert.True(responseBody.Aborted);
@@ -1318,7 +1318,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     });
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
             Assert.Equal(0, proxyResponseStream.Length);
@@ -1359,7 +1359,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     });
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
             Assert.Equal(0, proxyResponseStream.Length);
@@ -1400,7 +1400,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     });
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
             Assert.Equal(0, proxyResponseStream.Length);
@@ -1457,7 +1457,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return Task.FromResult(response);
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status101SwitchingProtocols, httpContext.Response.StatusCode);
             var errorFeature = httpContext.Features.Get<IProxyErrorFeature>();
@@ -1513,7 +1513,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                     return Task.FromResult(response);
                 });
 
-            await sut.ProxyAsync(httpContext, destinationPrefix, client, null, default);
+            await sut.ProxyAsync(httpContext, destinationPrefix, client);
 
             Assert.Equal(StatusCodes.Status101SwitchingProtocols, httpContext.Response.StatusCode);
             var errorFeature = httpContext.Features.Get<IProxyErrorFeature>();
@@ -1535,7 +1535,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
             var proxy = CreateProxy();
 
             await Assert.ThrowsAsync<ArgumentException>(() => proxy.ProxyAsync(httpContext,
-                destinationPrefix, httpClient, transforms, requestOptions));
+                destinationPrefix, httpClient, requestOptions, transforms));
         }
 
         private static void AssertProxyStartStop(List<EventWrittenEventArgs> events, string destinationPrefix, int statusCode)

--- a/test/ReverseProxy.Tests/Service/Proxy/HttpProxyTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/HttpProxyTests.cs
@@ -448,7 +448,11 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
         [InlineData("HEAD", "HTTP/1.1", "")]
         [InlineData("POST", "HTTP/1.1", "")]
         [InlineData("POST", "HTTP/1.1", "Content-Length:0")]
+        // https://github.com/microsoft/reverse-proxy/issues/618
+        [InlineData("POST", "HTTP/1.1", "Content-Length:0;Content-Type:text/plain")]
         [InlineData("POST", "HTTP/2", "Content-Length:0")]
+        // https://github.com/microsoft/reverse-proxy/issues/618
+        [InlineData("POST", "HTTP/2", "Content-Length:0;Content-Type:text/plain")]
         [InlineData("PATCH", "HTTP/1.1", "")]
         [InlineData("DELETE", "HTTP/1.1", "")]
         [InlineData("Unknown", "HTTP/1.1", "")]

--- a/test/ReverseProxy.Tests/Service/Proxy/LoadBalancingPoliciesTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/LoadBalancingPoliciesTests.cs
@@ -136,7 +136,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
 
             var context = new DefaultHttpContext();
 
-            var routeConfig = new RouteConfig(new RouteInfo("route-1"), new ProxyRoute(), new ClusterInfo("cluster1", new DestinationManager()), transforms: null);
+            var routeConfig = new RouteConfig(new RouteInfo("route-1"), new ProxyRoute(), new ClusterInfo("cluster1", new DestinationManager()), transformer: null);
             var endpoint = new Endpoint(default, new EndpointMetadataCollection(routeConfig), string.Empty);
             context.SetEndpoint(endpoint);
 

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/HttpMethodTransformTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/HttpMethodTransformTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Xunit;
 
@@ -15,14 +16,15 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         public void HttpMethod_Works(string fromMethod, string toMethod, string requestMethod, string expected)
         {
             var httpContext = new DefaultHttpContext();
+            var request = new HttpRequestMessage() { Method = new HttpMethod(requestMethod) };
             var context = new RequestParametersTransformContext()
             {
-                Method = requestMethod,
-                HttpContext = httpContext
+                HttpContext = httpContext,
+                Request = request,
             };
             var transform = new HttpMethodTransform(fromMethod, toMethod);
             transform.Apply(context);
-            Assert.Equal(expected, context.Method);
+            Assert.Equal(expected, request.Method.Method);
         }
     }
 }

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/HttpMethodTransformTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/HttpMethodTransformTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
             var context = new RequestParametersTransformContext()
             {
                 HttpContext = httpContext,
-                Request = request,
+                ProxyRequest = request,
             };
             var transform = new HttpMethodTransform(fromMethod, toMethod);
             transform.Apply(context);

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/RequestHeaderClientCertTransformTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/RequestHeaderClientCertTransformTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
@@ -17,7 +18,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         {
             var httpContext = new DefaultHttpContext();
             var transform = new RequestHeaderClientCertTransform();
-            var result = transform.Apply(httpContext, StringValues.Empty);
+            var result = transform.Apply(httpContext, new HttpRequestMessage(), StringValues.Empty);
             Assert.Equal(StringValues.Empty, result);
         }
 
@@ -27,7 +28,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
             var httpContext = new DefaultHttpContext();
             httpContext.Connection.ClientCertificate = Certificates.SelfSignedValidWithClientEku;
             var transform = new RequestHeaderClientCertTransform();
-            var result = transform.Apply(httpContext, StringValues.Empty);
+            var result = transform.Apply(httpContext, new HttpRequestMessage(), StringValues.Empty);
             var expected = Convert.ToBase64String(Certificates.SelfSignedValidWithClientEku.RawData);
             Assert.Equal(expected, result);
         }
@@ -37,7 +38,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         {
             var httpContext = new DefaultHttpContext();
             var transform = new RequestHeaderClientCertTransform();
-            var result = transform.Apply(httpContext, "OtherValue");
+            var result = transform.Apply(httpContext, new HttpRequestMessage(), "OtherValue");
             Assert.Equal(StringValues.Empty, result);
         }
 
@@ -47,7 +48,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
             var httpContext = new DefaultHttpContext();
             httpContext.Connection.ClientCertificate = Certificates.SelfSignedValidWithClientEku;
             var transform = new RequestHeaderClientCertTransform();
-            var result = transform.Apply(httpContext, "OtherValue");
+            var result = transform.Apply(httpContext, new HttpRequestMessage(), "OtherValue");
             var expected = Convert.ToBase64String(Certificates.SelfSignedValidWithClientEku.RawData);
             Assert.Equal(expected, result);
         }

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/RequestHeaderForwardedTransformTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/RequestHeaderForwardedTransformTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net;
+using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.ReverseProxy.Utilities;
 using Xunit;
@@ -25,7 +26,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Scheme = scheme;
             var transform = new RequestHeaderForwardedTransform(randomFactory, forFormat: RequestHeaderForwardedTransform.NodeFormat.None, byFormat: RequestHeaderForwardedTransform.NodeFormat.None, host: false, proto: true, append);
-            var result = transform.Apply(httpContext, startValue.Split("|", System.StringSplitOptions.RemoveEmptyEntries));
+            var result = transform.Apply(httpContext, new HttpRequestMessage(), startValue.Split("|", System.StringSplitOptions.RemoveEmptyEntries));
             Assert.Equal(expected.Split("|", System.StringSplitOptions.RemoveEmptyEntries), result);
         }
 
@@ -48,7 +49,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Host = new HostString(host);
             var transform = new RequestHeaderForwardedTransform(randomFactory, forFormat: RequestHeaderForwardedTransform.NodeFormat.None, byFormat: RequestHeaderForwardedTransform.NodeFormat.None, host: true, proto: false, append);
-            var result = transform.Apply(httpContext, startValue.Split("|", System.StringSplitOptions.RemoveEmptyEntries));
+            var result = transform.Apply(httpContext, new HttpRequestMessage(), startValue.Split("|", System.StringSplitOptions.RemoveEmptyEntries));
             Assert.Equal(expected.Split("|", System.StringSplitOptions.RemoveEmptyEntries), result);
         }
 
@@ -79,7 +80,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
             httpContext.Connection.RemoteIpAddress = string.IsNullOrEmpty(ip) ? null : IPAddress.Parse(ip);
             httpContext.Connection.RemotePort = port;
             var transform = new RequestHeaderForwardedTransform(randomFactory, forFormat: format, byFormat: RequestHeaderForwardedTransform.NodeFormat.None, host: false, proto: false, append);
-            var result = transform.Apply(httpContext, startValue.Split("|", System.StringSplitOptions.RemoveEmptyEntries));
+            var result = transform.Apply(httpContext, new HttpRequestMessage(), startValue.Split("|", System.StringSplitOptions.RemoveEmptyEntries));
             Assert.Equal(expected.Split("|", System.StringSplitOptions.RemoveEmptyEntries), result);
         }
 
@@ -110,7 +111,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
             httpContext.Connection.LocalIpAddress = string.IsNullOrEmpty(ip) ? null : IPAddress.Parse(ip);
             httpContext.Connection.LocalPort = port;
             var transform = new RequestHeaderForwardedTransform(randomFactory, forFormat: RequestHeaderForwardedTransform.NodeFormat.None, byFormat: format, host: false, proto: false, append);
-            var result = transform.Apply(httpContext, startValue.Split("|", System.StringSplitOptions.RemoveEmptyEntries));
+            var result = transform.Apply(httpContext, new HttpRequestMessage(), startValue.Split("|", System.StringSplitOptions.RemoveEmptyEntries));
             Assert.Equal(expected.Split("|", System.StringSplitOptions.RemoveEmptyEntries), result);
         }
 
@@ -133,7 +134,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
                 forFormat: RequestHeaderForwardedTransform.NodeFormat.IpAndPort,
                 byFormat: RequestHeaderForwardedTransform.NodeFormat.Random,
                 host: true, proto: true, append);
-            var result = transform.Apply(httpContext, startValue.Split("|", System.StringSplitOptions.RemoveEmptyEntries));
+            var result = transform.Apply(httpContext, new HttpRequestMessage(), startValue.Split("|", System.StringSplitOptions.RemoveEmptyEntries));
             Assert.Equal(expected.Split("|", System.StringSplitOptions.RemoveEmptyEntries), result);
         }
 

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/RequestHeaderValueTransformTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/RequestHeaderValueTransformTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Xunit;
 
@@ -22,7 +23,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
         {
             var httpContext = new DefaultHttpContext();
             var transform = new RequestHeaderValueTransform(value, append);
-            var result = transform.Apply(httpContext, startValue.Split(";", System.StringSplitOptions.RemoveEmptyEntries));
+            var result = transform.Apply(httpContext, new HttpRequestMessage(), startValue.Split(";", System.StringSplitOptions.RemoveEmptyEntries));
             Assert.Equal(expected.Split(";", System.StringSplitOptions.RemoveEmptyEntries), result);
         }
     }

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/RequestHeaderXForwardedForTransformTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/RequestHeaderXForwardedForTransformTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Net;
+using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Xunit;
 
@@ -29,7 +30,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
             var httpContext = new DefaultHttpContext();
             httpContext.Connection.RemoteIpAddress = string.IsNullOrEmpty(remoteIp) ? null : IPAddress.Parse(remoteIp);
             var transform = new RequestHeaderXForwardedForTransform(append);
-            var result = transform.Apply(httpContext, startValue.Split(";", System.StringSplitOptions.RemoveEmptyEntries));
+            var result = transform.Apply(httpContext, new HttpRequestMessage(), startValue.Split(";", System.StringSplitOptions.RemoveEmptyEntries));
             Assert.Equal(expected.Split(";", System.StringSplitOptions.RemoveEmptyEntries), result);
         }
     }

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/RequestHeaderXForwardedHostTransformTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/RequestHeaderXForwardedHostTransformTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Xunit;
 
@@ -30,7 +31,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Host = string.IsNullOrEmpty(host) ? new HostString() : new HostString(host);
             var transform = new RequestHeaderXForwardedHostTransform(append);
-            var result = transform.Apply(httpContext, startValue.Split(";", System.StringSplitOptions.RemoveEmptyEntries));
+            var result = transform.Apply(httpContext, new HttpRequestMessage(), startValue.Split(";", System.StringSplitOptions.RemoveEmptyEntries));
             Assert.Equal(expected.Split(";", System.StringSplitOptions.RemoveEmptyEntries), result);
         }
     }

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/RequestHeaderXForwardedPathBaseTransformTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/RequestHeaderXForwardedPathBaseTransformTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Xunit;
 
@@ -32,7 +33,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
             var httpContext = new DefaultHttpContext();
             httpContext.Request.PathBase = string.IsNullOrEmpty(pathBase) ? new PathString() : new PathString(pathBase);
             var transform = new RequestHeaderXForwardedPathBaseTransform(append);
-            var result = transform.Apply(httpContext, startValue.Split(";", System.StringSplitOptions.RemoveEmptyEntries));
+            var result = transform.Apply(httpContext, new HttpRequestMessage(), startValue.Split(";", System.StringSplitOptions.RemoveEmptyEntries));
             Assert.Equal(expected.Split(";", System.StringSplitOptions.RemoveEmptyEntries), result);
         }
     }

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/RequestHeaderXForwardedProtoTransformTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/RequestHeaderXForwardedProtoTransformTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Xunit;
 
@@ -21,7 +22,7 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Scheme = scheme;
             var transform = new RequestHeaderXForwardedProtoTransform(append);
-            var result = transform.Apply(httpContext, startValue.Split(";", System.StringSplitOptions.RemoveEmptyEntries));
+            var result = transform.Apply(httpContext, new HttpRequestMessage(), startValue.Split(";", System.StringSplitOptions.RemoveEmptyEntries));
             Assert.Equal(expected.Split(";", System.StringSplitOptions.RemoveEmptyEntries), result);
         }
     }

--- a/test/ReverseProxy.Tests/Utilities/RequestUtilitiesTests.cs
+++ b/test/ReverseProxy.Tests/Utilities/RequestUtilitiesTests.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Microsoft.ReverseProxy.Utilities
+{
+    public class RequestUtilitiesTests
+    {
+        [Theory]
+        [InlineData("http://localhost", "", "", "http://localhost/")]
+        [InlineData("http://localhost/", "", "", "http://localhost/")]
+        [InlineData("http://localhost", "/", "", "http://localhost/")]
+        [InlineData("http://localhost/", "/", "", "http://localhost/")]
+        [InlineData("http://localhost", "", "?query", "http://localhost/?query")]
+        [InlineData("http://localhost", "/path", "?query", "http://localhost/path?query")]
+        [InlineData("http://localhost", "/path/", "?query", "http://localhost/path/?query")]
+        [InlineData("http://localhost/", "/path", "?query", "http://localhost/path?query")]
+        [InlineData("http://localhost/base", "", "", "http://localhost/base")]
+        [InlineData("http://localhost/base", "", "?query", "http://localhost/base?query")]
+        [InlineData("http://localhost/base", "/path", "?query", "http://localhost/base/path?query")]
+        [InlineData("http://localhost/base/", "/path", "?query", "http://localhost/base/path?query")]
+        [InlineData("http://localhost/base/", "/path/", "?query", "http://localhost/base/path/?query")]
+        public void MakeDestinationAddress(string destinationPrefix, string path, string query, string expected)
+        {
+            var uri = RequestUtilities.MakeDestinationAddress(destinationPrefix, new PathString(path), new QueryString(query));
+            Assert.Equal(expected, uri.AbsoluteUri);
+        }
+    }
+}


### PR DESCRIPTION
#594 IHttpProxy is getting much more attention/usage than other parts of YARP. Long term we're interested in moving that component into ASP.NET Core. However, IHttpProxy also brings in the entire transforms infrastructure which it's not clear if people using IHttpProxy directly need, or if they could use a simplified model (e.g. callbacks).

Here's the proposed new transforms model for IHttpProxy:
```
    public record HttpTransforms
    {
        public static readonly HttpTransforms Empty = new HttpTransforms();

        /// <summary>
        /// Indicates if all request headers should be copied to the outgoing HttpRequestMessage before invoking
        /// OnRequest. Disable this if you want to manually control which headers are copied.
        /// Note this copy excludes certain protocol headers like HTTP/2 psuedo headers (":authority").
        /// </summary>
        public bool CopyRequestHeaders { get; init; } = true;

        /// <summary>
        /// Indicates if all response headers should be copied from the received HttpResponseMessage before invoking
        /// OnResponse. Disable this if you want to manually control which headers are copied.
        /// Note this copy excludes certain protocol headers like `Transfer-Encoding: chunked`.
        /// </summary>
        public bool CopyResponseHeaders { get; init; } = true;

        /// <summary>
        /// Indicates if all response trailers should be copied from the received HttpResponseMessage before invoking
        /// OnResponseTrailers. Disable this if you want to manually control which headers are copied.
        /// </summary>
        public bool CopyResponseTrailers { get; init; } = true;

        /// <summary>
        /// A callback that is invoked prior to sending the proxied request. All HttpRequestMessage fields are
        /// initialized except RequestUri, which will be initialized after the callback if no value is provided.
        /// The string parameter represents the destination URI prefix that should be used when constructing the RequestUri.
        /// The headers will be copied before the callback if CopyRequestHeaders is enabled.
        /// </summary>
        public Func<HttpContext, HttpRequestMessage, string, Task> OnRequest { get; init; }

        /// <summary>
        /// A callback that is invoked when the proxied response is received. The status code and reason phrase will be copied
        /// to the HttpContext.Response before the callback is invoked, but may still be modified there. The headers will be
        /// copied to HttpContext.Response.Headers before the callback if CopyResponseHeaders is enabled.
        /// </summary>
        public Func<HttpContext, HttpResponseMessage, Task> OnResponse { get; init; }

        /// <summary>
        /// A callback that is invoked after the response body to modify trailers, if supported. The trailers will be
        /// copied to the HttpContext.Response before the callback if CopyResponseTrailers is enabled.
        /// </summary>
        public Func<HttpContext, HttpResponseMessage, Task> OnResponseTrailers { get; init; }
    }
```

The idea is that everything should just work but you can get in and tweak things as needed. The higher layer uses these callbacks to hook in and run about the same structured transforms logic it was doing before. There's a little code duplication around header copying to to investigate, and some tests that need cleaning up.
