### PR TITLE
Remove *.pfx from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,7 +232,6 @@ ClientBin/
 *.dbmdl
 *.dbproj.schemaview
 *.jfm
-*.pfx
 *.publishsettings
 orleans.codegen.cs
 


### PR DESCRIPTION
When running crank benchmarks using a local YARP build, crank will respect the gitignores when uploading the files.

Having this `.pfx` in it means we're not copying the `testCert.pfx` to the perf machines, breaking some runs (https, h2).