### PR TITLE
Use ValueStopwatch to reduce allocation

### DIFF
--- a/src/ReverseProxy.ServiceFabric/FabricWrapper/PropertyManagementClientWrapper.cs
+++ b/src/ReverseProxy.ServiceFabric/FabricWrapper/PropertyManagementClientWrapper.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Fabric;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.ReverseProxy.Utilities;
 
 namespace Microsoft.ReverseProxy.ServiceFabric
 {
@@ -56,7 +56,7 @@ namespace Microsoft.ReverseProxy.ServiceFabric
             PropertyEnumerationResult previousResult = null;
 
             // Set up the counter that record the time lapse.
-            var stopWatch = Stopwatch.StartNew();
+            var stopWatch = ValueStopwatch.StartNew();
             do
             {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/ReverseProxy.ServiceFabric/FabricWrapper/QueryClientWrapper.cs
+++ b/src/ReverseProxy.ServiceFabric/FabricWrapper/QueryClientWrapper.cs
@@ -3,13 +3,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Fabric;
 using System.Fabric.Query;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.ReverseProxy.Utilities;
 
 namespace Microsoft.ReverseProxy.ServiceFabric
 {
@@ -51,7 +51,7 @@ namespace Microsoft.ReverseProxy.ServiceFabric
             ApplicationList previousResult = null;
 
             // Set up the counter that record the time lapse.
-            var stopWatch = Stopwatch.StartNew();
+            var stopWatch = ValueStopwatch.StartNew();
             do
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -114,7 +114,7 @@ namespace Microsoft.ReverseProxy.ServiceFabric
             ServiceList previousResult = null;
 
             // Set up the counter that record the time lapse.
-            var stopWatch = Stopwatch.StartNew();
+            var stopWatch = ValueStopwatch.StartNew();
             do
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -182,7 +182,7 @@ namespace Microsoft.ReverseProxy.ServiceFabric
             ServicePartitionList previousResult = null;
 
             // Set up the counter that record the time lapse.
-            var stopWatch = Stopwatch.StartNew();
+            var stopWatch = ValueStopwatch.StartNew();
             do
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -218,7 +218,7 @@ namespace Microsoft.ReverseProxy.ServiceFabric
             ServiceReplicaList previousResult = null;
 
             // Set up the counter that record the time lapse.
-            var stopWatch = Stopwatch.StartNew();
+            var stopWatch = ValueStopwatch.StartNew();
             do
             {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/ReverseProxy.ServiceFabric/Microsoft.ReverseProxy.ServiceFabric.csproj
+++ b/src/ReverseProxy.ServiceFabric/Microsoft.ReverseProxy.ServiceFabric.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\ReverseProxy\Utilities\ValueStopwatch.cs" Link="Utilities\ValueStopwatch.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.ReverseProxy.ServiceFabric.Tests" />
   </ItemGroup>

--- a/src/ReverseProxy/Utilities/Clock.cs
+++ b/src/ReverseProxy/Utilities/Clock.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,7 +9,7 @@ namespace Microsoft.ReverseProxy.Utilities
 {
     internal sealed class Clock : IClock
     {
-        private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+        private readonly ValueStopwatch _stopwatch = ValueStopwatch.StartNew();
 
         public long TickCount => Environment.TickCount64;
 


### PR DESCRIPTION
`ValueStopwatch` could replace `Stopwatch` to reduce allocation.
Since `ValueStopwatch` is an internal type in `ReverseProxy` project, I added it to `ReverseProxy.ServiceFabric` as a linked file.