### PR TITLE
Make ProxyHttpClientFactory public and extensible 

### DIFF
--- a/src/ReverseProxy/Service/Proxy/Infrastructure/CallbackProxyHttpClientFactory.cs
+++ b/src/ReverseProxy/Service/Proxy/Infrastructure/CallbackProxyHttpClientFactory.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Net.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Yarp.ReverseProxy.Service.Proxy.Infrastructure
+{
+    internal class CallbackProxyHttpClientFactory : ProxyHttpClientFactory
+    {
+        private readonly Action<ProxyHttpClientContext, SocketsHttpHandler> _configureClient;
+
+        internal CallbackProxyHttpClientFactory(ILogger<ProxyHttpClientFactory> logger,
+            Action<ProxyHttpClientContext, SocketsHttpHandler> configureClient) : base(logger)
+        {
+            _configureClient = configureClient ?? throw new ArgumentNullException(nameof(configureClient));
+        }
+
+        protected override void ConfigureHandler(ProxyHttpClientContext context, SocketsHttpHandler handler)
+        {
+            base.ConfigureHandler(context, handler);
+            _configureClient(context, handler);
+        }
+    }
+}

--- a/testassets/ReverseProxy.Code/Startup.cs
+++ b/testassets/ReverseProxy.Code/Startup.cs
@@ -52,6 +52,10 @@ namespace Yarp.ReverseProxy.Sample
 
             services.AddReverseProxy()
                 .LoadFromMemory(routes, clusters)
+                .ConfigureClient((context, handler) =>
+                {
+                    handler.Expect100ContinueTimeout = TimeSpan.FromMilliseconds(300);
+                })
                 .AddTransformFactory<MyTransformFactory>()
                 .AddTransforms<MyTransformProvider>()
                 .AddTransforms(transformBuilderContext =>


### PR DESCRIPTION
Fixes #805 Make ProxyHttpClientFactory public and extensible
Fixes #843 (@berhir) Enable adding HttpMessageHandler middleware (e.g. DelegatingHandler)
Contributes to #801 Allow using ProxyHttpClientFactory for direct IHttpProxy scenarios

ProxyHttpClientFactory is now public so people can: 
A) Create it directly when using IHttpProxy
B) Derive from it to customize the SocketHttpHandler settings without completely re-implementing IProxyHttpClientFactory
C) Derive from it to enable wrapping SocketHttpHandler with DelegatingHandler middleware.

There's also a new extension for simple scenarios:
```C#
            services.AddReverseProxy()
                .ConfigureClient((context, handler) =>
                {
                    handler.Expect100ContinueTimeout = TimeSpan.FromMilliseconds(300);
                })
```