### PR TITLE
Build samples and test assets

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -3,10 +3,8 @@
     <ItemGroup>
         <ProjectToBuild Include="$(RepoRoot)src\**\*.csproj" />
         <ProjectToBuild Include="$(RepoRoot)test\**\*.csproj" />
-<!--    
         <ProjectToBuild Include="$(RepoRoot)samples\**\*.csproj" />
         <ProjectToBuild Include="$(RepoRoot)testassets\**\*.csproj" />
--->
         <ProjectToBuild Include="$(RepoRoot)docs\docfx\docfx.csproj" Condition="'$(OS)' == 'Windows_NT'" />
     </ItemGroup>
 </Project>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -4,6 +4,6 @@
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
 
   <PropertyGroup>
-    <IsShipping>false</IsShipping>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 </Project>

--- a/testassets/Directory.Build.props
+++ b/testassets/Directory.Build.props
@@ -4,6 +4,6 @@
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
 
   <PropertyGroup>
-    <IsShipping>false</IsShipping>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Our `/samples` and `/testassets` folders are not built as part of the PR, CI, or command line flow, making them prone to getting out of date and breaking. They only build by default in VS.

When I enabled the build for those folders I got the following error:
```
D:\github\reverse-proxy\.dotnet\sdk\5.0.103\Sdks\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets(194,6): error : This project cannot be packaged because packaging has been disabled. Add <IsPackable>true</IsPackable> to the project file to enable producing a package from this project. [D:\github\reverse-proxy\samples\ReverseProxy.ServiceFabric.Sample\ReverseProxy.ServiceFabric.Sample.csproj]
```
`<WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>` works around this but it's not clear if that's the right solution.