### PR TITLE
Stash ILoadBalancingPolicy in ClusterConfig

### DIFF
--- a/src/ReverseProxy/Service/RuntimeModel/ClusterConfig.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/ClusterConfig.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Net.Http;
 using Microsoft.ReverseProxy.Abstractions;
+using Microsoft.ReverseProxy.Service.LoadBalancing;
 
 namespace Microsoft.ReverseProxy.RuntimeModel
 {
@@ -21,10 +22,12 @@ namespace Microsoft.ReverseProxy.RuntimeModel
     {
         public ClusterConfig(
             Cluster cluster,
-            HttpMessageInvoker httpClient)
+            HttpMessageInvoker httpClient,
+            ILoadBalancingPolicy loadBalancingPolicy)
         {
             Options = cluster ?? throw new ArgumentNullException(nameof(cluster));
             HttpClient = httpClient;
+            LoadBalancingPolicy = loadBalancingPolicy;
         }
 
         public Cluster Options { get; }
@@ -33,6 +36,11 @@ namespace Microsoft.ReverseProxy.RuntimeModel
         /// An <see cref="HttpMessageInvoker"/> that used for proxying requests to an upstream server.
         /// </summary>
         public HttpMessageInvoker HttpClient { get; }
+
+        /// <summary>
+        /// An <see cref="ILoadBalancingPolicy"/> that used for picking the destination for the cluster.
+        /// </summary>
+        public ILoadBalancingPolicy LoadBalancingPolicy { get; }
 
         internal bool HasConfigChanged(ClusterConfig newClusterConfig)
         {

--- a/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
+++ b/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.ReverseProxy.DynamicEndpoint
                 proxyRoute,
                 new ClusterInfo("cluster-1", new DestinationManager())
                 {
-                    Config = new ClusterConfig(cluster, default)
+                    Config = new ClusterConfig(cluster, default, default)
                 },
                 HttpTransformer.Default);
 

--- a/test/ReverseProxy.Tests/Middleware/AffinityMiddlewareTestBase.cs
+++ b/test/ReverseProxy.Tests/Middleware/AffinityMiddlewareTestBase.cs
@@ -27,7 +27,8 @@ namespace Microsoft.ReverseProxy.Middleware
                     FailurePolicy = "Policy-1",
                 }
             },
-            new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object));
+            new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object),
+            default);
 
         internal ClusterInfo GetCluster()
         {

--- a/test/ReverseProxy.Tests/Middleware/DestinationInitializerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/DestinationInitializerMiddlewareTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
             var cluster1 = new ClusterInfo(
                 clusterId: "cluster1",
                 destinationManager: new DestinationManager());
-            cluster1.Config = new ClusterConfig(new Cluster(), httpClient);
+            cluster1.Config = new ClusterConfig(new Cluster(), httpClient, default);
             var destination1 = cluster1.DestinationManager.GetOrCreateItem(
                 "destination1",
                 destination =>
@@ -93,7 +93,8 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
                         }
                     }
                 },
-                httpClient);
+                httpClient,
+                default);
             var destination1 = cluster1.DestinationManager.GetOrCreateItem(
                 "destination1",
                 destination =>

--- a/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.ReverseProxy.Middleware
                         }
                     }
                 },
-                null);
+                null, null);
             var clusterInfo = new ClusterInfo(id, new DestinationManager());
             clusterInfo.Config = clusterConfig;
             clusterInfo.DestinationManager.GetOrCreateItem("destination0", d => { });

--- a/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
@@ -52,7 +52,8 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
                 clusterId: "cluster1",
                 destinationManager: new DestinationManager());
             var clusterConfig = new ClusterConfig(new Cluster() { HttpRequest = httpRequestOptions },
-                httpClient);
+                httpClient,
+                default);
             var destination1 = cluster1.DestinationManager.GetOrCreateItem(
                 "destination1",
                 destination =>
@@ -140,7 +141,7 @@ namespace Microsoft.ReverseProxy.Middleware.Tests
             var cluster1 = new ClusterInfo(
                 clusterId: "cluster1",
                 destinationManager: new DestinationManager());
-            var clusterConfig = new ClusterConfig(new Cluster(), httpClient);
+            var clusterConfig = new ClusterConfig(new Cluster(), httpClient, default);
             httpContext.Features.Set<IReverseProxyFeature>(
                 new ReverseProxyFeature() { AvailableDestinations = Array.Empty<DestinationInfo>(), ClusterConfig = clusterConfig });
             httpContext.Features.Set(cluster1);

--- a/test/ReverseProxy.Tests/Service/HealthChecks/ActiveHealthCheckMonitorTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/ActiveHealthCheckMonitorTests.cs
@@ -243,7 +243,7 @@ namespace Microsoft.ReverseProxy.Service.HealthChecks
                 }
             };
             cluster2.Config = new ClusterConfig(new Cluster { Id = cluster2.ClusterId, HealthCheck = healthCheckConfig },
-                cluster2.Config.HttpClient);
+                cluster2.Config.HttpClient, default);
 
             monitor.OnClusterChanged(cluster2);
 
