### PR TITLE
Fix the link to the Code of Conduct

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -60,4 +60,4 @@ Your pull request will now go through extensive checks by the subject matter exp
 
 ## Code of conduct
 
-See [CODE-OF-CONDUCT.md](./CODE-OF-CONDUCT.md)
+See [CODE-OF-CONDUCT.md](./CODE_OF_CONDUCT.md)


### PR DESCRIPTION
Or we could rename the file so it has the same name as it has in ASP.Net Core repository.