### PR TITLE
Support baggage header in ActivityPropagationHandler

### DIFF
--- a/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/ActivityContextHeaders.cs
+++ b/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/ActivityContextHeaders.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.ReverseProxy.Abstractions
+{
+    [Flags]
+    public enum ActivityContextHeaders
+    {
+        None = 0,
+        Baggage = 1,
+        CorrelationContext = 2,
+        BaggageAndCorrelationContext = Baggage | CorrelationContext
+    }
+}

--- a/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/ProxyHttpClientOptions.cs
+++ b/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/ProxyHttpClientOptions.cs
@@ -39,9 +39,9 @@ namespace Microsoft.ReverseProxy.Abstractions
         public int? MaxConnectionsPerServer { get; init; }
 
         /// <summary>
-        /// Enables or disables the activity correlation headers for outgoing requests.
+        /// Specifies the activity correlation headers for outgoing requests.
         /// </summary>
-        public bool? PropagateActivityContext { get; init; }
+        public ActivityContextHeaders? ActivityContextHeaders { get; init; }
 
         // TODO: Add this property once we have migrated to SDK version that supports it.
         //public bool? EnableMultipleHttp2Connections { get; init; }
@@ -58,7 +58,7 @@ namespace Microsoft.ReverseProxy.Abstractions
                 && CertEquals(ClientCertificate, other.ClientCertificate)
                 && DangerousAcceptAnyServerCertificate == other.DangerousAcceptAnyServerCertificate
                 && MaxConnectionsPerServer == other.MaxConnectionsPerServer
-                && PropagateActivityContext == other.PropagateActivityContext;
+                && ActivityContextHeaders == other.ActivityContextHeaders;
         }
 
         private static bool CertEquals(X509Certificate2 certificate1, X509Certificate2 certificate2)
@@ -83,7 +83,7 @@ namespace Microsoft.ReverseProxy.Abstractions
                 ClientCertificate?.Thumbprint,
                 DangerousAcceptAnyServerCertificate,
                 MaxConnectionsPerServer,
-                PropagateActivityContext);
+                ActivityContextHeaders);
         }
     }
 }

--- a/src/ReverseProxy/Configuration/ConfigurationConfigProvider.cs
+++ b/src/ReverseProxy/Configuration/ConfigurationConfigProvider.cs
@@ -325,7 +325,7 @@ namespace Microsoft.ReverseProxy.Configuration
                 DangerousAcceptAnyServerCertificate = section.ReadBool(nameof(ProxyHttpClientOptions.DangerousAcceptAnyServerCertificate)),
                 ClientCertificate = clientCertificate,
                 MaxConnectionsPerServer = section.ReadInt32(nameof(ProxyHttpClientOptions.MaxConnectionsPerServer)),
-                PropagateActivityContext = section.ReadBool(nameof(ProxyHttpClientOptions.PropagateActivityContext))
+                ActivityContextHeaders = section.ReadEnum<ActivityContextHeaders>(nameof(ProxyHttpClientOptions.ActivityContextHeaders))
             };
         }
 

--- a/src/ReverseProxy/Service/Proxy/Infrastructure/ProxyHttpClientFactory.cs
+++ b/src/ReverseProxy/Service/Proxy/Infrastructure/ProxyHttpClientFactory.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;
+using Microsoft.ReverseProxy.Abstractions;
 using Microsoft.ReverseProxy.Telemetry;
 
 namespace Microsoft.ReverseProxy.Service.Proxy.Infrastructure
@@ -67,9 +68,10 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Infrastructure
 
             Log.ProxyClientCreated(_logger, context.ClusterId);
 
-            if (newClientOptions.PropagateActivityContext.GetValueOrDefault(true))
+            var activityContextHeaders = newClientOptions.ActivityContextHeaders.GetValueOrDefault(ActivityContextHeaders.BaggageAndCorrelationContext);
+            if (activityContextHeaders != ActivityContextHeaders.None)
             {
-                return new HttpMessageInvoker(new ActivityPropagationHandler(handler), disposeHandler: true);
+                return new HttpMessageInvoker(new ActivityPropagationHandler(activityContextHeaders, handler), disposeHandler: true);
             }
 
             return new HttpMessageInvoker(handler, disposeHandler: true);

--- a/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/ClusterTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/ClusterTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
                     SslProtocols = SslProtocols.Tls11 | SslProtocols.Tls12,
                     MaxConnectionsPerServer = 10,
                     DangerousAcceptAnyServerCertificate = true,
