### PR TITLE
Unsafe header enumeration POC

### DIFF
--- a/src/ReverseProxy/Service/Proxy/HttpTransformer.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpTransformer.cs
@@ -1,10 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -103,18 +109,346 @@ namespace Microsoft.ReverseProxy.Service.Proxy
 
         private static void CopyResponseHeaders(HttpContext httpContext, HttpHeaders source, IHeaderDictionary destination)
         {
+            Debug.Assert(source.GetType() == typeof(HttpResponseHeaders) || source.GetType() == typeof(HttpContentHeaders));
+
             var isHttp2OrGreater = ProtocolHelper.IsHttp2OrGreater(httpContext.Request.Protocol);
 
-            foreach (var header in source)
+            if (UnsafeHeaderManipulation.IsSupported)
             {
-                var headerName = header.Key;
-                if (RequestUtilities.ShouldSkipResponseHeader(headerName, isHttp2OrGreater))
+                var headers = UnsafeHeaderManipulation.GetRawResponseHeaders(source);
+                if (headers is null)
                 {
-                    continue;
+                    return;
                 }
 
-                Debug.Assert(header.Value is string[]);
-                destination.Append(headerName, header.Value as string[] ?? header.Value.ToArray());
+                foreach (var header in headers)
+                {
+                    var headerName = header.Key.Name;
+                    if (RequestUtilities.ShouldSkipResponseHeader(headerName, isHttp2OrGreater))
+                    {
+                        continue;
+                    }
+
+                    if (header.Value is string valueString)
+                    {
+                        if (!UnsafeHeaderManipulation.HeaderValueContainsInvalidNewLine(valueString))
+                        {
+                            destination.Append(headerName, valueString);
+                        }
+                    }
+                    // Fallback to regular, validated APIs
+                    else if (source.TryGetValues(headerName, out var values))
+                    {
+                        Debug.Assert(values is string[]);
+                        destination.Append(headerName, values as string[] ?? values.ToArray());
+                    }
+                }
+            }
+            else
+            {
+                foreach (var header in source)
+                {
+                    var headerName = header.Key;
+                    if (RequestUtilities.ShouldSkipResponseHeader(headerName, isHttp2OrGreater))
+                    {
+                        continue;
+                    }
+
+                    Debug.Assert(header.Value is string[]);
+                    destination.Append(headerName, header.Value as string[] ?? header.Value.ToArray());
+                }
+            }
+        }
+    }
+
+    public static class FeatureSwitches
+    {
+        internal static bool UnsafeHeaderManipulation = true;
+        public static void DisableUnsafeHeaderManipulation() => UnsafeHeaderManipulation = false;
+    }
+
+    //internal static class UnsafeHeaderManipulation
+    public static class UnsafeHeaderManipulation
+    {
+        public static readonly bool IsSupported = CheckIsSupported();
+
+        internal static bool HeaderValueContainsInvalidNewLine(string value)
+        {
+            var index = value.IndexOf('\r');
+
+            if (index == -1)
+            {
+                return false;
+            }
+
+            return ContainsInvalidNewLineSlow(value, index);
+
+            static bool ContainsInvalidNewLineSlow(string value, int i)
+            {
+                // Search for newlines followed by non-whitespace: This is not allowed in any header (be it a known or
+                // custom header). E.g. "value\r\nbadformat: header" is invalid. However "value\r\n goodformat: header"
+                // is valid: newlines followed by whitespace are allowed in header values.
+                for (; i < value.Length; i++)
+                {
+                    if (value[i] == '\r' && (uint)(i + 1) < (uint)value.Length && value[i + 1] == '\n')
+                    {
+                        i++;
+
+                        if (i == value.Length)
+                        {
+                            return true; // We have a string terminating with \r\n. This is invalid.
+                        }
+
+                        var c = value[i];
+                        if (c != ' ' && c != '\t')
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        public static Dictionary<HeaderDescriptor, object> GetRawResponseHeaders(HttpHeaders headers)
+        {
+            Debug.Assert(headers.GetType() == typeof(HttpResponseHeaders) || headers.GetType() == typeof(HttpContentHeaders));
+
+            return Unsafe.As<RawHttpHeaders>(headers).Data;
+        }
+
+        private sealed class RawHttpHeaders
+        {
+#pragma warning disable CS0649 // Data is never assigned to, and will always have its default value null
+            public readonly Dictionary<HeaderDescriptor, object> Data;
+#pragma warning restore CS0649 // Data is never assigned to, and will always have its default value null
+        }
+
+        public readonly struct HeaderDescriptor : IEquatable<HeaderDescriptor>
+        {
+#pragma warning disable CS0649 // Foo is never assigned to, and will always have its default value null
+#pragma warning disable IDE0032 // Use auto property
+            private readonly string _headerName;
+            private readonly object _knownHeader;
+#pragma warning restore IDE0032 // Use auto property
+#pragma warning restore CS0649 // Foo is never assigned to, and will always have its default value null
+
+            public string Name => _headerName;
+
+            public bool Equals(HeaderDescriptor other) =>
+                _knownHeader == null ?
+                    string.Equals(_headerName, other._headerName, StringComparison.OrdinalIgnoreCase) :
+                    _knownHeader == other._knownHeader;
+
+            public override int GetHashCode() => _knownHeader?.GetHashCode() ?? StringComparer.OrdinalIgnoreCase.GetHashCode(_headerName);
+        }
+
+        private static bool CheckIsSupported()
+        {
+            try
+            {
+                if (!FeatureSwitches.UnsafeHeaderManipulation)
+                {
+                    return false;
+                }
+
+                if (Environment.Version.Major < 5)
+                {
+                    return false;
+                }
+
+                var isSupported = CheckIsSupportedCore();
+
+                if (!isSupported)
+                {
+                    Debug.Fail("Unsafe header manipulation should be supported");
+                }
+
+                return isSupported;
+            }
+            catch (Exception ex)
+            {
+                Debug.Fail(ex.ToString());
+                return false;
+            }
+
+            static bool CheckIsSupportedCore()
+            {
+                if (Environment.Version.Major > 6)
+                {
+                    // We should have a different story for 6/7
+                    // If someone is using a year old build of YARP and their perf drops by 5%, that is fine
+                    return false;
+                }
+
+                // Dictionary<HeaderDescriptor, object> _headerStore;
+                var headerStoreField = typeof(HttpHeaders).GetField("_headerStore", BindingFlags.Instance | BindingFlags.NonPublic);
+                if (headerStoreField is null)
+                {
+                    return false;
+                }
+
+                var headerStore = headerStoreField.FieldType;
+
+                if (!headerStore.IsGenericType)
+                {
+                    return false;
+                }
+
+                if (headerStore.GetGenericTypeDefinition() != typeof(Dictionary<,>))
+                {
+                    return false;
+                }
+
+                var storeGenerics = headerStore.GetGenericArguments();
+                if (storeGenerics.Length != 2)
+                {
+                    return false;
+                }
+
+                if (storeGenerics[1] != typeof(object))
+                {
+                    return false;
+                }
+
+                // internal readonly struct HeaderDescriptor : IEquatable<HeaderDescriptor>
+                // {
+                //     private readonly string _headerName;
+                //     private readonly KnownHeader? _knownHeader;
+                // }
+                var headerDescriptor = storeGenerics[0];
+                if (headerDescriptor.Name != nameof(HeaderDescriptor) || !headerDescriptor.IsValueType)
+                {
+                    return false;
+                }
+
+                var headerDescriptorFields = headerDescriptor.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                if (headerDescriptorFields.Length != 2)
+                {
+                    return false;
+                }
+
+                var (headerName, knownHeader) = headerDescriptorFields[0].Name == "_headerName"
+                    ? (headerDescriptorFields[0], headerDescriptorFields[1])
+                    : (headerDescriptorFields[1], headerDescriptorFields[0]);
+
+                if (headerName.Name != "_headerName" || headerName.FieldType != typeof(string))
+                {
+                    return false;
+                }
+
+                if (knownHeader.Name != "_knownHeader" || knownHeader.FieldType.IsValueType)
+                {
+                    return false;
+                }
+
+                if (GetFieldOffset(headerDescriptor, headerName) != 0)
+                {
+                    return false;
+                }
+
+                if (GetFieldOffset(headerDescriptor, knownHeader) != IntPtr.Size)
+                {
+                    return false;
+                }
+
+                if (GetFieldOffset(typeof(HttpResponseHeaders), headerStoreField) != 0)
+                {
+                    return false;
+                }
+
+                if (GetFieldOffset(typeof(HttpContentHeaders), headerStoreField) != 0)
+                {
+                    return false;
+                }
+
+                // At this point it should be safe to access the raw headers
+                // As we're lying to the runtime, some Dictionary functionality is not available
+                // Ensure that the APIs we are actually using work
+                if (!TestUsageScenario())
+                {
+                    return false;
+                }
+
+                return true;
+            }
+
+            static bool TestUsageScenario()
+            {
+                const string TestHeaderName = "foo";
+                const string TestHeaderValue = "bar";
+
+                var dummyResponse = new HttpResponseMessage();
+                dummyResponse.Headers.TryAddWithoutValidation(TestHeaderName, TestHeaderValue);
+
+                var rawHeaders = GetRawResponseHeaders(dummyResponse.Headers);
+                if (rawHeaders is null)
+                {
+                    return false;
+                }
+
+                var sawHeader = false;
+                foreach (var entry in rawHeaders)
+                {
+                    if (entry.Key.Name == TestHeaderName)
+                    {
+                        if (sawHeader || !ReferenceEquals(entry.Value, TestHeaderValue))
+                        {
+                            return false;
+                        }
+                        sawHeader = true;
+                    }
+                }
+
+                if (!sawHeader)
+                {
+                    return false;
+                }
+
+                return true;
+            }
+        }
+
+        public static int GetFieldOffset(Type type, FieldInfo field)
+        {
+            // Functionally equivalent to:
+            // var dummyObject = new TObj();
+            // return (int)Unsafe.ByteOffset(ref dummyObject, ref Unsafe.As<FIELD_TYPE, TObj>(ref dummyObject.FieldName));
+
+            var fieldOffsetFunction = GenerateFieldOffsetMethod(field);
+            var dummyObject = type.IsValueType ? Activator.CreateInstance(type) : FormatterServices.GetUninitializedObject(type);
+            var offset = fieldOffsetFunction(dummyObject);
+            return offset - (type.IsValueType ? 0 : IntPtr.Size);
+
+            static Func<object, int> GenerateFieldOffsetMethod(FieldInfo field)
+            {
+                var method = new DynamicMethod(
+                    name: "GetFieldOffset",
+                    returnType: typeof(int),
+                    parameterTypes: new[] { typeof(object) },
+                    m: typeof(UnsafeHeaderManipulation).Module,
+                    skipVisibility: true);
+
+                var il = method.GetILGenerator();
+
+                // Load the address of the object's field
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldflda, field);
+
+                // Load the object
+                il.Emit(OpCodes.Ldarg_0);
+
+                // Substract (field - object)
+                il.Emit(OpCodes.Sub);
+
+                // Convert to int32
+                il.Emit(OpCodes.Conv_I4);
+
+                // Return
+                il.Emit(OpCodes.Ret);
+
+                return (Func<object, int>)method.CreateDelegate(typeof(Func<object, int>));
             }
         }
     }

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderForwardedTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderForwardedTransform.cs
@@ -59,16 +59,19 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
             AppendBy(httpContext, builder);
             var value = builder.ToString();
 
-            var existingValues = TakeHeader(context, ForwardedHeaderName);
+            StringValues values = default;
             if (Append)
             {
-                var values = StringValues.Concat(existingValues, value);
-                AddHeader(context, ForwardedHeaderName, values);
+                values = TakeHeader(context, ForwardedHeaderName);
             }
             else
             {
-                AddHeader(context, ForwardedHeaderName, value);
+                RemoveHeader(context, ForwardedHeaderName);
             }
+
+            values = StringValues.Concat(values, value);
+
+            AddHeader(context, ForwardedHeaderName, values);
 
             return default;
         }

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderValueTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderValueTransform.cs
@@ -33,17 +33,21 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var existingValues = TakeHeader(context, HeaderName);
-
+            StringValues values = default;
             if (Append)
             {
-                var values = StringValues.Concat(existingValues, Value);
-                AddHeader(context, HeaderName, values);
+                values = TakeHeader(context, HeaderName);
             }
-            else if (!string.IsNullOrEmpty(Value))
+            else
             {
-                // Set
-                AddHeader(context, HeaderName, Value);
+                RemoveHeader(context, HeaderName);
+            }
+
+            values = StringValues.Concat(values, Value);
+
+            if (!StringValues.IsNullOrEmpty(values))
+            {
+                AddHeader(context, HeaderName, values);
             }
 
             return default;

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedForTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedForTransform.cs
@@ -34,26 +34,26 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
                 throw new System.ArgumentNullException(nameof(context));
             }
 
-            var existingValues = TakeHeader(context, HeaderName);
-
             var remoteIp = context.HttpContext.Connection.RemoteIpAddress?.ToString();
 
-            if (remoteIp == null)
+            StringValues values = default;
+            if (Append)
             {
-                if (Append && !string.IsNullOrEmpty(existingValues))
-                {
-                    AddHeader(context, HeaderName, existingValues);
-                }
-            }
-            else if (Append)
-            {
-                var values = StringValues.Concat(existingValues, remoteIp);
-                AddHeader(context, HeaderName, values);
+                values = TakeHeader(context, HeaderName);
             }
             else
             {
-                // Set
-                AddHeader(context, HeaderName, remoteIp);
+                RemoveHeader(context, HeaderName);
+            }
+
+            if (remoteIp != null)
+            {
+                values = StringValues.Concat(values, remoteIp);
+            }
+
+            if (!StringValues.IsNullOrEmpty(values))
+            {
+                AddHeader(context, HeaderName, values);
             }
 
             return default;

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedHostTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedHostTransform.cs
@@ -32,26 +32,26 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
                 throw new System.ArgumentNullException(nameof(context));
             }
 
