### PR TITLE
Avoid reallocating the header values array

### DIFF
--- a/src/ReverseProxy/Service/Proxy/HttpTransformer.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpTransformer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -112,7 +113,8 @@ namespace Microsoft.ReverseProxy.Service.Proxy
                     continue;
                 }
 
-                destination.Append(headerName, header.Value.ToArray());
+                Debug.Assert(header.Value is string[]);
+                destination.Append(headerName, header.Value as string[] ?? header.Value.ToArray());
             }
         }
     }


### PR DESCRIPTION
The `IEnumerable<string>` for header values returned by the `HttpHeaders` enumerator will always be a `string[]` in Runtime, so we can perform a type check instead of reallocating the array.

https://github.com/dotnet/runtime/blob/65b923ac88979317369a357daca070e5b0164b10/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs#L345-L346

Saves a `string[]` / every header.