### PR TITLE
Fix ProxyConfigManager remarks

### DIFF
--- a/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ReverseProxy.Service.Management
     /// in a thread-safe manner while avoiding locks on the hot path.
     /// </summary>
     /// <remarks>
-    /// This takes inspiration from <a https://github.com/dotnet/aspnetcore/blob/cbe16474ce9db7ff588aed89596ff4df5c3f62e1/src/Mvc/Mvc.Core/src/Routing/ActionEndpointDataSourceBase.cs"/>.
+    /// This takes inspiration from <a "https://github.com/dotnet/aspnetcore/blob/cbe16474ce9db7ff588aed89596ff4df5c3f62e1/src/Mvc/Mvc.Core/src/Routing/ActionEndpointDataSourceBase.cs"/>.
     /// </remarks>
     internal class ProxyConfigManager : EndpointDataSource, IDisposable
     {


### PR DESCRIPTION
A missing double quotation is breaking the GitHub styling.
Before:
![E102AC1A-1ED7-4DE7-B7D4-C90B47F8EE6A](https://user-images.githubusercontent.com/19396090/109420678-06998f80-79e9-11eb-9bb9-2c5000b9420c.jpeg)
After:
![43FF42B5-9FA1-4979-9609-20DCA0433066](https://user-images.githubusercontent.com/19396090/109420680-08fbe980-79e9-11eb-86f3-05de900a1e19.jpeg)
