### PR TITLE
Middleware docs and helper API cleanup

### DIFF
--- a/docs/docfx/articles/direct-proxying.md
+++ b/docs/docfx/articles/direct-proxying.md
@@ -67,7 +67,7 @@ public void Configure(IApplicationBuilder app, IHttpProxy httpProxy)
             await httpProxy.ProxyAsync(httpContext, "https://localhost:10000/", httpClient,
                 requestOptions, transformer);
 
-            var errorFeature = httpContext.Features.Get<IProxyErrorFeature>();
+            var errorFeature = httpContext.GetProxyErrorFeature();
             if (errorFeature != null)
             {
                 var error = errorFeature.Error;

--- a/docs/docfx/articles/middleware.md
+++ b/docs/docfx/articles/middleware.md
@@ -1,0 +1,145 @@
+# Middleware
+
+## Introduction
+
+ASP.NET Core uses a [middleware pipeline](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/middleware/) to divide request processing into discrete steps. These can be added, removed, and ordered as needed to suite an applications needs. ASP.NET Core middleware can also be used customize proxy specific behavior.
+
+## Defaults
+The [getting started](getting_started.md) sample shows the following Configure method. This sets up a middleware pipeline with development tools, routing, and proxy configured endpoints (`MapReverseProxy`).
+
+```C#
+public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+{
+    if (env.IsDevelopment())
+    {
+        app.UseDeveloperExceptionPage();
+    }
+    
+    // Enable endpoint routing, required for the reverse proxy
+    app.UseRouting();
+    // Register the reverse proxy routes
+    app.UseEndpoints(endpoints => 
+    {
+        endpoints.MapReverseProxy(); 
+    }); 
+} 
+```
+
+The parmeterless [MapReverseProxy](xref:Microsoft.AspNetCore.Builder.ReverseProxyIEndpointRouteBuilderExtensions.MapReverseProxy) overload includes all standard proxy middleware for [session affinity](session-affinity.md), [load balancing](load-balancing.md), [passive health checks](dest-health-checks.md), and the final proxying of the request. Each of these checks the configuration of the matched route, cluster, and destination and performs their task accordingly.
+
+## Adding Middleware
+
+Middleware added to your application pipeline will see the request in different states of processing depending on where the middleware is added. Middleware added before `UseRouting` will see all requests and can manipulate them before any routing takes place. Middleware added between `UseRouting` and `UseEndpoints` can call `HttpContext.GetEndpoint()` to check which endpoint routing matched the request to (if any), and use any metadata that was associated with that endpoint. This is how [Authentication, Authorization](authn-authz.md) and [CORS](cors.md) are handled.
+
+[MapReverseProxy](xref:Microsoft.AspNetCore.Builder.ReverseProxyIEndpointRouteBuilderExtensions.MapReverseProxy) provides an overload that lets you build a middleware pipeline that will run only for requests matched to proxy configured routes.
+
+```
+endpoints.MapReverseProxy(proxyPipeline =>
+{
+    proxyPipeline.Use((context, next) =>
+    {
+        // Custom inline middleware
+
+        return next();
+    });
+    proxyPipeline.UseAffinitizedDestinationLookup();
+    proxyPipeline.UseProxyLoadBalancing();
+    proxyPipeline.UsePassiveHealthChecks();
+});
+```
+
+By default this overload of `MapReverseProxy` only includes the minimal setup and proxying logic at the start and end of its pipeline. Middleware for session affinity, load balancing, and passive health checks are not included by default so that you can exclude, replace, or control their ordering with any additional middleware.
+
+## Custom Proxy Middleware
+
+Middlware inside the `MapReverseProxy` pipeline have access to all of the proxy data and state associated with a request (the route, cluster, destinations, etc.) through the [IReverseProxyFeature](xref:Yarp.ReverseProxy.Middleware.IReverseProxyFeature). This is available from `HttpContext.Features` or the extension method `HttpContext.GetRequiredProxyFeature()`.
+
+The data in `IReverseProxyFeature` are snapshotted from the proxy configuration at the start of the proxy pipeline and will not be affected by proxy configuration changes that occur while the request is being processed.
+
+```C#
+proxyPipeline.Use((context, next) =>
+{
+    var proxyFeature = context.GetRequiredProxyFeature();
+    var cluster = proxyFeature.ClusterSnapshot;
+    var destinations = proxyFeature.AvailableDestinations;
+
+    return next();
+});
+```
+
+### What to do with middleware
+
+Middleware can control if a request gets proxied or not, can influence where it's proxied to, and can add additional features like error handling, retries, etc..
+
+#### Send an immediate response
+
+If a middleware inspects a request and determines that it should not be proxied, it may generate its own response and return control to the server without calling `next()`.
+
+```C#
+proxyPipeline.Use((context, next) =>
+{
+    if (!CheckAllowedRequest(context, out var reason))
+    {
+        context.Response.StatusCode = StatusCodes.Status400BadRequest;
+        return context.Response.WriteAsync(reason);
+    }
+
+    return next();
+});
+```
+
+#### Filter destinations
+
+Middleware like session affinity and load balancing examine the `IReverseProxyFeature` and the cluster configuration to decide which destination a request should be sent to.
+
+`AllDestinations` lists all destinations in the selected cluster.
+
+`AvailableDestinations` lists the destinations currently considered eligible to handle the request. It is initialized to `AllDestinations`, excluding unhealthy ones if health checks are enabled. `AllDestinations` should be reduced to a single destination by the end of the pipeline or else one will be selected randomly from the remainder.
+
+`ProxiedDestination` is set by the proxy logic at the end of the pipeline to indicate which destination was ultimately used.  If there are no available destinations remaining then a 503 error response is sent.
+
+```C#
+proxyPipeline.Use(async (context, next) =>
+{
+    var proxyFeature = context.GetRequiredProxyFeature();
+    proxyFeature.AvailableDestinations = Filter(proxyFeature.AvailableDestinations);
+
+    await next();
+
+    Report(proxyFeature.ProxiedDestination);
+});
+```
+
+`DestinationInfo` implements `IReadOnlyList<DestinationInfo>` so a single destination can be assigned to `AvailableDestinations` without creating a new list.
+
+#### Error handling
+
+Middleware can wrap the call to `await next()` in a try/catch block to handle exceptions from later components.
+
+The proxy logic at the end of the pipeline ([IHttpProxy](direct-proxying.md)) does not throw exceptions for common request proxy errors. These are captured and reported in the [IProxyErrorFeature](xref:Yarp.ReverseProxy.Service.Proxy.IProxyErrorFeature) available from `HttpContext.Features` or the `HttpContext.GetProxyErrorFeature()` extension method.
+
+```C#
+proxyPipeline.Use(async (context, next) =>
+{
+    await next();
+
+    var errorFeature = context.GetProxyErrorFeature();
+    if (errorFeature != null)
+    {
+        Report(errorFeature.Error, errorFeature.Exception);
+    }
+});
+```
+
+If the response has not started (`HttpResponse.HasStarted`) it can be cleared (`HttpResponse.Clear()`) and an alternate response sent, or the request state may be reset and tried again.
+
+### What not to do with middleware
+
+Middleware are discouraged from modifying request fields such as headers in order to affect the outgoing proxied request. Such modifications may interfere with features like retries and are better handled by [transforms](transforms.md).
+
+Middleware should check `HttpResponse.HasStarted` before modifying response fields after calling `next()`. If the response has already started being sent to the client then the middleware can no longer modify it (except maybe Trailers). [Transforms](transforms.md) can be used to inspect and suppress unwanted responses. Otherwise see the next note.
+
+Middleware should avoid interacting with the request or response bodies. Bodies are not buffered by default, so interacting with them can prevent them from reaching their destinations. While enabling buffering is possible, it's discouraged as it can add significant memory and latency overhead. Using a wrapped, streaming approach is recommended if the body must be examined or modified. See the [ResponseCompression](https://github.com/dotnet/aspnetcore/blob/24588220006bc164b63293129cc94ac6292250e4/src/Middleware/ResponseCompression/src/ResponseCompressionMiddleware.cs#L55-L73) middleware for an example.
+
+Middleware MUST NOT do any multi-threaded work on an individual request, `HttpContext` and its associated members are not thread safe.
+

--- a/docs/docfx/articles/middleware.md
+++ b/docs/docfx/articles/middleware.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-ASP.NET Core uses a [middleware pipeline](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/middleware/) to divide request processing into discrete steps. These can be added, removed, and ordered as needed to suite an applications needs. ASP.NET Core middleware can also be used customize proxy specific behavior.
+ASP.NET Core uses a [middleware pipeline](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/middleware/) to divide request processing into discrete steps. The app developer can add and order middleware as needed. ASP.NET Core middleware is also used to implement and customize reverse proxy functionality.
 
 ## Defaults
 The [getting started](getting_started.md) sample shows the following Configure method. This sets up a middleware pipeline with development tools, routing, and proxy configured endpoints (`MapReverseProxy`).
@@ -25,7 +25,7 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 } 
 ```
 
-The parmeterless [MapReverseProxy](xref:Microsoft.AspNetCore.Builder.ReverseProxyIEndpointRouteBuilderExtensions.MapReverseProxy) overload includes all standard proxy middleware for [session affinity](session-affinity.md), [load balancing](load-balancing.md), [passive health checks](dest-health-checks.md), and the final proxying of the request. Each of these checks the configuration of the matched route, cluster, and destination and performs their task accordingly.
+The parmeterless [MapReverseProxy](xref:Microsoft.AspNetCore.Builder.ReverseProxyIEndpointRouteBuilderExtensions.MapReverseProxy) overload includes all standard proxy middleware for [session affinity](session-affinity.md), [load balancing](load-balancing.md), [passive health checks](dest-health-checks.md), and the final proxying of the request. Each of these check the configuration of the matched route, cluster, and destination and perform their task accordingly.
 
 ## Adding Middleware
 
@@ -67,11 +67,24 @@ proxyPipeline.Use((context, next) =>
 });
 ```
 
