### PR TITLE
Remove default value for DangerousAcceptAnyServerCertificate in ConfigurationConfigProvider

### DIFF
--- a/src/ReverseProxy/Configuration/ConfigurationConfigProvider.cs
+++ b/src/ReverseProxy/Configuration/ConfigurationConfigProvider.cs
@@ -319,7 +319,7 @@ namespace Microsoft.ReverseProxy.Configuration
             return new ProxyHttpClientOptions
             {
                 SslProtocols = sslProtocols,
-                DangerousAcceptAnyServerCertificate = section.ReadBool(nameof(ProxyHttpClientOptions.DangerousAcceptAnyServerCertificate)) ?? true,
+                DangerousAcceptAnyServerCertificate = section.ReadBool(nameof(ProxyHttpClientOptions.DangerousAcceptAnyServerCertificate)),
                 ClientCertificate = clientCertificate,
                 MaxConnectionsPerServer = section.ReadInt32(nameof(ProxyHttpClientOptions.MaxConnectionsPerServer)),
                 PropagateActivityContext = section.ReadBool(nameof(ProxyHttpClientOptions.PropagateActivityContext))


### PR DESCRIPTION
Fixes https://github.com/microsoft/reverse-proxy/issues/623