@@ -391,7 +391,8 @@ namespace Microsoft.ReverseProxy.Service.HealthChecks
                         }
                     }
                 },
-                httpClient);
+                httpClient,
+                default);
             var clusterInfo = new ClusterInfo(id, new DestinationManager());
             clusterInfo.Config = clusterConfig;
             for (var i = 0; i < destinationCount; i++)

--- a/test/ReverseProxy.Tests/Service/HealthChecks/ConsecutiveFailuresHealthPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/ConsecutiveFailuresHealthPolicyTests.cs
@@ -138,7 +138,7 @@ namespace Microsoft.ReverseProxy.Service.HealthChecks
                     },
                     Metadata = metadata,
                 },
-                null);
+                null, null);
             var clusterInfo = new ClusterInfo(id, new DestinationManager());
             clusterInfo.Config = clusterConfig;
             for (var i = 0; i < destinationCount; i++)
@@ -158,7 +158,7 @@ namespace Microsoft.ReverseProxy.Service.HealthChecks
         {
             public void SetActive(ClusterInfo cluster, IEnumerable<NewActiveDestinationHealth> newHealthStates)
             {
-                foreach(var newHealthState in newHealthStates)
+                foreach (var newHealthState in newHealthStates)
                 {
                     newHealthState.Destination.Health.Active = newHealthState.NewActiveHealth;
                 }

--- a/test/ReverseProxy.Tests/Service/HealthChecks/DefaultProbingRequestFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/DefaultProbingRequestFactoryTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.ReverseProxy.Service.HealthChecks
 #endif
                     }
                 },
-                null);
+                null, null);
         }
     }
 }

--- a/test/ReverseProxy.Tests/Service/HealthChecks/DestinationHealthUpdaterTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/DestinationHealthUpdaterTests.cs
@@ -138,6 +138,7 @@ namespace Microsoft.ReverseProxy.Service.HealthChecks
                         },
                     },
                 },
+                default,
                 default);
             return cluster;
         }

--- a/test/ReverseProxy.Tests/Service/HealthChecks/TransportFailureRateHealthPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/TransportFailureRateHealthPolicyTests.cs
@@ -223,7 +223,7 @@ namespace Microsoft.ReverseProxy.Service.HealthChecks
                     },
                     Metadata = metadata,
                 },
-                null);
+                null, null);
             var clusterInfo = new ClusterInfo(id, new DestinationManager());
             clusterInfo.Config = clusterConfig;
             for (var i = 0; i < destinationCount; i++)

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/ClusterInfoTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/ClusterInfoTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.ReverseProxy.RuntimeModel.Tests
             Assert.NotNull(state2);
             Assert.Empty(state2.AllDestinations);
 
-            cluster.Config = new ClusterConfig(new Cluster(), httpClient: new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object));
+            cluster.Config = new ClusterConfig(new Cluster(), httpClient: new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object), default);
             Assert.Same(state2, cluster.DynamicState);
 
             cluster.UpdateDynamicState();
@@ -252,7 +252,8 @@ namespace Microsoft.ReverseProxy.RuntimeModel.Tests
                         }
                     }
                 },
-                httpClient: new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object));
+                httpClient: new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object),
+                default);
         }
     }
 }


### PR DESCRIPTION
Move the selection of `ILoadBalancingPolicy` from `LoadBalancingMiddleware` to `ProxyConfigManager` so that we are only searching a dictionary once when the endpoints are creating instead of every requests.

Currently when the number of destinations are one or zero, we won't check the `ILoadBalancingPolicy`. In order to skip these checks on each requests, `FirstLoadBalancingPolicy` is being selected when number of destinations are one or zero, regardless of load balancing policy for that cluster.

Fixes https://github.com/microsoft/reverse-proxy/issues/733