### PR TITLE
Make TlsFrameHelper public 

### DIFF
--- a/src/ReverseProxy/Utilities/TlsFrameHelper.cs
+++ b/src/ReverseProxy/Utilities/TlsFrameHelper.cs
@@ -14,7 +14,7 @@ using System.Text;
 namespace Microsoft.ReverseProxy.Utilities.Tls
 {
     // SSL3/TLS protocol frames definitions.
-    internal enum TlsContentType : byte
+    public enum TlsContentType : byte
     {
         ChangeCipherSpec = 20,
         Alert = 21,
@@ -22,7 +22,7 @@ namespace Microsoft.ReverseProxy.Utilities.Tls
         AppData = 23
     }
 
-    internal enum TlsHandshakeType : byte
+    public enum TlsHandshakeType : byte
     {
         HelloRequest = 0,
         ClientHello = 1,
@@ -41,13 +41,13 @@ namespace Microsoft.ReverseProxy.Utilities.Tls
         MessageHash = 254
     }
 
-    internal enum TlsAlertLevel : byte
+    public enum TlsAlertLevel : byte
     {
         Warning = 1,
         Fatal = 2,
     }
 
-    internal enum TlsAlertDescription : byte
+    public enum TlsAlertDescription : byte
     {
         CloseNotify = 0, // warning
         UnexpectedMessage = 10, // error
@@ -75,7 +75,7 @@ namespace Microsoft.ReverseProxy.Utilities.Tls
         UnsupportedExt = 110, // error
     }
 
-    internal enum ExtensionType : ushort
+    public enum ExtensionType : ushort
     {
         ServerName = 0,
         MaximumFagmentLength = 1,
@@ -87,7 +87,7 @@ namespace Microsoft.ReverseProxy.Utilities.Tls
         SupportedVersions = 43
     }
 
-    internal struct TlsFrameHeader
+    public struct TlsFrameHeader
     {
         public TlsContentType Type;
         public SslProtocols Version;
@@ -96,7 +96,7 @@ namespace Microsoft.ReverseProxy.Utilities.Tls
         public override string ToString() => $"{Version}:{Type}[{Length}]";
     }
 
-    internal class TlsFrameHelper
+    public static class TlsFrameHelper
     {
         public const int HeaderSize = 5;
 

--- a/testassets/ReverseProxy.Direct/TlsFilter.cs
+++ b/testassets/ReverseProxy.Direct/TlsFilter.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.Logging;
+using Microsoft.ReverseProxy.Utilities.Tls;
+
+namespace Microsoft.ReverseProxy.Sample
+{
+    public class TlsFilter
+    {
+        // This sniffs the TLS handshake and rejects requests that meat specific criteria.
+        internal static async Task ProcessAsync(ConnectionContext connectionContext, Func<Task> next, ILogger logger)
+        {
+            var input = connectionContext.Transport.Input;
+            // Count how many bytes we've examined so we never go backwards, Pipes don't allow that.
+            var minBytesExamined = 0L;
+            while (true)
+            {
+                var result = await input.ReadAsync();
+                var buffer = result.Buffer;
+
+                if (result.IsCompleted)
+                {
+                    return;
+                }
+
+                if (buffer.Length == 0)
+                {
+                    continue;
+                }
+
+                if (!TryReadHello(buffer, logger, out var abort))
+                {
+                    minBytesExamined = buffer.Length;
+                    input.AdvanceTo(buffer.Start, buffer.End);
+                    continue;
+                }
+
+                var examined = buffer.Slice(buffer.Start, minBytesExamined).End;
+                input.AdvanceTo(buffer.Start, examined);
+
+                if (abort)
+                {
+                    // Close the connection.
+                    return;
+                }
+
+                break;
+            }
+
+            await next();
+        }
+
+        private static bool TryReadHello(ReadOnlySequence<byte> buffer, ILogger logger, out bool abort)
+        {
+            abort = false;
+
+            if (!buffer.IsSingleSegment)
+            {
+                throw new NotImplementedException("Multiple buffer segments");
+            }
+            var data = buffer.First.Span;
+
+            TlsFrameHelper.TlsFrameInfo info = default;
+            if (!TlsFrameHelper.TryGetFrameInfo(data, ref info))
+            {
+                return false;
+            }
+
+            if (!info.SupportedVersions.HasFlag(System.Security.Authentication.SslProtocols.Tls12))
+            {
+                logger.LogInformation("Unsupported versions: {versions}", info.SupportedVersions);
+                abort = true;
+            }
+            else
+            {
+                logger.LogInformation("Protocol versions: {versions}", info.SupportedVersions);
+            }
+
+            if (!AllowHost(info.TargetName))
+            {
+                logger.LogInformation("Disallowed host: {host}", info.TargetName);
+                abort = true;
+            }
+            else
+            {
+                logger.LogInformation("SNI: {host}", info.TargetName);
+            }
+
+            return true;
+        }
+
+        private static bool AllowHost(string targetName)
+        {
+            if (string.Equals("localhost", targetName, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/testassets/ReverseProxy.Direct/appsettings.json
+++ b/testassets/ReverseProxy.Direct/appsettings.json
@@ -6,15 +6,5 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*",
-  "Kestrel": {
-    "Endpoints": {
-      "https": {
-        "url": "https://localhost:5001"
-      },
-      "http": {
-        "url": "http://localhost:5000"
-      }
-    }
-  }
+  "AllowedHosts": "*"
 }


### PR DESCRIPTION
Fixes #813 Partners are going to need this feature soon. I'm making the current types public and adding an example to consume them as a kestrel connection middleware.