### PR TITLE
Update package dependent samples 

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -7,6 +7,7 @@
     <!-- Feeds to use to restore dependent packages from -->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+    <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <!-- Feed for benchmark infrastructure to restore Microsoft.NETCore.App.Runtime for self-contained builds -->
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
   </packageSources>

--- a/docs/docfx/articles/getting_started.md
+++ b/docs/docfx/articles/getting_started.md
@@ -40,7 +40,7 @@ And then add:
  
  ```XML
 <ItemGroup> 
-  <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.9.*" />
+  <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.10.*" />
 </ItemGroup> 
 ```
 

--- a/docs/docfx/articles/service-fabric-int.md
+++ b/docs/docfx/articles/service-fabric-int.md
@@ -14,8 +14,8 @@ Open the Project and find the `ItemGroup` referencing the YARP package, then add
  
  ```XML
 <ItemGroup> 
-  <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.8.*" />
-  <PackageReference Include="Yarp.ReverseProxy.ServiceFabric" Version="1.0.0-preview.8.*" />
+  <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.10.*" />
+  <PackageReference Include="Yarp.ReverseProxy.ServiceFabric" Version="1.0.0-preview.10.*" />
 </ItemGroup> 
 ```
 

--- a/docs/docfx/articles/session-affinity.md
+++ b/docs/docfx/articles/session-affinity.md
@@ -29,7 +29,7 @@ Session affinity is configured per cluster according to the following configurat
                 "Mode": "(Cookie|CustomHeader)", // defaults to 'Cookie'
                 "FailurePolicy": "(Redistribute|Return503)", // defaults to 'Redistribute'
                 "Settings" : {
-                    "CustomHeaderName": "<custom-header-name>" // defaults to 'X-Microsoft-Proxy-Affinity`
+                    "CustomHeaderName": "<custom-header-name>" // defaults to 'X-Yarp-Proxy-Affinity`
                 }
             }
         }
@@ -62,7 +62,7 @@ If a new affinity was established for the request, the affinity key gets attache
 There are two built-in affinity modes differing only in how the affinity key is stored on a request. The default mode is `Cookie`.
 1. `Cookie` - stores the key as a cookie. It expects the request's key to be delivered as a cookie with configured name and sets the same cookie with `Set-Cookie` header on the first response in an affinitized sequence. This mode is implemented by `CookieSessionAffinityProvider`. Cookie's options (e.g. name) can be configured via `CookieSessionAffinityProviderOptions`. The default name is `.Yarp.ReverseProxy.Affinity`
 
-2. `CustomHeader` - stores the key on a header. It expects the request's key to be delivered in a customer header with configured name and sets the same header on the first response in an affinitized sequence. This mode is implemented by `CustomHeaderSessionAffinityProvider`. The header name can be set by the setting `CustomHeaderName` in `SessionAffinityOptions.Settings` as shown in the example below. The default name is `X-Microsoft-Proxy-Affinity`.
+2. `CustomHeader` - stores the key on a header. It expects the request's key to be delivered in a customer header with configured name and sets the same header on the first response in an affinitized sequence. This mode is implemented by `CustomHeaderSessionAffinityProvider`. The header name can be set by the setting `CustomHeaderName` in `SessionAffinityOptions.Settings` as shown in the example below. The default name is `X-Yarp-Proxy-Affinity`.
 
 ## Affinity failure policy
 If the affinity key cannot be decoded or no healthy destination found it's considered as a failure and an affinity failure policy is called to handle it. The policy has the full access to `HttpContext` and can send response to the client by itself. It returns a boolean value indicating whether the request processing can proceed down the pipeline or must be terminated.

--- a/samples/BasicYarpSample/BasicYarpSample.csproj
+++ b/samples/BasicYarpSample/BasicYarpSample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ReverseProxy" Version="1.0.0-preview.9.*" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.10.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/ReverseProxy.Auth.Sample/ReverseProxy.Auth.Sample.csproj
+++ b/samples/ReverseProxy.Auth.Sample/ReverseProxy.Auth.Sample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ReverseProxy" Version="1.0.0-preview.9.*" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.10.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.Code.Sample/InMemoryConfigProvider.cs
+++ b/samples/ReverseProxy.Code.Sample/InMemoryConfigProvider.cs
@@ -5,8 +5,8 @@ using System.Collections.Generic;
 using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
-using Microsoft.ReverseProxy.Abstractions;
-using Microsoft.ReverseProxy.Service;
+using Yarp.ReverseProxy.Abstractions;
+using Yarp.ReverseProxy.Service;
 
 
 namespace Yarp.Sample