-                    PropagateActivityContext = true,
+                    ActivityContextHeaders = ActivityContextHeaders.CorrelationContext,
                 },
                 HttpRequest = new RequestProxyOptions
                 {
@@ -137,7 +137,7 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
                     SslProtocols = SslProtocols.Tls11 | SslProtocols.Tls12,
                     MaxConnectionsPerServer = 10,
                     DangerousAcceptAnyServerCertificate = true,
-                    PropagateActivityContext = true,
+                    ActivityContextHeaders = ActivityContextHeaders.CorrelationContext,
                 },
                 HttpRequest = new RequestProxyOptions
                 {
@@ -214,7 +214,7 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
                     SslProtocols = SslProtocols.Tls11 | SslProtocols.Tls12,
                     MaxConnectionsPerServer = 10,
                     DangerousAcceptAnyServerCertificate = true,
-                    PropagateActivityContext = true,
+                    ActivityContextHeaders = ActivityContextHeaders.CorrelationContext,
                 },
                 HttpRequest = new RequestProxyOptions
                 {
@@ -248,7 +248,7 @@ namespace Microsoft.ReverseProxy.Abstractions.Tests
                     SslProtocols = SslProtocols.Tls12,
                     MaxConnectionsPerServer = 10,
                     DangerousAcceptAnyServerCertificate = true,
-                    PropagateActivityContext = true,
+                    ActivityContextHeaders = ActivityContextHeaders.CorrelationContext,
                 }
             }));
             Assert.False(options1.Equals(options1 with { HttpRequest = new RequestProxyOptions() { } }));

--- a/test/ReverseProxy.Tests/Configuration/ConfigurationConfigProviderTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigurationConfigProviderTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.ReverseProxy.Configuration
                             SslProtocols = SslProtocols.Tls11 | SslProtocols.Tls12,
                             MaxConnectionsPerServer = 10,
                             DangerousAcceptAnyServerCertificate = true,
-                            PropagateActivityContext = true,
+                            ActivityContextHeaders = ActivityContextHeaders.Baggage
                         },
                         HttpRequest = new RequestProxyOptions()
                         {
@@ -214,6 +214,7 @@ namespace Microsoft.ReverseProxy.Configuration
                 },
                 ""MaxConnectionsPerServer"": 10,
                 ""PropagateActivityContext"": true,
+                ""ActivityContextHeaders"": ""Baggage""
             },
             ""HttpRequest"": {
                 ""Timeout"": ""00:01:00"",
@@ -595,7 +596,7 @@ namespace Microsoft.ReverseProxy.Configuration
             Assert.Equal(cluster1.SessionAffinity.Settings, abstractCluster1.SessionAffinity.Settings);
             Assert.Same(certificate, abstractCluster1.HttpClient.ClientCertificate);
             Assert.Equal(cluster1.HttpClient.MaxConnectionsPerServer, abstractCluster1.HttpClient.MaxConnectionsPerServer);
-            Assert.Equal(cluster1.HttpClient.PropagateActivityContext, abstractCluster1.HttpClient.PropagateActivityContext);
+            Assert.Equal(cluster1.HttpClient.ActivityContextHeaders, abstractCluster1.HttpClient.ActivityContextHeaders);
             Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, abstractCluster1.HttpClient.SslProtocols);
             Assert.Equal(cluster1.HttpRequest.Timeout, abstractCluster1.HttpRequest.Timeout);
             Assert.Equal(HttpVersion.Version10, abstractCluster1.HttpRequest.Version);

--- a/test/ReverseProxy.Tests/Service/Proxy/Infrastructure/ProxyHttpClientFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/Infrastructure/ProxyHttpClientFactoryTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
         public void CreateClient_ApplyPropagateActivityContext_Success()
         {
             var factory = new ProxyHttpClientFactory(Mock<ILogger<ProxyHttpClientFactory>>().Object);
-            var options = new ProxyHttpClientOptions { PropagateActivityContext = false };
+            var options = new ProxyHttpClientOptions { ActivityContextHeaders = ActivityContextHeaders.None };
             var client = factory.CreateClient(new ProxyHttpClientContext { NewOptions = options });
 
             var handler = GetHandler(client, expectActivityPropagationHandler: false);
@@ -132,7 +132,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                 DangerousAcceptAnyServerCertificate = true,
                 ClientCertificate = clientCertificate,
                 MaxConnectionsPerServer = 10,
-                PropagateActivityContext = true,
+                ActivityContextHeaders = ActivityContextHeaders.CorrelationContext,
             };
             var newOptions = oldOptions with { }; // Clone
             var oldMetadata = new Dictionary<string, string> { { "key1", "value1" }, { "key2", "value2" } };
