### PR TITLE
Avoid ReasonPhrase overhead when using default values

### DIFF
--- a/src/ReverseProxy/Service/Proxy/HttpProxy.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpProxy.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
@@ -437,7 +438,12 @@ namespace Microsoft.ReverseProxy.Service.Proxy
         private static Task CopyResponseStatusAndHeadersAsync(HttpResponseMessage source, HttpContext context, HttpTransformer transformer)
         {
             context.Response.StatusCode = (int)source.StatusCode;
-            context.Features.Get<IHttpResponseFeature>().ReasonPhrase = source.ReasonPhrase;
+
+            // Don't explicitly set the field if the default reason phrase is used
+            if (source.ReasonPhrase != ReasonPhrases.GetReasonPhrase((int)source.StatusCode))
+            {
+                context.Features.Get<IHttpResponseFeature>().ReasonPhrase = source.ReasonPhrase;
+            }
 
             // Copies headers
             return transformer.TransformResponseAsync(context, source);


### PR DESCRIPTION
If `ReasonPhrase` is set, AspNetCore will end up allocating the byte array for it, even if the value is the same as the cached one. This PR avoids setting the field if the value is the default (cached).

https://github.com/dotnet/aspnetcore/blob/e1bda79d87aa712a0b053824b4d31afa2c66cdce/src/Servers/Kestrel/Core/src/Internal/Http/ReasonPhrases.cs#L233

This can be improved in AspNetCore as well.

Saves a `byte[]` and a few `string` allocations / request.