### PR TITLE
Enable unit testing of IActiveHealthCheckPolicy without InternalsVisibleTo

### DIFF
--- a/src/ReverseProxy/Service/Management/DestinationManager.cs
+++ b/src/ReverseProxy/Service/Management/DestinationManager.cs
@@ -5,7 +5,7 @@ using Microsoft.ReverseProxy.RuntimeModel;
 
 namespace Microsoft.ReverseProxy.Service.Management
 {
-    internal sealed class DestinationManager : ItemManagerBase<DestinationInfo>, IDestinationManager
+    public sealed class DestinationManager : ItemManagerBase<DestinationInfo>, IDestinationManager
     {
         protected override DestinationInfo InstantiateItem(string itemId)
         {

--- a/src/ReverseProxy/Service/Management/IDestinationManager.cs
+++ b/src/ReverseProxy/Service/Management/IDestinationManager.cs
@@ -8,7 +8,7 @@ namespace Microsoft.ReverseProxy.Service.Management
     /// <summary>
     /// Manages the runtime state of destinations in a cluster.
     /// </summary>
-    internal interface IDestinationManager : IItemManager<DestinationInfo>
+    public interface IDestinationManager : IItemManager<DestinationInfo>
     {
     }
 }

--- a/src/ReverseProxy/Service/Management/IItemManager.cs
+++ b/src/ReverseProxy/Service/Management/IItemManager.cs
@@ -10,7 +10,7 @@ namespace Microsoft.ReverseProxy.Service.Management
     /// Manages the runtime state of items.
     /// </summary>
     /// <typeparam name="T">Item type.</typeparam>
-    internal interface IItemManager<T>
+    public interface IItemManager<T>
         where T : class
     {
         /// <summary>

--- a/src/ReverseProxy/Service/Management/ItemManagerBase.cs
+++ b/src/ReverseProxy/Service/Management/ItemManagerBase.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Microsoft.ReverseProxy.Service.Management
 {
-    internal abstract class ItemManagerBase<T> : IItemManager<T>
+    public abstract class ItemManagerBase<T> : IItemManager<T>
         where T : class
     {
         private readonly object _lockObject = new object();

--- a/src/ReverseProxy/Service/RuntimeModel/ClusterInfo.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/ClusterInfo.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ReverseProxy.RuntimeModel
         private volatile ClusterConfig _config;
         private readonly SemaphoreSlim _updateRequests = new SemaphoreSlim(2);
 
-        internal ClusterInfo(string clusterId, IDestinationManager destinationManager)
+        public ClusterInfo(string clusterId, IDestinationManager destinationManager)
         {
             ClusterId = clusterId ?? throw new ArgumentNullException(nameof(clusterId));
             DestinationManager = destinationManager ?? throw new ArgumentNullException(nameof(destinationManager));
@@ -41,10 +41,10 @@ namespace Microsoft.ReverseProxy.RuntimeModel
         public ClusterConfig Config
         {
             get => _config;
-            internal set => _config = value ?? throw new ArgumentNullException(nameof(value));
+            set => _config = value ?? throw new ArgumentNullException(nameof(value));
         }
 
-        internal IDestinationManager DestinationManager { get; }
+        public IDestinationManager DestinationManager { get; }
 
         /// <summary>
         /// Encapsulates parts of a cluster that can change atomically

--- a/src/ReverseProxy/Service/RuntimeModel/DestinationInfo.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/DestinationInfo.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ReverseProxy.RuntimeModel
         public DestinationConfig Config
         {
             get => _config;
-            internal set => _config = value ?? throw new ArgumentNullException(nameof(value));
+            set => _config = value ?? throw new ArgumentNullException(nameof(value));
         }
 
         /// <summary>


### PR DESCRIPTION
This will resolve #705.

Makes just enough public to reproduce the unit tests for the built in policy - https://github.com/microsoft/reverse-proxy/blob/66f39b675e05c9b2490cf49f817c33060c9b02e8/test/ReverseProxy.Tests/Service/HealthChecks/ConsecutiveFailuresHealthPolicyTests.cs#L17