@@ -171,7 +171,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                         DangerousAcceptAnyServerCertificate = true,
                         ClientCertificate = clientCertificate,
                         MaxConnectionsPerServer = null,
-                        PropagateActivityContext = false,
+                        ActivityContextHeaders = ActivityContextHeaders.None,
                     },
                     new ProxyHttpClientOptions
                     {
@@ -179,7 +179,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                         DangerousAcceptAnyServerCertificate = true,
                         ClientCertificate = clientCertificate,
                         MaxConnectionsPerServer = null,
-                        PropagateActivityContext = false,
+                        ActivityContextHeaders = ActivityContextHeaders.None,
                     },
                 },
                 new object[] {
@@ -189,7 +189,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                         DangerousAcceptAnyServerCertificate = true,
                         ClientCertificate = clientCertificate,
                         MaxConnectionsPerServer = null,
-                        PropagateActivityContext = false,
+                        ActivityContextHeaders = ActivityContextHeaders.None,
                     },
                     new ProxyHttpClientOptions
                     {
@@ -197,7 +197,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                         DangerousAcceptAnyServerCertificate = false,
                         ClientCertificate = clientCertificate,
                         MaxConnectionsPerServer = null,
-                        PropagateActivityContext = false,
+                        ActivityContextHeaders = ActivityContextHeaders.None,
                     },
                 },
                 new object[] {
@@ -207,7 +207,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                         DangerousAcceptAnyServerCertificate = true,
                         ClientCertificate = clientCertificate,
                         MaxConnectionsPerServer = null,
-                        PropagateActivityContext = false,
+                        ActivityContextHeaders = ActivityContextHeaders.None,
                     },
                     new ProxyHttpClientOptions
                     {
@@ -215,25 +215,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                         DangerousAcceptAnyServerCertificate = false,
                         ClientCertificate = null,
                         MaxConnectionsPerServer = null,
-                        PropagateActivityContext = false,
-                    },
-                },
-                new object[] {
-                    new ProxyHttpClientOptions
-                    {
-                        SslProtocols = SslProtocols.Tls11,
-                        DangerousAcceptAnyServerCertificate = true,
-                        ClientCertificate = null,
-                        MaxConnectionsPerServer = null,
-                        PropagateActivityContext = false,
-                    },
-                    new ProxyHttpClientOptions
-                    {
-                        SslProtocols = SslProtocols.Tls11,
-                        DangerousAcceptAnyServerCertificate = false,
-                        ClientCertificate = clientCertificate,
-                        MaxConnectionsPerServer = null,
-                        PropagateActivityContext = false,
+                        ActivityContextHeaders = ActivityContextHeaders.None,
                     },
                 },
                 new object[] {
@@ -243,7 +225,25 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                         DangerousAcceptAnyServerCertificate = true,
                         ClientCertificate = null,
                         MaxConnectionsPerServer = null,
-                        PropagateActivityContext = false,
+                        ActivityContextHeaders = ActivityContextHeaders.None,
+                    },
+                    new ProxyHttpClientOptions
+                    {
+                        SslProtocols = SslProtocols.Tls11,
+                        DangerousAcceptAnyServerCertificate = false,
+                        ClientCertificate = clientCertificate,
+                        MaxConnectionsPerServer = null,
+                        ActivityContextHeaders = ActivityContextHeaders.None,
+                    },
+                },
+                new object[] {
+                    new ProxyHttpClientOptions
+                    {
+                        SslProtocols = SslProtocols.Tls11,
+                        DangerousAcceptAnyServerCertificate = true,
+                        ClientCertificate = null,
+                        MaxConnectionsPerServer = null,
+                        ActivityContextHeaders = ActivityContextHeaders.None,
                     },
                     new ProxyHttpClientOptions
                     {
@@ -251,25 +251,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                         DangerousAcceptAnyServerCertificate = true,
                         ClientCertificate = clientCertificate,
                         MaxConnectionsPerServer = 10,
-                        PropagateActivityContext = false,
-                    },
-                },
-                new object[] {
-                    new ProxyHttpClientOptions
-                    {
-                        SslProtocols = SslProtocols.Tls11,
-                        DangerousAcceptAnyServerCertificate = true,
-                        ClientCertificate = null,
-                        MaxConnectionsPerServer = 10,
-                        PropagateActivityContext = false,
-                    },
-                    new ProxyHttpClientOptions
-                    {
-                        SslProtocols = SslProtocols.Tls11,
-                        DangerousAcceptAnyServerCertificate = true,
-                        ClientCertificate = clientCertificate,
-                        MaxConnectionsPerServer = null,
-                        PropagateActivityContext = false,
+                        ActivityContextHeaders = ActivityContextHeaders.None,
                     },
                 },
                 new object[] {
@@ -279,7 +261,25 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                         DangerousAcceptAnyServerCertificate = true,
                         ClientCertificate = null,
                         MaxConnectionsPerServer = 10,
-                        PropagateActivityContext = false,
+                        ActivityContextHeaders = ActivityContextHeaders.None,
+                    },
+                    new ProxyHttpClientOptions
+                    {
+                        SslProtocols = SslProtocols.Tls11,
+                        DangerousAcceptAnyServerCertificate = true,
+                        ClientCertificate = clientCertificate,
+                        MaxConnectionsPerServer = null,
+                        ActivityContextHeaders = ActivityContextHeaders.None,
+                    },
+                },
+                new object[] {
+                    new ProxyHttpClientOptions
+                    {
+                        SslProtocols = SslProtocols.Tls11,
+                        DangerousAcceptAnyServerCertificate = true,
+                        ClientCertificate = null,
+                        MaxConnectionsPerServer = 10,
+                        ActivityContextHeaders = ActivityContextHeaders.None,
                     },
                     new ProxyHttpClientOptions
                     {
@@ -287,7 +287,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                         DangerousAcceptAnyServerCertificate = true,
                         ClientCertificate = clientCertificate,
                         MaxConnectionsPerServer = 20,
-                        PropagateActivityContext = false,
+                        ActivityContextHeaders = ActivityContextHeaders.None,
                     },
                 },
                 new object[] {
@@ -297,7 +297,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                         DangerousAcceptAnyServerCertificate = true,
                         ClientCertificate = null,
                         MaxConnectionsPerServer = 10,
-                        PropagateActivityContext = true,
+                        ActivityContextHeaders = ActivityContextHeaders.CorrelationContext,
                     },
                     new ProxyHttpClientOptions
                     {
@@ -305,7 +305,43 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
                         DangerousAcceptAnyServerCertificate = true,
                         ClientCertificate = null,
                         MaxConnectionsPerServer = 10,
-                        PropagateActivityContext = false,
+                        ActivityContextHeaders = ActivityContextHeaders.None,
+                    },
+                },
+                new object[] {
+                    new ProxyHttpClientOptions
+                    {
+                        SslProtocols = SslProtocols.Tls11,
+                        DangerousAcceptAnyServerCertificate = true,
+                        ClientCertificate = null,
+                        MaxConnectionsPerServer = 10,
+                        ActivityContextHeaders = ActivityContextHeaders.Baggage,
+                    },
+                    new ProxyHttpClientOptions
+                    {
+                        SslProtocols = SslProtocols.Tls11,
+                        DangerousAcceptAnyServerCertificate = true,
+                        ClientCertificate = null,
+                        MaxConnectionsPerServer = 10,
+                        ActivityContextHeaders = ActivityContextHeaders.CorrelationContext,
+                    },
+                },
+                new object[] {
+                    new ProxyHttpClientOptions
+                    {
+                        SslProtocols = SslProtocols.Tls11,
+                        DangerousAcceptAnyServerCertificate = true,
+                        ClientCertificate = null,
+                        MaxConnectionsPerServer = 10,
+                        ActivityContextHeaders = ActivityContextHeaders.CorrelationContext,
+                    },
+                    new ProxyHttpClientOptions
+                    {
+                        SslProtocols = SslProtocols.Tls11,
+                        DangerousAcceptAnyServerCertificate = true,
+                        ClientCertificate = null,
+                        MaxConnectionsPerServer = 10,
+                        ActivityContextHeaders = ActivityContextHeaders.BaggageAndCorrelationContext,
                     },
                 }
             };
@@ -330,7 +366,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
         {
             var skippedSet = new HashSet<string>(skippedExtractors);
             var defaultHandler = new SocketsHttpHandler();
-            foreach(var extractor in GetAllExtractors().Where(e => !skippedSet.Contains(e.name)).Select(e => e.extractor))
+            foreach (var extractor in GetAllExtractors().Where(e => !skippedSet.Contains(e.name)).Select(e => e.extractor))
             {
                 Assert.Equal(extractor(defaultHandler), extractor(actualHandler));
             }


### PR DESCRIPTION
I've added an enum for `ActivityContextHeaders` to support `baggage`, `CorrelationContext` or both.
I also shared the enum between the options model and runtime model which I'm not sure if it's ok. 

Fixes https://github.com/microsoft/reverse-proxy/issues/621