### PR TITLE
Only enable events/counters if there are listeners available

### DIFF
--- a/src/ReverseProxy.TelemetryConsumption/EventListenerService.cs
+++ b/src/ReverseProxy.TelemetryConsumption/EventListenerService.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Yarp.ReverseProxy.Telemetry.Consumption
+{
+    internal abstract class EventListenerService<TService, TTelemetryConsumer, TMetricsConsumer> : EventListener, IHostedService
+    {
+        protected abstract string EventSourceName { get; }
+
+        protected readonly ILogger<TService> Logger;
+        protected readonly IServiceProvider ServiceProvider;
+        protected readonly IHttpContextAccessor HttpContextAccessor;
+
+        private EventSource _eventSource;
+        private readonly ManualResetEventSlim _initializedMre = new();
+        private readonly int _ctorThreadId = Environment.CurrentManagedThreadId;
+        private readonly bool _enableEvents;
+        private readonly bool _enableMetrics;
+
+        public EventListenerService(ILogger<TService> logger, IServiceProvider serviceProvider, IHttpContextAccessor httpContextAccessor, ServiceCollectionInternal services)
+        {
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            ServiceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            HttpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+            _ = services ?? throw new ArgumentNullException(nameof(services));
+
+            _enableEvents = services.Services.Any(s => s.ServiceType == typeof(TTelemetryConsumer));
+            _enableMetrics = services.Services.Any(s => s.ServiceType == typeof(TMetricsConsumer));
+
+            lock (this)
+            {
+                if (_eventSource is not null)
+                {
+                    EnableEventSource();
+                }
+
+                // A different thread could be waiting for the ctor to finish, signal it that we're done
+                _initializedMre.Set();
+                _initializedMre = null;
+            }
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if (eventSource.Name == EventSourceName)
+            {
+                lock (this)
+                {
+                    _eventSource = eventSource;
+
+                    if (_initializedMre is null)
+                    {
+                        // Ctor already finished - enable the EventSource here
+                        EnableEventSource();
+                    }
+                }
+
+                // Ensure that the constructor finishes before exiting this method (so that the first events aren't dropped)
+                // It's possible that we are executing as a part of the base ctor - check the Thread ID to avoid a deadlock
+                if (Environment.CurrentManagedThreadId != _ctorThreadId)
+                {
+                    var mre = _initializedMre;
+                    if (mre is not null)
+                    {
+                        // This wait will generally be very short (waiting for the ctor on a different thread to finish)
+                        // If the ctor throws, the MRE will never be released - add a short timeout
+                        mre.Wait(TimeSpan.FromSeconds(15));
+                        mre.Dispose();
+                    }
+                }
+            }
+        }
+
+        private void EnableEventSource()
+        {
+            if (!_enableEvents && !_enableMetrics)
+            {
+                return;
+            }
+
+            var eventLevel = _enableEvents ? EventLevel.LogAlways : EventLevel.Critical;
+            var arguments = _enableMetrics ? new Dictionary<string, string> { { "EventCounterIntervalSec", MetricsOptions.Interval.TotalSeconds.ToString() } } : null;
+
+            EnableEvents(_eventSource, eventLevel, EventKeywords.None, arguments);
+            _eventSource = null;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/src/ReverseProxy.TelemetryConsumption/EventListenerService.cs
+++ b/src/ReverseProxy.TelemetryConsumption/EventListenerService.cs
@@ -19,7 +19,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
     {
         // We need a way to signal to OnEventSourceCreated that the EventListenerService constructor finished
         // OnEventSourceCreated may be called before we even reach the derived ctor (as it's exposed from the base ctor)
-        // Because of that, we can't assign the MRE as part of the ctor, we have to do it as part of the object initializer
+        // Because of that, we can't assign the MRE as part of the ctor, we have to do it as part of the _initializedMre field initializer
         // But since the ctor itself may throw here, we need a way to observe the same MRE instance from outside the ctor
         // We pull the MRE from a ThreadStatic that a ctor wrapper (Create) can observe
         [ThreadStatic]

--- a/src/ReverseProxy.TelemetryConsumption/Http/HttpEventListenerService.cs
+++ b/src/ReverseProxy.TelemetryConsumption/Http/HttpEventListenerService.cs
@@ -6,44 +6,23 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Yarp.ReverseProxy.Telemetry.Consumption
 {
-    internal sealed class HttpEventListenerService : EventListener, IHostedService
+    internal sealed class HttpEventListenerService : EventListenerService<HttpEventListenerService, IHttpTelemetryConsumer, IHttpMetricsConsumer>
     {
-        private readonly ILogger<HttpEventListenerService> _logger;
-        private readonly IServiceProvider _serviceProvider;
-        private readonly IHttpContextAccessor _httpContextAccessor;
-
         private HttpMetrics _previousMetrics;
         private HttpMetrics _currentMetrics = new();
         private int _eventCountersCount;
 
-        public HttpEventListenerService(ILogger<HttpEventListenerService> logger, IServiceProvider serviceProvider, IHttpContextAccessor httpContextAccessor)
-        {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
-            _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
-        }
+        protected override string EventSourceName => "System.Net.Http";
 
-        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-
-        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-
-        protected override void OnEventSourceCreated(EventSource eventSource)
-        {
-            if (eventSource.Name == "System.Net.Http")
-            {
-                var arguments = new Dictionary<string, string> { { "EventCounterIntervalSec", MetricsOptions.Interval.TotalSeconds.ToString() } };
-                EnableEvents(eventSource, EventLevel.LogAlways, EventKeywords.None, arguments);
-            }
-        }
+        public HttpEventListenerService(ILogger<HttpEventListenerService> logger, IServiceProvider serviceProvider, IHttpContextAccessor httpContextAccessor, ServiceCollectionInternal services)
+            : base(logger, serviceProvider, httpContextAccessor, services)
+        { }
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
@@ -60,7 +39,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 return;
             }
 
-            var context = _httpContextAccessor?.HttpContext;
+            var context = HttpContextAccessor.HttpContext;
             if (context is null)
             {
                 return;
@@ -284,14 +263,14 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 _previousMetrics = metrics;
                 _currentMetrics = new HttpMetrics();
 
-                if (previous is null || _serviceProvider is null)
+                if (previous is null)
                 {
                     return;
                 }
 
                 try
                 {
-                    foreach (var consumer in _serviceProvider.GetServices<IHttpMetricsConsumer>())
+                    foreach (var consumer in ServiceProvider.GetServices<IHttpMetricsConsumer>())
                     {
                         consumer.OnHttpMetrics(previous, metrics);
                     }
@@ -299,7 +278,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 catch (Exception ex)
                 {
                     // We can't let an uncaught exception propagate as that would crash the process
-                    _logger.LogError(ex, $"Uncaught exception occured while processing {nameof(HttpMetrics)}.");
+                    Logger.LogError(ex, $"Uncaught exception occured while processing {nameof(HttpMetrics)}.");
                 }
             }
         }

--- a/src/ReverseProxy.TelemetryConsumption/Kestrel/KestrelEventListenerService.cs
+++ b/src/ReverseProxy.TelemetryConsumption/Kestrel/KestrelEventListenerService.cs
@@ -5,53 +5,34 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Yarp.ReverseProxy.Telemetry.Consumption
 {
-    internal sealed class KestrelEventListenerService : EventListener, IHostedService
+#if !NET5_0
+    internal sealed class DummyClassNotInTheServiceCollection { }
+#endif
+
+    internal sealed class KestrelEventListenerService
+#if NET5_0
+        : EventListenerService<KestrelEventListenerService, IKestrelTelemetryConsumer, IKestrelMetricsConsumer>
+#else
+        : EventListenerService<KestrelEventListenerService, IKestrelTelemetryConsumer, DummyClassNotInTheServiceCollection>
+#endif
     {
 #if NET5_0
-        private readonly ILogger<KestrelEventListenerService> _logger;
-        private readonly IServiceProvider _serviceProvider;
-        private readonly IHttpContextAccessor _httpContextAccessor;
-
         private KestrelMetrics _previousMetrics;
         private KestrelMetrics _currentMetrics = new();
         private int _eventCountersCount;
-
-        public KestrelEventListenerService(ILogger<KestrelEventListenerService> logger, IServiceProvider serviceProvider, IHttpContextAccessor httpContextAccessor)
-        {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
-            _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
-        }
-#else
-        private readonly IHttpContextAccessor _httpContextAccessor;
-
-        public KestrelEventListenerService(IHttpContextAccessor httpContextAccessor)
-        {
-            _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
-        }
 #endif
 
-        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        protected override string EventSourceName => "Microsoft-AspNetCore-Server-Kestrel";
 
-        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-
-        protected override void OnEventSourceCreated(EventSource eventSource)
-        {
-            if (eventSource.Name == "Microsoft-AspNetCore-Server-Kestrel")
-            {
-                var arguments = new Dictionary<string, string> { { "EventCounterIntervalSec", MetricsOptions.Interval.TotalSeconds.ToString() } };
-                EnableEvents(eventSource, EventLevel.LogAlways, EventKeywords.None, arguments);
-            }
-        }
+        public KestrelEventListenerService(ILogger<KestrelEventListenerService> logger, IServiceProvider serviceProvider, IHttpContextAccessor httpContextAccessor, ServiceCollectionInternal services)
+            : base(logger, serviceProvider, httpContextAccessor, services)
+        { }
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
@@ -70,7 +51,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 return;
             }
 
-            var context = _httpContextAccessor?.HttpContext;
+            var context = HttpContextAccessor.HttpContext;
             if (context is null)
             {
                 return;
@@ -224,14 +205,14 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 _previousMetrics = metrics;
                 _currentMetrics = new KestrelMetrics();
 
-                if (previous is null || _serviceProvider is null)
+                if (previous is null)
                 {
                     return;
                 }
 
                 try
                 {
-                    foreach (var consumer in _serviceProvider.GetServices<IKestrelMetricsConsumer>())
+                    foreach (var consumer in ServiceProvider.GetServices<IKestrelMetricsConsumer>())
                     {
                         consumer.OnKestrelMetrics(previous, metrics);
                     }
@@ -239,7 +220,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 catch (Exception ex)
                 {
                     // We can't let an uncaught exception propagate as that would crash the process
-                    _logger.LogError(ex, $"Uncaught exception occured while processing {nameof(KestrelMetrics)}.");
+                    Logger.LogError(ex, $"Uncaught exception occured while processing {nameof(KestrelMetrics)}.");
                 }
             }
         }

--- a/src/ReverseProxy.TelemetryConsumption/ServiceCollectionInternal.cs
+++ b/src/ReverseProxy.TelemetryConsumption/ServiceCollectionInternal.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Yarp.ReverseProxy.Telemetry.Consumption
+{
+    internal record ServiceCollectionInternal(IServiceCollection Services);
+}

--- a/src/ReverseProxy.TelemetryConsumption/Sockets/SocketsEventListenerService.cs
+++ b/src/ReverseProxy.TelemetryConsumption/Sockets/SocketsEventListenerService.cs
@@ -6,44 +6,23 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Net.Sockets;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Yarp.ReverseProxy.Telemetry.Consumption
 {
-    internal sealed class SocketsEventListenerService : EventListener, IHostedService
+    internal sealed class SocketsEventListenerService : EventListenerService<SocketsEventListenerService, ISocketsTelemetryConsumer, ISocketsMetricsConsumer>
     {
-        private readonly ILogger<SocketsEventListenerService> _logger;
-        private readonly IServiceProvider _serviceProvider;
-        private readonly IHttpContextAccessor _httpContextAccessor;
-
         private SocketsMetrics _previousMetrics;
         private SocketsMetrics _currentMetrics = new();
         private int _eventCountersCount;
 
-        public SocketsEventListenerService(ILogger<SocketsEventListenerService> logger, IServiceProvider serviceProvider, IHttpContextAccessor httpContextAccessor)
-        {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
-            _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
-        }
+        protected override string EventSourceName => "System.Net.Sockets";
 
-        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-
-        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-
-        protected override void OnEventSourceCreated(EventSource eventSource)
-        {
-            if (eventSource.Name == "System.Net.Sockets")
-            {
-                var arguments = new Dictionary<string, string> { { "EventCounterIntervalSec", MetricsOptions.Interval.TotalSeconds.ToString() } };
-                EnableEvents(eventSource, EventLevel.LogAlways, EventKeywords.None, arguments);
-            }
-        }
+        public SocketsEventListenerService(ILogger<SocketsEventListenerService> logger, IServiceProvider serviceProvider, IHttpContextAccessor httpContextAccessor, ServiceCollectionInternal services)
+            : base(logger, serviceProvider, httpContextAccessor, services)
+        { }
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
@@ -60,7 +39,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 return;
             }
 
-            var context = _httpContextAccessor?.HttpContext;
+            var context = HttpContextAccessor.HttpContext;
             if (context is null)
             {
                 return;
@@ -170,14 +149,14 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 _previousMetrics = metrics;
                 _currentMetrics = new SocketsMetrics();
 
-                if (previous is null || _serviceProvider is null)
+                if (previous is null)
                 {
                     return;
                 }
 
                 try
                 {
-                    foreach (var consumer in _serviceProvider.GetServices<ISocketsMetricsConsumer>())
+                    foreach (var consumer in ServiceProvider.GetServices<ISocketsMetricsConsumer>())
                     {
                         consumer.OnSocketsMetrics(previous, metrics);
                     }
@@ -185,7 +164,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 catch (Exception ex)
                 {
                     // We can't let an uncaught exception propagate as that would crash the process
-                    _logger.LogError(ex, $"Uncaught exception occured while processing {nameof(SocketsMetrics)}.");
+                    Logger.LogError(ex, $"Uncaught exception occured while processing {nameof(SocketsMetrics)}.");
                 }
             }
         }

--- a/src/ReverseProxy.TelemetryConsumption/TelemetryConsumptionExtensions.cs
+++ b/src/ReverseProxy.TelemetryConsumption/TelemetryConsumptionExtensions.cs
@@ -22,13 +22,13 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddHttpContextAccessor();
             services.TryAddSingleton(new ServiceCollectionInternal(services));
 
-            services.AddHostedService<ProxyEventListenerService>();
-            services.AddHostedService<KestrelEventListenerService>();
+            services.AddHostedService(provider => ProxyEventListenerService.Create<ProxyEventListenerService>(provider));
+            services.AddHostedService(provider => KestrelEventListenerService.Create<KestrelEventListenerService>(provider));
 #if NET5_0
-            services.AddHostedService<HttpEventListenerService>();
-            services.AddHostedService<NameResolutionEventListenerService>();
-            services.AddHostedService<NetSecurityEventListenerService>();
-            services.AddHostedService<SocketsEventListenerService>();
+            services.AddHostedService(provider => HttpEventListenerService.Create<HttpEventListenerService>(provider));
+            services.AddHostedService(provider => NameResolutionEventListenerService.Create<NameResolutionEventListenerService>(provider));
+            services.AddHostedService(provider => NetSecurityEventListenerService.Create<NetSecurityEventListenerService>(provider));
+            services.AddHostedService(provider => SocketsEventListenerService.Create<SocketsEventListenerService>(provider));
 #endif
             return services;
         }

--- a/src/ReverseProxy.TelemetryConsumption/TelemetryConsumptionExtensions.cs
+++ b/src/ReverseProxy.TelemetryConsumption/TelemetryConsumptionExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Yarp.ReverseProxy.Telemetry.Consumption;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -9,92 +10,27 @@ namespace Microsoft.Extensions.DependencyInjection
     {
 #if NET5_0
         /// <summary>
-        /// Shortcut for registering all (Proxy, Kestrel, Http, NameResolution, NetSecurity and Sockets) telemetry listeners.
+        /// Registers all telemetry listeners (Proxy, Kestrel, Http, NameResolution, NetSecurity and Sockets).
         /// </summary>
 #else
         /// <summary>
-        /// Shortcut for registering all (Proxy and Kestrel) telemetry listeners.
+        /// Registers all telemetry listeners (Proxy and Kestrel).
         /// </summary>
 #endif
         public static IServiceCollection AddTelemetryListeners(this IServiceCollection services)
         {
-            services.AddProxyTelemetryListener();
-            services.AddKestrelTelemetryListener();
-#if NET5_0
-            services.AddHttpTelemetryListener();
-            services.AddNameResolutionTelemetryListener();
-            services.AddNetSecurityTelemetryListener();
-            services.AddSocketsTelemetryListener();
-#endif
-            return services;
-        }
-
-        /// <summary>
-        /// Registers a service responsible for calling <see cref="IProxyTelemetryConsumer"/>s and <see cref="IProxyMetricsConsumer"/>s.
-        /// </summary>
-        public static IServiceCollection AddProxyTelemetryListener(this IServiceCollection services)
-        {
             services.AddHttpContextAccessor();
+            services.TryAddSingleton(new ServiceCollectionInternal(services));
+
             services.AddHostedService<ProxyEventListenerService>();
-            return services;
-        }
-
-#if NET5_0
-        /// <summary>
-        /// Registers a service responsible for calling <see cref="IKestrelTelemetryConsumer"/>s and <see cref="IKestrelMetricsConsumer"/>s.
-        /// </summary>
-#else
-        /// <summary>
-        /// Registers a service responsible for calling <see cref="IKestrelTelemetryConsumer"/>s
-        /// </summary>
-#endif
-        public static IServiceCollection AddKestrelTelemetryListener(this IServiceCollection services)
-        {
-            services.AddHttpContextAccessor();
             services.AddHostedService<KestrelEventListenerService>();
-            return services;
-        }
-
 #if NET5_0
-        /// <summary>
-        /// Registers a service responsible for calling <see cref="IHttpTelemetryConsumer"/>s and <see cref="IHttpMetricsConsumer"/>s.
-        /// </summary>
-        public static IServiceCollection AddHttpTelemetryListener(this IServiceCollection services)
-        {
-            services.AddHttpContextAccessor();
             services.AddHostedService<HttpEventListenerService>();
-            return services;
-        }
-
-        /// <summary>
-        /// Registers a service responsible for calling <see cref="INameResolutionTelemetryConsumer"/>s and <see cref="INameResolutionMetricsConsumer"/>s.
-        /// </summary>
-        public static IServiceCollection AddNameResolutionTelemetryListener(this IServiceCollection services)
-        {
-            services.AddHttpContextAccessor();
             services.AddHostedService<NameResolutionEventListenerService>();
-            return services;
-        }
-
-        /// <summary>
-        /// Registers a service responsible for calling <see cref="INetSecurityTelemetryConsumer"/>s and <see cref="INetSecurityMetricsConsumer"/>s.
-        /// </summary>
-        public static IServiceCollection AddNetSecurityTelemetryListener(this IServiceCollection services)
-        {
-            services.AddHttpContextAccessor();
             services.AddHostedService<NetSecurityEventListenerService>();
-            return services;
-        }
-
-        /// <summary>
-        /// Registers a service responsible for calling <see cref="ISocketsTelemetryConsumer"/>s and <see cref="ISocketsMetricsConsumer"/>s.
-        /// </summary>
-        public static IServiceCollection AddSocketsTelemetryListener(this IServiceCollection services)
-        {
-            services.AddHttpContextAccessor();
             services.AddHostedService<SocketsEventListenerService>();
+#endif
             return services;
         }
-#endif
     }
 }

--- a/test/ReverseProxy.FunctionalTests/TelemetryConsumptionTests.cs
+++ b/test/ReverseProxy.FunctionalTests/TelemetryConsumptionTests.cs
@@ -99,6 +99,11 @@ namespace Yarp.ReverseProxy
             {
                 Assert.True(stages[i - 1].Timestamp <= stages[i].Timestamp);
             }
+
+
+            // As a workaround for https://github.com/dotnet/runtime/pull/51227, run the metrics test after telemetry finishes
+            // It should otherwise be a separate test
+            await MetricsConsumptionWorks();
         }
 
         private sealed class TelemetryConsumer :
@@ -114,7 +119,7 @@ namespace Yarp.ReverseProxy
         {
             public string ClusterId { get; set; }
 
-            public readonly List<(string Stage, DateTime Timestamp)> Stages = new List<(string, DateTime)>(16);
+            public readonly List<(string Stage, DateTime Timestamp)> Stages = new();
 
             private void AddStage(string stage, DateTime timestamp)
             {
@@ -164,8 +169,7 @@ namespace Yarp.ReverseProxy
 #endif
         }
 
-        [Fact]
-        public async Task MetricsConsumptionWorks()
+        private async Task MetricsConsumptionWorks()
         {
             MetricsOptions.Interval = TimeSpan.FromMilliseconds(10);
 

--- a/testassets/ReverseProxy.Code/Startup.cs
+++ b/testassets/ReverseProxy.Code/Startup.cs
@@ -90,7 +90,7 @@ namespace Yarp.ReverseProxy.Sample
             services.AddHttpContextAccessor();
             services.AddSingleton<IProxyMetricsConsumer, ProxyMetricsConsumer>();
             services.AddScoped<IProxyTelemetryConsumer, ProxyTelemetryConsumer>();
-            services.AddProxyTelemetryListener();
+            services.AddTelemetryListeners();
         }
 
         /// <summary>


### PR DESCRIPTION
Removed the `AddProxyTelemetryListener`, `AddHttpTelemetryListener`, ... extension methods as they don't provide any benefit over just `AddTelemetryListeners` after this change. This is the only change to the public API, the rest are internal implementation details.

Added an abstract `EventListenerService` class as a base of all listeners.
It abstracts away the synchronization around enabling the EventSource based on parameters from the constructor.

The listener implementations now inspect the service collection for registered consumers and only enable the necessary `EventSource`s with the needed parameters. We will only enable events if a telemetry consumer is present & only enable event counters if a metrics consumer is present. Previously we would always enable events & metrics, even if only metrics were being used.

`EventSource` & `EventSourceListener` have a weird interaction where the `OnEventSourceCreated` may be called from the base constructor. That means parameters passed to the listener constructor can't control what happens in `OnEventSourceCreated`.
To work around that, the `EventSourceName` is taken from a property implemented by derived types instead of being a ctor argument.
Since only the ctor can decide on whether we need events/metrics, we delay calling `EnableEvents` until the ctor runs and inspects the service collection.
We avoid returning from `OnEventSourceCreated` before enabling the `EventSource` so that the first event isn't dropped.