-### What to do with middleware
+## What to do with middleware
 
-Middleware can control if a request gets proxied or not, can influence where it's proxied to, and can add additional features like error handling, retries, etc..
+Middleware can generate logs, control if a request gets proxied or not, influence where it's proxied to, and add additional features like error handling, retries, etc..
 
-#### Send an immediate response
+### Logs and Metrics
+
+Middleware can inspect request and response fields to generate logs and aggregate metrics. See the note about bodies under "What not to do with middleware" below.
+
+```C#
+proxyPipeline.Use(async (context, next) =>
+{
+    LogRequest(context);
+    await next();
+    LogResponse(context);
+});
+```
+
+### Send an immediate response
 
 If a middleware inspects a request and determines that it should not be proxied, it may generate its own response and return control to the server without calling `next()`.
 
@@ -88,13 +101,13 @@ proxyPipeline.Use((context, next) =>
 });
 ```
 
-#### Filter destinations
+### Filter destinations
 
 Middleware like session affinity and load balancing examine the `IReverseProxyFeature` and the cluster configuration to decide which destination a request should be sent to.
 
 `AllDestinations` lists all destinations in the selected cluster.
 
-`AvailableDestinations` lists the destinations currently considered eligible to handle the request. It is initialized to `AllDestinations`, excluding unhealthy ones if health checks are enabled. `AllDestinations` should be reduced to a single destination by the end of the pipeline or else one will be selected randomly from the remainder.
+`AvailableDestinations` lists the destinations currently considered eligible to handle the request. It is initialized to `AllDestinations`, excluding unhealthy ones if health checks are enabled. `AvailableDestinations` should be reduced to a single destination by the end of the pipeline or else one will be selected randomly from the remainder.
 
 `ProxiedDestination` is set by the proxy logic at the end of the pipeline to indicate which destination was ultimately used.  If there are no available destinations remaining then a 503 error response is sent.
 
@@ -112,7 +125,7 @@ proxyPipeline.Use(async (context, next) =>
 
 `DestinationInfo` implements `IReadOnlyList<DestinationInfo>` so a single destination can be assigned to `AvailableDestinations` without creating a new list.
 
-#### Error handling
+### Error handling
 
 Middleware can wrap the call to `await next()` in a try/catch block to handle exceptions from later components.
 
@@ -131,13 +144,13 @@ proxyPipeline.Use(async (context, next) =>
 });
 ```
 