-            var existingValues = TakeHeader(context, HeaderName);
-
             var host = context.HttpContext.Request.Host;
 
-            if (!host.HasValue)
+            StringValues values = default;
+            if (Append)
             {
-                if (Append && !string.IsNullOrEmpty(existingValues))
-                {
-                    AddHeader(context, HeaderName, existingValues);
-                }
-            }
-            else if (Append)
-            {
-                var values = StringValues.Concat(existingValues, host.ToUriComponent());
-                AddHeader(context, HeaderName, values);
+                values = TakeHeader(context, HeaderName);
             }
             else
             {
-                // Set
-                AddHeader(context, HeaderName, host.ToUriComponent());
+                RemoveHeader(context, HeaderName);
+            }
+
+            if (host.HasValue)
+            {
+                values = StringValues.Concat(values, host.ToUriComponent());
+            }
+
+            if (!StringValues.IsNullOrEmpty(values))
+            {
+                AddHeader(context, HeaderName, values);
             }
 
             return default;

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedPathBaseTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedPathBaseTransform.cs
@@ -28,26 +28,26 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
                 throw new System.ArgumentNullException(nameof(context));
             }
 
-            var existingValues = TakeHeader(context, HeaderName);
-
             var pathBase = context.HttpContext.Request.PathBase;
 
