### PR TITLE
Make IsExternalInit public

### DIFF
--- a/src/ReverseProxy/Utilities/IsExternalInit.cs
+++ b/src/ReverseProxy/Utilities/IsExternalInit.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#if !NET
 namespace System.Runtime.CompilerServices
 {
     // Allows "init" properties in .NET Core 3.1.
-    internal static class IsExternalInit { }
+    public static class IsExternalInit { }
 }
+#endif


### PR DESCRIPTION
C# 9 features like init only properties weren't officially supported on .NET Core 3.1, though it can be used with the 5.0 SDK and a copy of the IsExternalInit class (which we were told by Jared to make public). 

cc: @davidni we'll see if this being public means that you don't have to add your own copy.