-If the response has not started (`HttpResponse.HasStarted`) it can be cleared (`HttpResponse.Clear()`) and an alternate response sent, or the request state may be reset and tried again.
+If the response has not started (`HttpResponse.HasStarted`) it can be cleared (`HttpResponse.Clear()`) and an alternate response sent, or the proxy feature fields may be reset and the request retried.
 
-### What not to do with middleware
+## What not to do with middleware
 
-Middleware are discouraged from modifying request fields such as headers in order to affect the outgoing proxied request. Such modifications may interfere with features like retries and are better handled by [transforms](transforms.md).
+Middleware should be cautious about modifying request fields such as headers in order to affect the outgoing proxied request. Such modifications may interfere with features like retries and may be better handled by [transforms](transforms.md).
 
-Middleware should check `HttpResponse.HasStarted` before modifying response fields after calling `next()`. If the response has already started being sent to the client then the middleware can no longer modify it (except maybe Trailers). [Transforms](transforms.md) can be used to inspect and suppress unwanted responses. Otherwise see the next note.
+Middleware MUST check `HttpResponse.HasStarted` before modifying response fields after calling `next()`. If the response has already started being sent to the client then the middleware can no longer modify it (except maybe Trailers). [Transforms](transforms.md) can be used to inspect and suppress unwanted responses. Otherwise see the next note.
 
 Middleware should avoid interacting with the request or response bodies. Bodies are not buffered by default, so interacting with them can prevent them from reaching their destinations. While enabling buffering is possible, it's discouraged as it can add significant memory and latency overhead. Using a wrapped, streaming approach is recommended if the body must be examined or modified. See the [ResponseCompression](https://github.com/dotnet/aspnetcore/blob/24588220006bc164b63293129cc94ac6292250e4/src/Middleware/ResponseCompression/src/ResponseCompressionMiddleware.cs#L55-L73) middleware for an example.
 

