### PR TITLE
Log ProxyError with LogLevel.Error

### DIFF
--- a/src/ReverseProxy/Service/Proxy/HttpProxy.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpProxy.cs
@@ -643,7 +643,7 @@ namespace Microsoft.ReverseProxy.Service.Proxy
                 "Proxying to {targetUrl}");
 
             private static readonly Action<ILogger, ProxyError, string, Exception> _proxyError = LoggerMessage.Define<ProxyError, string>(
-                LogLevel.Information,
+                LogLevel.Error,
                 EventIds.ProxyError,
                 "{error}: {message}");
 


### PR DESCRIPTION
Prevent suppressing error messages when minimum log level is set above `LogLevel.Information`