### PR TITLE
Disable Hosting.Diagnostics logging

### DIFF
--- a/samples/BenchmarkApp/appsettings.json
+++ b/samples/BenchmarkApp/appsettings.json
@@ -1,9 +1,14 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Default": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Microsoft.AspNetCore.Hosting.Diagnostics": "None"
+    },
+    "EventLog": {
+      "LogLevel": {
+        "Default": "None"
+      }
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
Results in removing the overhead associated with creating an Activity per request.

Diff should be around 13%.

Note: The HttpClient scenario doesn't suffer from this as it's not calling `Host.CreateDefaultBuilder`, but creating the builder manually.