--- a/docs/docfx/articles/toc.yml
+++ b/docs/docfx/articles/toc.yml
@@ -20,6 +20,8 @@
   href: session-affinity.md
 - name: Load Balancing
   href: load-balancing.md
+- name: Middleware
+  href: middleware.md
 - name: Transforms
   href: transforms.md
 - name: Destinations Health Checks

--- a/src/ReverseProxy/Middleware/DestinationInitializerMiddleware.cs
+++ b/src/ReverseProxy/Middleware/DestinationInitializerMiddleware.cs
@@ -26,7 +26,11 @@ namespace Yarp.ReverseProxy.Middleware
 
         public Task Invoke(HttpContext context)
         {
-            var routeConfig = context.GetRequiredRouteConfig();
+            var endpoint = context.GetEndpoint()
+               ?? throw new InvalidOperationException($"Routing Endpoint wasn't set for the current request.");
+
+            var routeConfig = endpoint.Metadata.GetMetadata<RouteConfig>()
+                ?? throw new InvalidOperationException($"Routing Endpoint is missing {typeof(RouteConfig).FullName} metadata.");
 
             var cluster = routeConfig.Cluster;
             // TODO: Validate on load https://github.com/microsoft/reverse-proxy/issues/797

--- a/src/ReverseProxy/Middleware/HttpContextFeaturesExtensions.cs
+++ b/src/ReverseProxy/Middleware/HttpContextFeaturesExtensions.cs
@@ -18,7 +18,6 @@ namespace Microsoft.AspNetCore.Http
         /// </summary>
         public static ClusterInfo GetRequiredCluster(this HttpContext context)
         {
-            // TODO: Retarget these to wrap GetRequiredProxyFeature
             var routeConfig = context.GetRequiredRouteConfig();
             var cluster = routeConfig.Cluster ?? throw new InvalidOperationException("Cluster unspecified.");
             return cluster;

--- a/src/ReverseProxy/Middleware/HttpContextFeaturesExtensions.cs
+++ b/src/ReverseProxy/Middleware/HttpContextFeaturesExtensions.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
-using Microsoft.AspNetCore.Http;
+using Yarp.ReverseProxy.Middleware;
 using Yarp.ReverseProxy.RuntimeModel;
 using Yarp.ReverseProxy.Service.Proxy;
 
-namespace Yarp.ReverseProxy.Middleware
+namespace Microsoft.AspNetCore.Http
 {
     /// <summary>
     /// Extension methods for fetching proxy configuration from the current HttpContext.
@@ -29,12 +29,10 @@ namespace Yarp.ReverseProxy.Middleware
         /// </summary>
         public static RouteConfig GetRequiredRouteConfig(this HttpContext context)
         {
-            // TODO: Retarget these to wrap GetRequiredProxyFeature
-            var endpoint = context.GetEndpoint()
-               ?? throw new InvalidOperationException($"Routing Endpoint wasn't set for the current request.");
+            var proxyFeature = context.GetRequiredProxyFeature();
 
-            var routeConfig = endpoint.Metadata.GetMetadata<RouteConfig>()
-                ?? throw new InvalidOperationException($"Routing Endpoint is missing {typeof(RouteConfig).FullName} metadata.");
+            var routeConfig = proxyFeature.RouteSnapshot
+                ?? throw new InvalidOperationException($"Proxy feature is missing {typeof(RouteConfig).FullName}.");
 
             return routeConfig;
         }

--- a/src/ReverseProxy/Middleware/HttpContextFeaturesExtensions.cs
+++ b/src/ReverseProxy/Middleware/HttpContextFeaturesExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.AspNetCore.Http;
 using Yarp.ReverseProxy.RuntimeModel;
+using Yarp.ReverseProxy.Service.Proxy;
 
 namespace Yarp.ReverseProxy.Middleware
 {
@@ -17,6 +18,7 @@ namespace Yarp.ReverseProxy.Middleware
         /// </summary>
         public static ClusterInfo GetRequiredCluster(this HttpContext context)
         {
+            // TODO: Retarget these to wrap GetRequiredProxyFeature
             var routeConfig = context.GetRequiredRouteConfig();
             var cluster = routeConfig.Cluster ?? throw new InvalidOperationException("Cluster unspecified.");
             return cluster;
@@ -27,6 +29,7 @@ namespace Yarp.ReverseProxy.Middleware
         /// </summary>
         public static RouteConfig GetRequiredRouteConfig(this HttpContext context)
         {
+            // TODO: Retarget these to wrap GetRequiredProxyFeature
             var endpoint = context.GetEndpoint()
                ?? throw new InvalidOperationException($"Routing Endpoint wasn't set for the current request.");
 
@@ -42,6 +45,14 @@ namespace Yarp.ReverseProxy.Middleware
         public static IReverseProxyFeature GetRequiredProxyFeature(this HttpContext context)
         {
             return context.Features.Get<IReverseProxyFeature>() ?? throw new InvalidOperationException("ReverseProxyFeature unspecified.");
+        }
+
+        /// <summary>
+        /// Retrieves the IProxyErrorFeature instance associated with the current request, if any.
+        /// </summary>
+        public static IProxyErrorFeature GetProxyErrorFeature(this HttpContext context)
+        {
+            return context.Features.Get<IProxyErrorFeature>();
         }
     }
 }

--- a/src/ReverseProxy/Middleware/IReverseProxyFeature.cs
+++ b/src/ReverseProxy/Middleware/IReverseProxyFeature.cs
@@ -27,7 +27,8 @@ namespace Yarp.ReverseProxy.Middleware
         IReadOnlyList<DestinationInfo> AllDestinations { get; }
 
         /// <summary>
-        /// Cluster destinations that can handle the current request.
+        /// Cluster destinations that can handle the current request. This will initially include all destinations except those
+        /// currently marked as unhealth if health checks are enabled.
         /// </summary>
         IReadOnlyList<DestinationInfo> AvailableDestinations { get; set; }
 

--- a/src/ReverseProxy/Service/SessionAffinity/AffinitizeTransform.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/AffinitizeTransform.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
-using Yarp.ReverseProxy.Middleware;
+using Microsoft.AspNetCore.Http;
 using Yarp.ReverseProxy.RuntimeModel;
 using Yarp.ReverseProxy.Service.RuntimeModel.Transforms;
 

--- a/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
@@ -97,9 +97,8 @@ namespace Yarp.ReverseProxy.Middleware
         private HttpContext GetContext(ClusterInfo cluster, int selectedDestination, IProxyErrorFeature error)
         {
             var context = new DefaultHttpContext();
-            context.Features.Set(GetProxyFeature(cluster.Config, cluster.DynamicState.AllDestinations[selectedDestination]));
+            context.Features.Set(GetProxyFeature(cluster, cluster.DynamicState.AllDestinations[selectedDestination]));
             context.Features.Set(error);
-            context.SetEndpoint(GetEndpoint(cluster));
             return context;
         }
 
@@ -110,12 +109,13 @@ namespace Yarp.ReverseProxy.Middleware
             return policy;
         }
 
-        private IReverseProxyFeature GetProxyFeature(ClusterConfig clusterConfig, DestinationInfo destination)
+        private IReverseProxyFeature GetProxyFeature(ClusterInfo clusterInfo, DestinationInfo destination)
         {
             return new ReverseProxyFeature()
             {
                 ProxiedDestination = destination,
-                ClusterSnapshot = clusterConfig,
+                ClusterSnapshot = clusterInfo.Config,
+                RouteSnapshot = new RouteConfig(new ProxyRoute(), clusterInfo, HttpTransformer.Default),
             };
         }
 
@@ -143,15 +143,6 @@ namespace Yarp.ReverseProxy.Middleware
             clusterInfo.UpdateDynamicState();
 
             return clusterInfo;
-        }
-
-        private Endpoint GetEndpoint(ClusterInfo cluster)
-        {
-            var endpoints = new List<Endpoint>(1);
-            var routeConfig = new RouteConfig(new ProxyRoute(), cluster, HttpTransformer.Default);
-            var endpoint = new Endpoint(default, new EndpointMetadataCollection(routeConfig), string.Empty);
-            endpoints.Add(endpoint);
-            return endpoint;
         }
     }
 }

