### PR TITLE
Make DestinationInfo.ConcurrentRequestCount settable

### DIFF
--- a/src/ReverseProxy/Service/RuntimeModel/DestinationInfo.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/DestinationInfo.cs
@@ -49,8 +49,13 @@ namespace Yarp.ReverseProxy.RuntimeModel
 
         /// <summary>
         /// Keeps track of the total number of concurrent requests on this endpoint.
+        /// The setter should only be used for testing purposes.
         /// </summary>
-        public int ConcurrentRequestCount => ConcurrencyCounter.Value;
+        public int ConcurrentRequestCount
+        {
+            get => ConcurrencyCounter.Value;
+            set => ConcurrencyCounter.Value = value;
+        }
 
         internal AtomicCounter ConcurrencyCounter { get; } = new AtomicCounter();
 

--- a/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
@@ -98,7 +98,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             var sut = Create<ProxyInvokerMiddleware>();
 
             Assert.Equal(0, cluster1.ConcurrencyCounter.Value);
-            Assert.Equal(0, destination1.ConcurrencyCounter.Value);
+            Assert.Equal(0, destination1.ConcurrentRequestCount);
 
             var task = sut.Invoke(httpContext);
             if (task.IsFaulted)
@@ -111,14 +111,14 @@ namespace Yarp.ReverseProxy.Middleware.Tests
 
             await tcs1.Task; // Wait until we get to the proxying step.
             Assert.Equal(1, cluster1.ConcurrencyCounter.Value);
-            Assert.Equal(1, destination1.ConcurrencyCounter.Value);
+            Assert.Equal(1, destination1.ConcurrentRequestCount);
 
             Assert.Same(destination1, httpContext.GetRequiredProxyFeature().ProxiedDestination);
 
             tcs2.TrySetResult(true);
             await task;
             Assert.Equal(0, cluster1.ConcurrencyCounter.Value);
-            Assert.Equal(0, destination1.ConcurrencyCounter.Value);
+            Assert.Equal(0, destination1.ConcurrentRequestCount);
 
             var invoke = Assert.Single(events, e => e.EventName == "ProxyInvoke");
             Assert.Equal(3, invoke.Payload.Count);

--- a/test/ReverseProxy.Tests/Service/Proxy/LoadBalancingPoliciesTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/LoadBalancingPoliciesTests.cs
@@ -43,7 +43,7 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
             {
                 var result = loadBalancer.PickDestination(context, destinations);
                 Assert.Same(destinations[0], result);
-                result.ConcurrencyCounter.Increment();
+                result.ConcurrentRequestCount++;
             }
         }
 
@@ -68,7 +68,7 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
             {
                 var result = loadBalancer.PickDestination(context, destinations);
                 Assert.Same(destinations[RandomInstance.Sequence[i]], result);
-                result.ConcurrencyCounter.Increment();
+                result.ConcurrentRequestCount++;
             }
         }
 
@@ -81,7 +81,7 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
                 new DestinationInfo("d2"),
                 new DestinationInfo("d3")
             };
-            destinations[0].ConcurrencyCounter.Increment();
+            destinations[0].ConcurrentRequestCount++;
 
             const int Iterations = 10;
             var random = new Random(42);
@@ -97,7 +97,7 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
                 var second = destinations[RandomInstance.Sequence[i * 2 + 1]];
                 var expected = first.ConcurrentRequestCount <= second.ConcurrentRequestCount ? first : second;
                 Assert.Same(expected, result);
-                result.ConcurrencyCounter.Increment();
+                result.ConcurrentRequestCount++;
             }
         }
 
@@ -110,7 +110,7 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
                 new DestinationInfo("d2"),
                 new DestinationInfo("d3")
             };
-            destinations[0].ConcurrencyCounter.Increment();
+            destinations[0].ConcurrentRequestCount++;
 
             var context = new DefaultHttpContext();
             var loadBalancer = Create<LeastRequestsLoadBalancingPolicy>();
@@ -119,7 +119,7 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
             {
                 var result = loadBalancer.PickDestination(context, destinations);
                 Assert.Same(destinations.OrderBy(d => d.ConcurrentRequestCount).First(), result);
-                result.ConcurrencyCounter.Increment();
+                result.ConcurrentRequestCount++;
             }
         }
 
@@ -132,7 +132,7 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
                 new DestinationInfo("d2"),
                 new DestinationInfo("d3")
             };
-            destinations[0].ConcurrencyCounter.Increment();
+            destinations[0].ConcurrentRequestCount++;
 
             var context = new DefaultHttpContext();
 
@@ -146,7 +146,7 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
             {
                 var result = loadBalancer.PickDestination(context, destinations);
                 Assert.Same(destinations[i % destinations.Length], result);
-                result.ConcurrencyCounter.Increment();
+                result.ConcurrentRequestCount++;
             }
         }
     }


### PR DESCRIPTION
Addresses design review feedback. Someone writing an ILoadBalancingPolicy that depends on the ConcurrentRequestCount for destinations wouldn't be able to test it since that property can only be modified internally.