### PR TITLE
Fix BuildCluster_NullTimespan test

### DIFF
--- a/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/Util/LabelsParserTests.cs
+++ b/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/Util/LabelsParserTests.cs
@@ -192,7 +192,7 @@ namespace Microsoft.ReverseProxy.ServiceFabric.Tests
                 { "YARP.Backend.HealthCheck.Active.Interval", value },
             };
 
-            var cluster = LabelsParser.BuildCluster(_testServiceName, labels);
+            var cluster = LabelsParser.BuildCluster(_testServiceName, labels, null);
 
             cluster.HealthCheck.Active.Interval.Should().BeNull();
         }


### PR DESCRIPTION
I just noticed https://github.com/microsoft/reverse-proxy/pull/605 breaks the build. Here's the fix.