### PR TITLE
Make MakeDestinationAddress public

### DIFF
--- a/src/ReverseProxy/Service/Proxy/HttpTransformer.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpTransformer.cs
@@ -29,6 +29,7 @@ namespace Yarp.ReverseProxy.Service.Proxy
         /// <summary>
         /// A callback that is invoked prior to sending the proxied request. All HttpRequestMessage fields are
         /// initialized except RequestUri, which will be initialized after the callback if no value is provided.
+        /// See <see cref="RequestUtilities.MakeDestinationAddress(string, PathString, QueryString)"/> for constructing a custom request Uri.
         /// The string parameter represents the destination URI prefix that should be used when constructing the RequestUri.
         /// The headers are copied by the base implementation, excluding some protocol headers like HTTP/2 pseudo headers (":authority").
         /// </summary>

--- a/src/ReverseProxy/Utilities/RequestUtilities.cs
+++ b/src/ReverseProxy/Utilities/RequestUtilities.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
@@ -11,7 +10,10 @@ using Microsoft.Net.Http.Headers;
 
 namespace Yarp.ReverseProxy.Utilities
 {
-    internal static class RequestUtilities
+    /// <summary>
+    /// APIs that can be used when transforming requests.
+    /// </summary>
+    public static class RequestUtilities
     {
         internal static bool ShouldSkipResponseHeader(string headerName, bool isHttp2OrGreater)
         {
@@ -37,10 +39,11 @@ namespace Yarp.ReverseProxy.Utilities
         /// <summary>
         /// Appends the given path and query to the destination prefix while avoiding duplicate '/'.
         /// </summary>
-        /// <param name="destinationPrefix">The scheme, host, port, and possibly path base for the destination server.</param>
+        /// <param name="destinationPrefix">The scheme, host, port, and optional path base for the destination server.
+        /// e.g. "http://example.com:80/path/prefix"</param>
         /// <param name="path">The path to append.</param>
         /// <param name="query">The query to append</param>
-        internal static Uri MakeDestinationAddress(string destinationPrefix, PathString path, QueryString query)
+        public static Uri MakeDestinationAddress(string destinationPrefix, PathString path, QueryString query)
         {
             ReadOnlySpan<char> prefixSpan = destinationPrefix;
 


### PR DESCRIPTION
Addresses design feedback.

HttpTransformer.TransformRequestAsync has all request fields populated before it's called except headers and the RequestUri as those are the most commonly transformed. There are some tricks to creating the request uri correctly and efficiently, so we're making this API public to help people get it right.