--- a/test/ReverseProxy.Tests/Service/Proxy/LoadBalancingPoliciesTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/LoadBalancingPoliciesTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Xunit;
 using Yarp.ReverseProxy.Abstractions;
 using Yarp.ReverseProxy.Common.Tests;
+using Yarp.ReverseProxy.Middleware;
 using Yarp.ReverseProxy.RuntimeModel;
 using Yarp.ReverseProxy.Service.LoadBalancing;
 using Yarp.ReverseProxy.Service.Management;
@@ -137,8 +138,11 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
             var context = new DefaultHttpContext();
 
             var routeConfig = new RouteConfig(new ProxyRoute(), new ClusterInfo("cluster1", new DestinationManager()), transformer: null);
-            var endpoint = new Endpoint(default, new EndpointMetadataCollection(routeConfig), string.Empty);
-            context.SetEndpoint(endpoint);
+            var feature = new ReverseProxyFeature()
+            {
+                RouteSnapshot = routeConfig,
+            };
+            context.Features.Set<IReverseProxyFeature>(feature);
 
             var loadBalancer = Create<RoundRobinLoadBalancingPolicy>();
 

--- a/testassets/ReverseProxy.Direct/Startup.cs
+++ b/testassets/ReverseProxy.Direct/Startup.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Yarp.ReverseProxy.Middleware;
 using Yarp.ReverseProxy.Service.Proxy;
 using Yarp.ReverseProxy.Service.RuntimeModel.Transforms;
 
@@ -49,7 +50,7 @@ namespace Yarp.ReverseProxy.Sample
                 endpoints.Map("/{**catch-all}", async httpContext =>
                 {
                     await httpProxy.ProxyAsync(httpContext, "https://example.com", httpClient, requestOptions, transformer);
-                    var errorFeature = httpContext.Features.Get<IProxyErrorFeature>();
+                    var errorFeature = httpContext.GetProxyErrorFeature();
                     if (errorFeature != null)
                     {
                         var error = errorFeature.Error;


### PR DESCRIPTION
Fixes #114 - Docs for customizing functionality through ASP.NET middleware.
Fixes #878 - Testing middleware: Re-implements middleware helpers like GetRequiredCluster to fetch their information from the IReverseProxy feature rather than the endpoint, only DestinationInitializerMiddleware accesses the endpoint directly to create the feature. I've also moved these extensions to the same namespace as HttpContext.

cc: @jmezach 
