### PR TITLE
React to API breaks in samples

### DIFF
--- a/samples/ReverseProxy.Code.Sample/Startup.cs
+++ b/samples/ReverseProxy.Code.Sample/Startup.cs
@@ -48,8 +48,8 @@ namespace Yarp.Sample
                     // Use a custom proxy middleware, defined below
                     proxyPipeline.Use(MyCustomProxyStep);
                     // Don't forget to include these two middleware when you make a custom proxy pipeline (if you need them).
-                    proxyPipeline.UseAffinitizedDestinationLookup();
-                    proxyPipeline.UseProxyLoadBalancing();
+                    proxyPipeline.UseSessionAffinity();
+                    proxyPipeline.UseLoadBalancing();
                 });
             });
         }


### PR DESCRIPTION
This sample uses a wildcard package dependency and couldn't be updated until there was a build available.