### PR TITLE
Add ITransformBuilder.Create method

### DIFF
--- a/src/ReverseProxy/Abstractions/Config/ITransformBuilder.cs
+++ b/src/ReverseProxy/Abstractions/Config/ITransformBuilder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Yarp.ReverseProxy.Abstractions;
+using Yarp.ReverseProxy.Abstractions.Config;
 using Yarp.ReverseProxy.Service.Proxy;
 
 namespace Yarp.ReverseProxy.Service
@@ -28,5 +29,7 @@ namespace Yarp.ReverseProxy.Service
         /// Builds the transforms for the given route into executable rules.
         /// </summary>
         HttpTransformer Build(ProxyRoute route, Cluster cluster);
+
+        HttpTransformer Create(Action<TransformBuilderContext> action);
     }
 }

--- a/src/ReverseProxy/Service/Config/TransformBuilder.cs
+++ b/src/ReverseProxy/Service/Config/TransformBuilder.cs
@@ -160,5 +160,23 @@ namespace Yarp.ReverseProxy.Service.Config
                 context.ResponseTransforms,
                 context.ResponseTrailersTransforms);
         }
+
+        public HttpTransformer Create(Action<TransformBuilderContext> action)
+        {
+            var context = new TransformBuilderContext
+            {
+                Services = _services,
+            };
+
+            action(context);
+
+            return new StructuredTransformer(
+               context.CopyRequestHeaders,
+               context.CopyResponseHeaders,
+               context.CopyResponseTrailers,
+               context.RequestTransforms,
+               context.ResponseTransforms,
+               context.ResponseTrailersTransforms);
+        }
     }
 }

--- a/testassets/ReverseProxy.Direct/Startup.cs
+++ b/testassets/ReverseProxy.Direct/Startup.cs
@@ -2,14 +2,14 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Yarp.ReverseProxy.Middleware;
+using Yarp.ReverseProxy.Abstractions.Config;
+using Yarp.ReverseProxy.Service;
 using Yarp.ReverseProxy.Service.Proxy;
 using Yarp.ReverseProxy.Service.RuntimeModel.Transforms;
 
@@ -41,7 +41,17 @@ namespace Yarp.ReverseProxy.Sample
                 UseCookies = false
             });
 
-            var transformer = new CustomTransformer(); // or HttpTransformer.Default;
+            var transformBuilder = app.ApplicationServices.GetRequiredService<ITransformBuilder>();
+            var transformer = transformBuilder.Create(context =>
+            {
+                context.AddQueryRemoveKey("param1");
+                context.AddQueryValue("area", "xx2", false);
+                context.AddOriginalHost(false);
+            });
+
+            // or var transformer = new CustomTransformer();
+            // or var transformer = HttpTransformer.Default;
+
             var requestOptions = new RequestProxyOptions { Timeout = TimeSpan.FromSeconds(100) };
 
             app.UseRouting();


### PR DESCRIPTION
- Is it ok that `Cluster` and `ProxyRoute` is null in context? or should there be another type and change all extensions method?
- Should there be any default transform in `Create` (e.g. X-Forwarded) ? 

Fixes https://github.com/microsoft/reverse-proxy/issues/801