### PR TITLE
Remove access modifier in interfaces

### DIFF
--- a/src/ReverseProxy/Service/LoadBalancing/ILoadBalancingPolicy.cs
+++ b/src/ReverseProxy/Service/LoadBalancing/ILoadBalancingPolicy.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ReverseProxy.Service.LoadBalancing
         /// <summary>
         ///  A unique identifier for this load balancing policy. This will be referenced from config.
         /// </summary>
-        public string Name { get; }
+        string Name { get; }
 
         /// <summary>
         /// Picks a destination to send traffic to.

--- a/src/ReverseProxy/Service/Proxy/IProxyErrorFeature.cs
+++ b/src/ReverseProxy/Service/Proxy/IProxyErrorFeature.cs
@@ -13,11 +13,11 @@ namespace Microsoft.ReverseProxy.Service.Proxy
         /// <summary>
         /// The specified ProxyError.
         /// </summary>
-        public ProxyError Error { get; }
+        ProxyError Error { get; }
 
         /// <summary>
         /// An Exception that occurred when proxying the request to the destination.
         /// </summary>
-        public Exception Exception { get; }
+        Exception Exception { get; }
     }
 }

--- a/src/ReverseProxy/Service/SessionAffinity/IAffinityFailurePolicy.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/IAffinityFailurePolicy.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
         /// <summary>
         ///  A unique identifier for this failure policy. This will be referenced from config.
         /// </summary>
-        public string Name { get; }
+        string Name { get; }
 
         /// <summary>
         /// Handles affinity failures. This method assumes the full control on <see cref="HttpContext"/>
@@ -29,6 +29,6 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
         /// 'true' if the failure is considered recoverable and the request processing can proceed.
         /// Otherwise, 'false' indicating that an error response has been generated and the request's processing must be terminated.
         /// </returns>
-        public Task<bool> Handle(HttpContext context, SessionAffinityOptions options, AffinityStatus affinityStatus);
+        Task<bool> Handle(HttpContext context, SessionAffinityOptions options, AffinityStatus affinityStatus);
     }
 }

--- a/src/ReverseProxy/Service/SessionAffinity/ISessionAffinityProvider.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/ISessionAffinityProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
         /// <summary>
         ///  A unique identifier for this session affinity implementation. This will be referenced from config.
         /// </summary>
-        public string Mode { get; }
+        string Mode { get; }
 
         /// <summary>
         /// Finds <see cref="DestinationInfo"/> to which the current request is affinitized by the affinity key.
@@ -26,7 +26,7 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
         /// <param name="clusterId">Target cluster ID.</param>
         /// <param name="options">Affinity options.</param>
         /// <returns><see cref="AffinityResult"/> carrying the found affinitized destinations if any and the <see cref="AffinityStatus"/>.</returns>
-        public AffinityResult FindAffinitizedDestinations(HttpContext context, IReadOnlyList<DestinationInfo> destinations, string clusterId, SessionAffinityOptions options);
+        AffinityResult FindAffinitizedDestinations(HttpContext context, IReadOnlyList<DestinationInfo> destinations, string clusterId, SessionAffinityOptions options);
 
         /// <summary>
         /// Affinitize the current request to the given <see cref="DestinationInfo"/> by setting the affinity key extracted from <see cref="DestinationInfo"/>.
@@ -34,6 +34,6 @@ namespace Microsoft.ReverseProxy.Service.SessionAffinity
         /// <param name="context">Current request's context.</param>
         /// <param name="options">Affinity options.</param>
         /// <param name="destination"><see cref="DestinationInfo"/> to which request is to be affinitized.</param>
-        public void AffinitizeRequest(HttpContext context, SessionAffinityOptions options, DestinationInfo destination);
+        void AffinitizeRequest(HttpContext context, SessionAffinityOptions options, DestinationInfo destination);
     }
 }


### PR DESCRIPTION
To keep it consistent with the rest of the code base.