### PR TITLE
Smaller buffer size for perf.

### DIFF
--- a/src/ReverseProxy/Service/Proxy/StreamCopier.cs
+++ b/src/ReverseProxy/Service/Proxy/StreamCopier.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy
     /// </summary>
     internal static class StreamCopier
     {
-        // Based on performance investigations.
+        // Based on performance investigations, see https://github.com/microsoft/reverse-proxy/pull/330#issuecomment-758851852.
         private const int DefaultBufferSize = 65536;
 
         private static readonly TimeSpan TimeBetweenTransferringEvents = TimeSpan.FromSeconds(1);

--- a/src/ReverseProxy/Service/Proxy/StreamCopier.cs
+++ b/src/ReverseProxy/Service/Proxy/StreamCopier.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy
     /// </summary>
     internal static class StreamCopier
     {
-        // Taken from https://github.com/aspnet/Proxy/blob/816f65429b29d98e3ca98dd6b4d5e990f5cc7c02/src/Microsoft.AspNetCore.Proxy/ProxyAdvancedExtensions.cs#L19
+        // Based on performance investigations.
         private const int DefaultBufferSize = 65536;
 
         private static readonly TimeSpan TimeBetweenTransferringEvents = TimeSpan.FromSeconds(1);

--- a/src/ReverseProxy/Service/Proxy/StreamCopier.cs
+++ b/src/ReverseProxy/Service/Proxy/StreamCopier.cs
@@ -18,7 +18,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy
     internal static class StreamCopier
     {
         // Taken from https://github.com/aspnet/Proxy/blob/816f65429b29d98e3ca98dd6b4d5e990f5cc7c02/src/Microsoft.AspNetCore.Proxy/ProxyAdvancedExtensions.cs#L19
-        private const int DefaultBufferSize = 81920;
+        private const int DefaultBufferSize = 65536;
 
         private static readonly TimeSpan TimeBetweenTransferringEvents = TimeSpan.FromSeconds(1);
 

--- a/test/ReverseProxy.Tests/Service/Proxy/StreamCopyHttpContentTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/StreamCopyHttpContentTests.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.ReverseProxy.Common.Tests;
 using Microsoft.ReverseProxy.Utilities;
 using Moq;
@@ -38,11 +39,22 @@ namespace Microsoft.ReverseProxy.Service.Proxy.Tests
         }
 
         [Theory]
-        [InlineData(false, 1)] // we expect to always flush at least once to trigger sending request headers
-        [InlineData(true, 2)]
-        public async Task CopyToAsync_AutoFlushing(bool autoFlush, int expectedFlushes)
+        [InlineData(false)] // we expect to always flush at least once to trigger sending request headers
+        [InlineData(true)]
+        public async Task CopyToAsync_AutoFlushing(bool autoFlush)
         {
+            // Must be same as StreamCopier constant.
+            const int DefaultBufferSize = 65536;
             const int SourceSize = (128 * 1024) - 3;
+
+            var expectedFlushes = 0;
+            if (autoFlush)
+            {
+                // How many buffers is needed to send the source rounded up.
+                expectedFlushes = (SourceSize - 1) / DefaultBufferSize + 1;
+            }
+            // Explicit flush after headers are sent.
+            expectedFlushes++;
 
             var sourceBytes = Enumerable.Range(0, SourceSize).Select(i => (byte)(i % 256)).ToArray();
             var source = new MemoryStream(sourceBytes);


### PR DESCRIPTION
Based on findings from https://github.com/microsoft/reverse-proxy/pull/330#issuecomment-758851852
The smaller buffer should bring some perf improvement.