### PR TITLE
Disallow punycode host names in config

### DIFF
--- a/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/ProxyMatch.cs
+++ b/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/ProxyMatch.cs
@@ -19,6 +19,7 @@ namespace Yarp.ReverseProxy.Abstractions
 
         /// <summary>
         /// Only match requests with the given Host header.
+        /// Supports wildcards and ports. For unicode host names, do not use punycode.
         /// </summary>
         public IReadOnlyList<string> Hosts { get; init; }
 

--- a/src/ReverseProxy/Service/Config/ConfigValidator.cs
+++ b/src/ReverseProxy/Service/Config/ConfigValidator.cs
@@ -121,7 +121,7 @@ namespace Yarp.ReverseProxy.Service
 
             foreach (var host in hosts)
             {
-                if (string.IsNullOrWhiteSpace(host))
+                if (string.IsNullOrEmpty(host))
                 {
                     errors.Add(new ArgumentException($"Empty host name has been set for route '{routeId}'."));
                 }

--- a/src/ReverseProxy/Service/Config/ConfigValidator.cs
+++ b/src/ReverseProxy/Service/Config/ConfigValidator.cs
@@ -121,9 +121,13 @@ namespace Yarp.ReverseProxy.Service
 
             foreach (var host in hosts)
             {
-                if (string.IsNullOrEmpty(host))
+                if (string.IsNullOrWhiteSpace(host))
                 {
-                    errors.Add(new ArgumentException($"Invalid host name '{host}' for route '{routeId}'."));
+                    errors.Add(new ArgumentException($"Empty host name has been set for route '{routeId}'."));
+                }
+                else if (host.Contains("xn--", StringComparison.OrdinalIgnoreCase))
+                {
+                    errors.Add(new ArgumentException($"Punycode host name '{host}' has been set for route '{routeId}'. Use the unicode host name instead."));
                 }
             }
         }

--- a/src/ReverseProxy/Service/Config/ConfigValidator.cs
+++ b/src/ReverseProxy/Service/Config/ConfigValidator.cs
@@ -76,7 +76,7 @@ namespace Yarp.ReverseProxy.Service
                 return errors;
             }
 
-            if ((route.Match.Hosts == null || route.Match.Hosts.Count == 0 || route.Match.Hosts.Any(host => string.IsNullOrEmpty(host))) && string.IsNullOrEmpty(route.Match.Path))
+            if ((route.Match.Hosts == null || !route.Match.Hosts.Any(host => !string.IsNullOrEmpty(host))) && string.IsNullOrEmpty(route.Match.Path))
             {
                 errors.Add(new ArgumentException($"Route '{route.RouteId}' requires Hosts or Path specified. Set the Path to '/{{**catchall}}' to match all requests."));
             }

--- a/test/ReverseProxy.Tests/Service/Config/ConfigValidatorTests.cs
+++ b/test/ReverseProxy.Tests/Service/Config/ConfigValidatorTests.cs
@@ -112,7 +112,6 @@ namespace Yarp.ReverseProxy.Service.Tests
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        [InlineData("  ")]
         [InlineData("xn--nicode-2ya")]
         [InlineData("Xn--nicode-2ya")]
         public async Task Rejects_InvalidHost(string host)

--- a/test/ReverseProxy.Tests/Service/Config/ConfigValidatorTests.cs
+++ b/test/ReverseProxy.Tests/Service/Config/ConfigValidatorTests.cs
@@ -136,10 +136,12 @@ namespace Yarp.ReverseProxy.Service.Tests
         }
 
         [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("example.com,")]
-        public async Task Rejects_MissingHostAndPath(string host)
+        [InlineData(null, null)]
+        [InlineData(null, "")]
+        [InlineData("", null)]
+        [InlineData(",", null)]
+        [InlineData("", "")]
+        public async Task Rejects_MissingHostAndPath(string host, string path)
         {
             var route = new ProxyRoute
             {
@@ -147,7 +149,8 @@ namespace Yarp.ReverseProxy.Service.Tests
                 ClusterId = "cluster1",
                 Match = new ProxyMatch
                 {
-                    Hosts = host?.Split(",")
+                    Hosts = host?.Split(","),
+                    Path = path
                 },
             };
 


### PR DESCRIPTION
HostMatcherPolicy will accept host names in punycode, but AspNetCore always tries to match against the unicode form of the request host.

This change gives Yarp users a warning in this case, where the entry would effectively get ignored.

I tested that Yarp works with `ünicode`, but not `xn--nicode-2ya` as the host.

Fixes #25