### PR TITLE
Docs - unify dependency on .NET 5 references

### DIFF
--- a/docs/docfx/articles/getting_started.md
+++ b/docs/docfx/articles/getting_started.md
@@ -7,7 +7,7 @@ title: Getting Started with YARP
 
 YARP is designed as a library that provides the core proxy functionality which you can then customize by adding or replacing modules. YARP is currently provided as a NuGet package and code snippets. We plan on providing a project template and pre-built exe in the future. 
 
-YARP 1.0.0 Preview 7 supports ASP.NET Core 3.1 and 5.0.0. You can download the .NET 5 SDK from https://dotnet.microsoft.com/download/dotnet/5.0. .NET 5.0 on Windows requires Visual Studio 2019 v16.8 or newer.
+YARP 1.0.0 Preview 7 supports ASP.NET Core 3.1 and 5.0. You can download the .NET 5 SDK from https://dotnet.microsoft.com/download/dotnet/5.0. ASP.NET Core 5.0 on Windows requires Visual Studio 2019 v16.8 or newer.
 
 ### Create a new project
 

--- a/docs/docfx/articles/runtimes.md
+++ b/docs/docfx/articles/runtimes.md
@@ -5,17 +5,17 @@ title: Supported Runtimes
 
 # YARP Supported Runtimes
 
-YARP 1.0 previews support ASP.NET Core 3.1 and 5.0 previews. You can download the .NET 5 Preview SDK from https://dotnet.microsoft.com/download/dotnet/5.0. See [Releases](https://github.com/microsoft/reverse-proxy/releases) for specific version support.
+YARP 1.0 previews support ASP.NET Core 3.1 and 5.0. You can download the .NET 5 SDK from https://dotnet.microsoft.com/download/dotnet/5.0. See [Releases](https://github.com/microsoft/reverse-proxy/releases) for specific version support.
 
-YARP will be taking advantage of 5.0 features and optimizations as they become available. This does mean that some features may not be available if you're running on 3.1.
+YARP is taking advantage of ASP.NET Core 5.0 features and optimizations. This does mean that some features may not be available if you're running on ASP.NET Core 3.1.
 
 ## Related 5.0 Runtime Improvements
 
-These are related improvements in .NET or ASP.NET Core 5.0 that YARP is able to take advantage of. We expect to add more as they become available.
+These are related improvements in .NET 5.0 or ASP.NET Core 5.0 that YARP is able to take advantage of:
 - Kestrel [reloadable config](https://github.com/dotnet/aspnetcore/issues/19376).
-- Kestrel HTTP/2 performance improvements.
-  - [HPACK static compression](https://github.com/dotnet/aspnetcore/pull/20058)
+- Kestrel HTTP/2 performance improvements:
+  - [HPACK static compression](https://github.com/dotnet/aspnetcore/pull/20058).
   - [HPACK dynamic compression](https://github.com/dotnet/aspnetcore/pull/19521).
-  - [Allocation savings via stream pooling](https://github.com/dotnet/aspnetcore/pull/18601)
-  - [Allocation savings via pipe pooling](https://github.com/dotnet/aspnetcore/pull/19356)
+  - [Allocation savings via stream pooling](https://github.com/dotnet/aspnetcore/pull/18601).
+  - [Allocation savings via pipe pooling](https://github.com/dotnet/aspnetcore/pull/19356).
 - HttpClient HTTP/2 [performance improvements](https://github.com/dotnet/runtime/issues/35184).


### PR DESCRIPTION
- We depend on .NET 5, not on previews anymore
- Unify ASP.NET Core vs. .NET references