--- a/samples/ReverseProxy.Code.Sample/ReverseProxy.Code.Sample.csproj
+++ b/samples/ReverseProxy.Code.Sample/ReverseProxy.Code.Sample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ReverseProxy" Version="1.0.0-preview.9.*" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.10.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.Code.Sample/Startup.cs
+++ b/samples/ReverseProxy.Code.Sample/Startup.cs
@@ -7,9 +7,9 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.ReverseProxy.Abstractions;
-using Microsoft.ReverseProxy.Middleware;
-using Microsoft.ReverseProxy.RuntimeModel;
+using Yarp.ReverseProxy.Abstractions;
+using Yarp.ReverseProxy.Middleware;
+using Yarp.ReverseProxy.RuntimeModel;
 
 
 namespace Yarp.Sample

--- a/samples/ReverseProxy.Config.Sample/CustomConfigFilter.cs
+++ b/samples/ReverseProxy.Config.Sample/CustomConfigFilter.cs
@@ -3,8 +3,8 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.ReverseProxy.Abstractions;
-using Microsoft.ReverseProxy.Service;
+using Yarp.ReverseProxy.Abstractions;
+using Yarp.ReverseProxy.Service;
 
 namespace Yarp.Sample
 {

--- a/samples/ReverseProxy.Config.Sample/ReverseProxy.Config.Sample.csproj
+++ b/samples/ReverseProxy.Config.Sample/ReverseProxy.Config.Sample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ReverseProxy" Version="1.0.0-preview.9.*" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.10.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.Direct.Sample/ReverseProxy.Direct.Sample.csproj
+++ b/samples/ReverseProxy.Direct.Sample/ReverseProxy.Direct.Sample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ReverseProxy" Version="1.0.0-preview.9.*" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.10.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.Direct.Sample/Startup.cs
+++ b/samples/ReverseProxy.Direct.Sample/Startup.cs
@@ -8,8 +8,8 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.ReverseProxy.Service.Proxy;
-using Microsoft.ReverseProxy.Service.RuntimeModel.Transforms;
+using Yarp.ReverseProxy.Service.Proxy;
+using Yarp.ReverseProxy.Service.RuntimeModel.Transforms;
 
 namespace Yarp.Sample
 {

--- a/samples/ReverseProxy.Metrics.Sample/ReverseProxy.Metrics.Sample.csproj
+++ b/samples/ReverseProxy.Metrics.Sample/ReverseProxy.Metrics.Sample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\ReverseProxy.TelemetryConsumption\Yarp.ReverseProxy.Telemetry.Consumption.csproj" />
+    <PackageReference Include="Yarp.ReverseProxy.Telemetry.Consumption" Version="1.0.0-preview.10.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.ServiceFabric.Sample/ReverseProxy.ServiceFabric.Sample.csproj
+++ b/samples/ReverseProxy.ServiceFabric.Sample/ReverseProxy.ServiceFabric.Sample.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\ReverseProxy.ServiceFabric\Yarp.ReverseProxy.ServiceFabric.csproj" />
+    <PackageReference Include="Yarp.ReverseProxy.ServiceFabric" Version="1.0.0-preview.10.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.Transforms.Sample/MyTransformFactory.cs
+++ b/samples/ReverseProxy.Transforms.Sample/MyTransformFactory.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using Microsoft.ReverseProxy.Abstractions.Config;
+using Yarp.ReverseProxy.Abstractions.Config;
 
 namespace Yarp.Sample
 {

--- a/samples/ReverseProxy.Transforms.Sample/MyTransformProvider.cs
+++ b/samples/ReverseProxy.Transforms.Sample/MyTransformProvider.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Net.Http;
-using Microsoft.ReverseProxy.Abstractions.Config;
+using Yarp.ReverseProxy.Abstractions.Config;
 
 namespace Yarp.Sample
 {

--- a/samples/ReverseProxy.Transforms.Sample/ReverseProxy.Transforms.Sample.csproj
+++ b/samples/ReverseProxy.Transforms.Sample/ReverseProxy.Transforms.Sample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ReverseProxy" Version="1.0.0-preview.9.*" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.10.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.Transforms.Sample/Startup.cs
+++ b/samples/ReverseProxy.Transforms.Sample/Startup.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.ReverseProxy.Abstractions.Config;
+using Yarp.ReverseProxy.Abstractions.Config;
 
 namespace Yarp.Sample
 {

--- a/src/ReverseProxy/Service/SessionAffinity/CustomHeaderSessionAffinityProvider.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/CustomHeaderSessionAffinityProvider.cs
@@ -14,7 +14,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
 {
     internal class CustomHeaderSessionAffinityProvider : BaseSessionAffinityProvider<string>
     {
-        public static readonly string DefaultCustomHeaderName = "X-Microsoft-Proxy-Affinity";
+        public static readonly string DefaultCustomHeaderName = "X-Yarp-Proxy-Affinity";
         private const string CustomHeaderNameKey = "CustomHeaderName";
 
         public CustomHeaderSessionAffinityProvider(


### PR DESCRIPTION
Contributes to #811

I've updates these samples temporarily using packages from our daily builds on the dotnet5 feed. Normally we'd wait for a nuget.org release, but there are more changes here than usual that I wanted done in time for the release. We should plan to push the newly branded packages to nuget next week.