### PR TITLE
remove hosts regex validator from configvalidator

### DIFF
--- a/src/ReverseProxy/Service/Config/ConfigValidator.cs
+++ b/src/ReverseProxy/Service/Config/ConfigValidator.cs
@@ -24,30 +24,6 @@ namespace Microsoft.ReverseProxy.Service
 {
     internal class ConfigValidator : IConfigValidator
     {
-        // TODO: IDN support. How strictly do we need to validate this anyways? This is app config, not external input.
-        /// <summary>
-        /// Regex explanation:
-        /// Either:
-        ///    A) A simple label without dashes
-        ///    B) A label containing dashes, but not as the first or last character.
-        /// </summary>
-        private const string DnsLabelRegexPattern = @"(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])";
-
-        /// <summary>
-        /// Regex explanation:
-        ///    - Optionally, allow "*." in the beginning
-        ///    - Then, one or more sequences of (LABEL ".")
-        ///    - Then, one LABEL
-        /// Where LABEL is described above in <see cref="DnsLabelRegexPattern"/>.
-        /// </summary>
-        private const string HostNameRegexPattern =
-            @"^" +
-            @"(?:\*\.)?" +
-            @"(?:" + DnsLabelRegexPattern + @"\.)*" +
-            DnsLabelRegexPattern +
-            @"$";
-        private static readonly Regex _hostNameRegex = new Regex(HostNameRegexPattern, RegexOptions.Compiled);
-
         private static readonly HashSet<string> _validMethods = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "HEAD", "OPTIONS", "GET", "PUT", "POST", "PATCH", "DELETE", "TRACE",
@@ -145,7 +121,7 @@ namespace Microsoft.ReverseProxy.Service
 
             foreach (var host in hosts)
             {
-                if (string.IsNullOrEmpty(host) || !_hostNameRegex.IsMatch(host))
+                if (string.IsNullOrEmpty(host))
                 {
                     errors.Add(new ArgumentException($"Invalid host name '{host}' for route '{routeId}'."));
                 }

--- a/test/ReverseProxy.Tests/Service/Config/ConfigValidatorTests.cs
+++ b/test/ReverseProxy.Tests/Service/Config/ConfigValidatorTests.cs
@@ -132,40 +132,6 @@ namespace Microsoft.ReverseProxy.Service.Tests
         }
 
         [Theory]
-        [InlineData(".example.com")]
-        [InlineData("example*.com")]
-        [InlineData("example.*.com")]
-        [InlineData("example.*a.com")]
-        [InlineData("*example.com")]
-        [InlineData("-example.com")]
-        [InlineData("example-.com")]
-        [InlineData("-example-.com")]
-        [InlineData("a.-example.com")]
-        [InlineData("a.example-.com")]
-        [InlineData("a.-example-.com")]
-        [InlineData("example.com,example-.com")]
-        public async Task Rejects_InvalidHost(string host)
-        {
-            var route = new ProxyRoute
-            {
-                RouteId = "route1",
-                Match = new ProxyMatch
-                {
-                    Hosts = host.Split(","),
-                },
-                ClusterId = "cluster1",
-            };
-
-            var services = CreateServices();
-            var validator = services.GetRequiredService<IConfigValidator>();
-
-            var result = await validator.ValidateRouteAsync(route);
-
-            Assert.NotEmpty(result);
-            Assert.Contains(result, err => err.Message.StartsWith("Invalid host name"));
-        }
-
-        [Theory]
         [InlineData("/{***a}")]
         [InlineData("/{")]
         [InlineData("/}")]

--- a/test/ReverseProxy.Tests/Service/Management/ProxyConfigManagerTests.cs
+++ b/test/ReverseProxy.Tests/Service/Management/ProxyConfigManagerTests.cs
@@ -279,7 +279,8 @@ namespace Microsoft.ReverseProxy.Service.Management.Tests
         [Fact]
         public async Task LoadAsync_RouteValidationError_Throws()
         {
-            var route1 = new ProxyRoute { RouteId = "route1", Match = new ProxyMatch { Hosts = new[] { "invalid host name" } }, ClusterId = "cluster1" };
+            var routeName = "route1";
+            var route1 = new ProxyRoute { RouteId = routeName, Match = new ProxyMatch { Hosts = null }, ClusterId = "cluster1" };
             var services = CreateServices(new List<ProxyRoute>() { route1 }, new List<Cluster>());
             var configManager = services.GetRequiredService<ProxyConfigManager>();
 
@@ -289,13 +290,13 @@ namespace Microsoft.ReverseProxy.Service.Management.Tests
 
             Assert.Single(agex.InnerExceptions);
             var argex = Assert.IsType<ArgumentException>(agex.InnerExceptions.First());
-            Assert.StartsWith("Invalid host", argex.Message);
+            Assert.StartsWith($"Route '{routeName}' requires Hosts or Path specified", argex.Message);
         }
 
         [Fact]
         public async Task LoadAsync_ConfigFilterRouteActions_CanFixBrokenRoute()
         {
-            var route1 = new ProxyRoute { RouteId = "route1", Match = new ProxyMatch { Hosts = new[] { "invalid host name" } }, Order = 1, ClusterId = "cluster1" };
+            var route1 = new ProxyRoute { RouteId = "route1", Match = new ProxyMatch { Hosts = null }, Order = 1, ClusterId = "cluster1" };
             var services = CreateServices(new List<ProxyRoute>() { route1 }, new List<Cluster>(), proxyBuilder =>
             {
                 proxyBuilder.AddProxyConfigFilter<FixRouteHostFilter>();


### PR DESCRIPTION
Removing the hosts name regex validation as the hostname is not coming from user input.

#25 