-            if (!pathBase.HasValue)
+            StringValues values = default;
+            if (Append)
             {
-                if (Append && !string.IsNullOrEmpty(existingValues))
-                {
-                    AddHeader(context, HeaderName, existingValues);
-                }
-            }
-            else if (Append)
-            {
-                var values = StringValues.Concat(existingValues, pathBase.ToUriComponent());
-                AddHeader(context, HeaderName, values);
+                values = TakeHeader(context, HeaderName);
             }
             else
             {
-                // Set
-                AddHeader(context, HeaderName, pathBase.ToUriComponent());
+                RemoveHeader(context, HeaderName);
+            }
+
+            if (pathBase.HasValue)
+            {
+                values = StringValues.Concat(values, pathBase.ToUriComponent());
+            }
+
+            if (!StringValues.IsNullOrEmpty(values))
+            {
+                AddHeader(context, HeaderName, values);
             }
 
             return default;

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedProtoTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderXForwardedProtoTransform.cs
@@ -28,20 +28,19 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
                 throw new System.ArgumentNullException(nameof(context));
             }
 
-            var existingValues = TakeHeader(context, HeaderName);
-
-            var scheme = context.HttpContext.Request.Scheme;
-
+            StringValues values = default;
             if (Append)
             {
-                var values = StringValues.Concat(existingValues, scheme);
-                AddHeader(context, HeaderName, values);
+                values = TakeHeader(context, HeaderName);
             }
             else
             {
-                // Set
-                AddHeader(context, HeaderName, scheme);
+                RemoveHeader(context, HeaderName);
             }
+
+            values = StringValues.Concat(values, context.HttpContext.Request.Scheme);
+
+            AddHeader(context, HeaderName, values);
 
             return default;
         }

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestTransform.cs
@@ -47,6 +47,14 @@ namespace Microsoft.ReverseProxy.Service.RuntimeModel.Transforms
             return existingValues;
         }
 
+        internal static void RemoveHeader(RequestTransformContext context, string headerName)
+        {
+            if (!context.ProxyRequest.Headers.Remove(headerName))
+            {
+                context.ProxyRequest.Content?.Headers.Remove(headerName);
+            }
+        }
+
         /// <summary>
         /// Adds the given header to the HttpRequestMessage or HttpContent where applicable.
         /// </summary>


### PR DESCRIPTION
Proof of concept change.

Actual enumeration change is f067ffd.

1774495 is used to avoid fetching header values that we were gonna throw away anyway.
As the header values are lazily initialized & parsed, these show up after bypassing validation.

The change yields improvements of:
- 4-7 % throughput (RPS)
- 25 % less allocated bytes (5730 => 4328)
- 34 % less allocated objects (76 => 50)