### PR TITLE
Handle `Expect:100-continue` when destination chooses not to accept request body

### DIFF
--- a/src/ReverseProxy/Service/Proxy/HttpProxy.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpProxy.cs
@@ -161,17 +161,6 @@ namespace Yarp.ReverseProxy.Service.Proxy
                     Log.HttpDowngradeDetected(_logger);
                 }
 
-                // Assert that, if we are proxying content to the destination, it must have started by now
-                // (since HttpClient.SendAsync has already completed asynchronously).
-                // If this check fails, there is a coding defect which would otherwise
-                // cause us to wait forever in step 9, so fail fast here.
-                if (requestContent != null && !requestContent.Started)
-                {
-                    // TODO: HttpClient might not need to read the body in some scenarios, such as an early auth failure with Expect: 100-continue.
-                    // https://github.com/microsoft/reverse-proxy/issues/617
-                    throw new InvalidOperationException("Proxying the Client request body to the Destination server hasn't started. This is a coding defect.");
-                }
-
                 try
                 {
                     // :: Step 5: Copy response status line Client ◄-- Proxy ◄-- Destination
@@ -229,7 +218,11 @@ namespace Yarp.ReverseProxy.Service.Proxy
                 }
 
                 // :: Step 9: Wait for completion of step 2: copying request body Client --► Proxy --► Destination
-                if (requestContent != null)
+                // NOTE: It is possible for the request body to NOT be copied even when there was an incoming requet body,
+                // e.g. when the request includes header `Expect: 100-continue` and the destination produced a non-1xx response.
+                // We must only wait for the request body to complete if it actually started,
+                // otherwise we run the risk of waiting indefinitely for a task that will never complete.
+                if (requestContent != null && requestContent.Started)
                 {
                     var (requestBodyCopyResult, requestBodyException) = await requestContent.ConsumptionTask;
 

--- a/testassets/TestClient/Program.cs
+++ b/testassets/TestClient/Program.cs
@@ -33,6 +33,7 @@ namespace SampleClient
             var scenarioFactories = new Dictionary<string, Func<IScenario>>(StringComparer.OrdinalIgnoreCase) {
                 {"Http1", () => new Http1Scenario()},
                 {"Http2", () => new Http2Scenario()},
+                {"Http2PostExpectContinue", () => new Http2PostExpectContinueScenario()},
                 // Disabled due to a conflict with a workaround to the issue https://github.com/microsoft/reverse-proxy/issues/255.
                 //{"RawUpgrade", () => new RawUpgradeScenario()},
                 {"WebSockets", () => new WebSocketsScenario()},

--- a/testassets/TestClient/Scenarios/Http2PostExpectContinueScenario.cs
+++ b/testassets/TestClient/Scenarios/Http2PostExpectContinueScenario.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SampleClient.Scenarios
+{
+    /// <summary>
+    /// Verifies that Island Gateway correctly handles the case where the client specifies
+    /// <c>Expect: 100-continue</c> and the destination fails early without accepting the request body.
+    /// This scenario can be encountered in real world scenarios, usually when authentication fails on the destination.
+    /// The <c>Expect: 100-continue</c> behavior causes the request body copy to not even start on Island Gateway in this case.
+    /// </summary>
+    internal class Http2PostExpectContinueScenario : IScenario
+    {
+        public async Task ExecuteAsync(CommandLineArgs args, CancellationToken cancellation)
+        {
+            using (var handler = new HttpClientHandler
+            {
+                AllowAutoRedirect = false,
+                AutomaticDecompression = DecompressionMethods.None,
+                UseCookies = false,
+                UseProxy = false,
+            })
+            using (var client = new HttpMessageInvoker(handler))
+            {
+                var targetUri = new Uri(new Uri(args.Target, UriKind.Absolute), "api/skipbody");
+                var stopwatch = Stopwatch.StartNew();
+                var request = new HttpRequestMessage(HttpMethod.Post, targetUri);
+                request.Version = new Version(2, 0);
+                request.Headers.ExpectContinue = true;
+                request.Content = new StringContent(new string('a', 1024 * 1024 * 10));
+                Console.WriteLine($"Calling {targetUri} with HTTP/2");
+
+                var response = await client.SendAsync(request, cancellation);
+                Console.WriteLine($"Received response: {(int)response.StatusCode} in {stopwatch.ElapsedMilliseconds} ms");
+                if (response.StatusCode != HttpStatusCode.Conflict)
+                {
+                    throw new InvalidOperationException($"Expected status 409 Conflict!");
+                }
+            }
+        }
+    }
+}

--- a/testassets/TestServer/Controllers/HttpController.cs
+++ b/testassets/TestServer/Controllers/HttpController.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace SampleServer.Controllers
@@ -23,6 +24,17 @@ namespace SampleServer.Controllers
         [Route("/api/noop")]
         public void NoOp()
         {
+        }
+
+        /// <summary>
+        /// Returns a 409 response without consuming the request body.
+        /// This is used to exercise <c>Expect:100-continue</c> behavior.
+        /// </summary>
+        [HttpPost]
+        [Route("/api/skipbody")]
+        public IActionResult SkipBody()
+        {
+            return StatusCode(StatusCodes.Status409Conflict);
         }
 
         /// <summary>


### PR DESCRIPTION
Contributes #617