### PR TITLE
Release10 merge docs release

### DIFF
--- a/docs/docfx/articles/configproviders.md
+++ b/docs/docfx/articles/configproviders.md
@@ -1,12 +1,14 @@
-# Configuration Providers
+# Extensibility: Configuration Providers
 
 Introduced: preview4
 
 ## Introduction
-Proxy configuration can be loaded programmatically from the source of your choosing by implementing an [IProxyConfigProvider](xref:Yarp.ReverseProxy.Service.IProxyConfigProvider).
+The [Basic Yarp Sample](https://github.com/microsoft/reverse-proxy/tree/main/samples/BasicYarpSample) show proxy confuguration being loaded from appsettings.json. Instead proxy configuration can be loaded programmatically from the source of your choosing. You do this by providing a couple of classes implementing [IProxyConfigProvider](xref:Yarp.ReverseProxy.Service.IProxyConfigProvider) and [IProxyConfig](xref:Yarp.ReverseProxy.Service.IProxyConfig).
+
+See [ReverseProxy.Code.Sample](https://github.com/microsoft/reverse-proxy/tree/main/samples/ReverseProxy.Code.Sample) for an example of a custom configuration provider.
 
 ## Structure
-[IProxyConfigProvider](xref:Yarp.ReverseProxy.Service.IProxyConfigProvider) has a single method `GetConfig()` that returns an [IProxyConfig](xref:Yarp.ReverseProxy.Service.IProxyConfig) instance. The IProxyConfig has lists of the current routes and clusters, as well as an `IChangeToken` to notify the proxy when this information is out of date and should be reloaded by calling `GetConfig()` again.
+[IProxyConfigProvider](xref:Yarp.ReverseProxy.Service.IProxyConfigProvider) has a single method `GetConfig()` that should return an [IProxyConfig](xref:Yarp.ReverseProxy.Service.IProxyConfig) instance. The IProxyConfig has lists of the current routes and clusters, as well as an `IChangeToken` to notify the proxy when this information is out of date and should be reloaded, which will cause `GetConfig()` to be called again.
 
 ### Routes
 The routes section is an ordered list of route matches and their associated configuration. A route requires at least the following fields:
@@ -33,13 +35,21 @@ The `IProxyConfigProvider` should be registered in the DI container as a singlet
 
 The proxy will validate the given configuration and if it's invalid, an exception will be thrown that prevents the application from starting. The provider can avoid this by using the [IConfigValidator](xref:Yarp.ReverseProxy.Service.IConfigValidator) to pre-validate routes and clusters and take whatever action it deems appropriate such as excluding invalid entries.
 
+### Atomicity
+
+The configuration objects and collections supplied to the proxy should be read-only and not modified once they have been handed to the proxy via `GetConfig()`. 
+
 ### Reload
 If the `IChangeToken` supports `ActiveChangeCallbacks`, once the proxy has processed the initial set of configuration it will register a callback with this token. Note the proxy does not support polling for changes.
 
-When the provider wants to provide new configuration to the proxy it should first load that configuration in the background, optionally validate it using the [IConfigValidator](xref:Yarp.ReverseProxy.Service.IConfigValidator), and only then signal the `IChangeToken` from the prior `IProxyConfig` instance that new data is available. The proxy will call `GetConfig()` again to retrieve the new data.
+When the provider wants to provide new configuration to the proxy it should:
+- load that configuration in the background. 
+  - Route and cluster objects are immutable, so new instances have be created for any new data.
+  - Objects for unchanged routes and clusters can be re-used, or new instances can be created - changes will be detected by diffing them.
+- optionally validate the configuration using the [IConfigValidator](xref:Yarp.ReverseProxy.Service.IConfigValidator), and only then signal the `IChangeToken` from the prior `IProxyConfig` instance that new data is available. The proxy will call `GetConfig()` again to retrieve the new data.
 
 There are important differences when reloading configuration vs the first configuration load.
-- The new configuration will be diffed against the current one and only modified routes or clusters will be updated. The update will be applied atomically and will only affect new requests, not request currently in progress.
+- The new configuration will be diffed against the current one and only modified routes or clusters will be updated. The update will be applied atomically and will only affect new requests, not requests currently in progress.
 - Any errors in the reload process will be logged and suppressed. The application will continue using the last known good configuration.
 - If `GetConfig()` throws the proxy will be unable to listen for future changes because `IChangeToken`s are single-use.
 

--- a/docs/docfx/index.md
+++ b/docs/docfx/index.md
@@ -3,14 +3,22 @@ uid: root
 title: YARP Documentation
 ---
 
-# YARP: A Reverse Proxy
+# YARP: Yet Another Reverse Proxy
 
 Welcome to the documentation for YARP! YARP is a library to help create reverse proxy servers that are high-performance, production-ready, and highly customizable. Right now it's still in preview, but please provide us your feedback by going to [the GitHub repository](https://github.com/microsoft/reverse-proxy).
 
-We found a bunch of internal teams at Microsoft who were either building a reverse proxy for their service or had been asking about APIs and tech for building one, so we decided to get them all together to work on a common solution, this project.
+## Why YARP
+
+We found a bunch of internal teams at Microsoft who were either building a reverse proxy for their service or had been asking about APIs and tech for building one, so we decided to get them all together to work on a common solution, this project. Each of these projects was doing something slightly off the beaten path which meant they were not well served by existing proxies, and customization of those proxies had a high cost and ongoing maintenance considerations.
+
+Many of the existing proxies were built to support HTTP/1.1, but with workloads changing to include gRPC traffic, they require HTTP/2 support which requires a significantly more complex implementation. By using YARP the projects get to customize the routing and handling behavior without having to implement the http protocol.
+
+## Using YARP
 
 YARP is built on .NET using the infrastructure from ASP.NET and .NET (.NET Core 3.1 and .NET 5.0). The key differentiator for YARP is that it's been designed to be easily customized and tweaked via .NET code to match the specific needs of each deployment scenario. 
 
-We expect YARP to ship as a library, project template, and a single-file exe, to provide a variety of choices for building a robust, performant proxy server. Its pipeline and modules are designed so that you can then customize the functionality for your needs. For example, while YARP supports configuration files, we expect that many users will want to manage the configuration programmatically based on their own configuration management system, YARP will provide a configuration API to enable that customization in-proc. YARP is designed with customizability as a primary scenario rather than requiring you to break out to script or rebuild the library from source.
+Eventually we expect YARP to ship as a library, project template, and a single-file exe, to provide a variety of choices for building a robust, performant proxy server. Its pipeline and modules are designed so that you can then customize the functionality for your needs. For example, while YARP supports configuration files, we expect that many users will want to manage the configuration programmatically based on their own configuration management system. YARP provides a configuration API to enable that customization in-proc. 
 
-See the [Getting Started](xref:getting_started) guide for a brief tutorial.
+YARP is designed with customizability as a primary scenario rather than requiring you to break out to script or rebuild the library from source.
+
+See the [Getting Started](xref:getting_started) guide for a brief tutorial, or [Basic Sample](https://github.com/microsoft/reverse-proxy/tree/main/samples/BasicYarpSample) for a fully commented sample showing how to use the YARP library to implement a fairly well featured proxy.


### PR DESCRIPTION
#844

These 2 docs commits were only made into release/docs and the auto-merge failed because of Microsoft => Yarp xref changes.