### PR TITLE
Only enable events/counters if there are listeners available

### DIFF
--- a/samples/Prometheus/ReverseProxy.Metrics-Promethius.Sample/PrometheusServiceExtensions.cs
+++ b/samples/Prometheus/ReverseProxy.Metrics-Promethius.Sample/PrometheusServiceExtensions.cs
@@ -1,11 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Yarp.ReverseProxy.Telemetry.Consumption;
 
@@ -15,7 +10,7 @@ namespace Yarp.Sample
     {
         public static IServiceCollection AddPrometheusProxyMetrics(this IServiceCollection services)
         {
-            services.AddProxyTelemetryListener();
+            services.AddTelemetryListeners();
             services.AddSingleton<IProxyMetricsConsumer, PrometheusProxyMetrics>();
             return services;
         }
@@ -23,28 +18,28 @@ namespace Yarp.Sample
 #if NET5_0_OR_GREATER
         public static IServiceCollection AddPrometheusDnsMetrics(this IServiceCollection services)
         {
-            services.AddNameResolutionTelemetryListener();
+            services.AddTelemetryListeners();
             services.AddSingleton<INameResolutionMetricsConsumer, PrometheusDnsMetrics>();
             return services;
         }
 
         public static IServiceCollection AddPrometheusKestrelMetrics(this IServiceCollection services)
         {
-            services.AddKestrelTelemetryListener();
+            services.AddTelemetryListeners();
             services.AddSingleton<IKestrelMetricsConsumer, PrometheusKestrelMetrics>();
             return services;
         }
 
         public static IServiceCollection AddPrometheusOutboundHttpMetrics(this IServiceCollection services)
         {
-            services.AddHttpTelemetryListener();
+            services.AddTelemetryListeners();
             services.AddSingleton<IHttpMetricsConsumer, PrometheusOutboundHttpMetrics>();
             return services;
         }
 
         public static IServiceCollection AddPrometheusSocketsMetrics(this IServiceCollection services)
         {
-            services.AddSocketsTelemetryListener();
+            services.AddTelemetryListeners();
             services.AddSingleton<ISocketsMetricsConsumer, PrometheusSocketMetrics>();
             return services;
         }

--- a/samples/Prometheus/ReverseProxy.Metrics-Promethius.Sample/Startup.cs
+++ b/samples/Prometheus/ReverseProxy.Metrics-Promethius.Sample/Startup.cs
@@ -5,11 +5,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Prometheus;
-using Yarp.ReverseProxy.Telemetry.Consumption;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
-using System;
-using Yarp.ReverseProxy.Middleware;
 
 namespace Yarp.Sample
 {
@@ -19,7 +14,6 @@ namespace Yarp.Sample
     public class Startup
     {
         private readonly IConfiguration _configuration;
-
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Startup" /> class.
@@ -37,8 +31,6 @@ namespace Yarp.Sample
             services.AddControllers();
             services.AddReverseProxy()
                 .LoadFromConfig(_configuration.GetSection("ReverseProxy"));
-
-            services.AddHttpContextAccessor();
 
             //Enable metric collection for all the underlying event counters used by YARP
             services.AddAllPrometheusMetrics();

--- a/src/ReverseProxy.TelemetryConsumption/EventListenerService.cs
+++ b/src/ReverseProxy.TelemetryConsumption/EventListenerService.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Yarp.ReverseProxy.Telemetry.Consumption
+{
+    internal abstract class EventListenerService<TService, TTelemetryConsumer, TMetricsConsumer> : EventListener, IHostedService
+    {
+        // We need a way to signal to OnEventSourceCreated that the EventListenerService constructor finished
+        // OnEventSourceCreated may be called before we even reach the derived ctor (as it's exposed from the base ctor)
+        // Because of that, we can't assign the MRE as part of the ctor, we have to do it as part of the _initializedMre field initializer
+        // But since the ctor itself may throw here, we need a way to observe the same MRE instance from outside the ctor
+        // We pull the MRE from a ThreadStatic that a ctor wrapper (Create) can observe
+        [ThreadStatic]
+        private static ManualResetEventSlim _threadStaticInitializedMre;
+
+        public static TEventListener Create<TEventListener>(IServiceProvider serviceProvider)
+            where TEventListener : EventListenerService<TService, TTelemetryConsumer, TMetricsConsumer>
+        {
+            _threadStaticInitializedMre = new();
+            try
+            {
+                return ActivatorUtilities.CreateInstance<TEventListener>(serviceProvider);
+            }
+            finally
+            {
+                _threadStaticInitializedMre.Set();
+                _threadStaticInitializedMre = null;
+            }
+        }
+
+        protected abstract string EventSourceName { get; }
+
+        protected readonly ILogger<TService> Logger;
+        protected readonly TMetricsConsumer[] MetricsConsumers;
+        protected readonly TTelemetryConsumer[] TelemetryConsumers;
+
+        private EventSource _eventSource;
+        private readonly object _syncObject = new();
+        private readonly ManualResetEventSlim _initializedMre = _threadStaticInitializedMre;
+
+        public EventListenerService(
+            ILogger<TService> logger,
+            IEnumerable<TTelemetryConsumer> telemetryConsumers,
+            IEnumerable<TMetricsConsumer> metricsConsumers)
+        {
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _ = telemetryConsumers ?? throw new ArgumentNullException(nameof(telemetryConsumers));
+            _ = metricsConsumers ?? throw new ArgumentNullException(nameof(metricsConsumers));
+
+            TelemetryConsumers = telemetryConsumers.ToArray();
+            MetricsConsumers = metricsConsumers.ToArray();
+
+            if (TelemetryConsumers.Any(s => s is null) || metricsConsumers.Any(c => c is null))
+            {
+                throw new ArgumentException("A consumer may not be null",
+                    TelemetryConsumers.Any(s => s is null) ? nameof(telemetryConsumers) : nameof(metricsConsumers));
+            }
+
+            if (TelemetryConsumers.Length == 0)
+            {
+                TelemetryConsumers = null;
+            }
+
+            if (MetricsConsumers.Length == 0)
+            {
+                MetricsConsumers = null;
+            }
+
+            lock (_syncObject)
+            {
+                if (_eventSource is not null)
+                {
+                    EnableEventSource();
+                }
+
+                Debug.Assert(_initializedMre is not null);
+                _initializedMre = null;
+            }
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if (eventSource.Name == EventSourceName)
+            {
+                lock (_syncObject)
+                {
+                    _eventSource = eventSource;
+
+                    if (_initializedMre is null)
+                    {
+                        // Ctor already finished - enable the EventSource here
+                        EnableEventSource();
+                    }
+                }
+
+                // Ensure that the constructor finishes before exiting this method (so that the first events aren't dropped)
+                // It's possible that we are executing as a part of the base ctor - only block if we're running on a different thread
+                var mre = _initializedMre;
+                if (mre is not null && !ReferenceEquals(mre, _threadStaticInitializedMre))
+                {
+                    mre.Wait();
+                }
+            }
+        }
+
+        private void EnableEventSource()
+        {
+            var enableEvents = TelemetryConsumers is not null;
+            var enableMetrics = MetricsConsumers is not null;
+
+            if (!enableEvents && !enableMetrics)
+            {
+                return;
+            }
+
+            var eventLevel = enableEvents ? EventLevel.Verbose : EventLevel.Critical;
+            var arguments = enableMetrics ? new Dictionary<string, string> { { "EventCounterIntervalSec", MetricsOptions.Interval.TotalSeconds.ToString() } } : null;
+
+            EnableEvents(_eventSource, eventLevel, EventKeywords.None, arguments);
+            _eventSource = null;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/src/ReverseProxy.TelemetryConsumption/Http/IHttpTelemetryConsumer.cs
+++ b/src/ReverseProxy.TelemetryConsumption/Http/IHttpTelemetryConsumer.cs
@@ -22,19 +22,19 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
         /// <param name="versionMajor">Major component of the request's HTTP version.</param>
         /// <param name="versionMinor">Minor component of the request's HTTP version.</param>
         /// <param name="versionPolicy"><see cref="HttpVersionPolicy"/> of the request.</param>
-        void OnRequestStart(DateTime timestamp, string scheme, string host, int port, string pathAndQuery, int versionMajor, int versionMinor, HttpVersionPolicy versionPolicy);
+        void OnRequestStart(DateTime timestamp, string scheme, string host, int port, string pathAndQuery, int versionMajor, int versionMinor, HttpVersionPolicy versionPolicy) { }
 
         /// <summary>
         /// Called after an HTTP request.
         /// </summary>
         /// <param name="timestamp">Timestamp when the event was fired.</param>
-        void OnRequestStop(DateTime timestamp);
+        void OnRequestStop(DateTime timestamp) { }
 
         /// <summary>
         /// Called before <see cref="OnRequestStop(DateTime)"/> if the request failed.
         /// </summary>
         /// <param name="timestamp">Timestamp when the event was fired.</param>
-        void OnRequestFailed(DateTime timestamp);
+        void OnRequestFailed(DateTime timestamp) { }
 
         /// <summary>
         /// Called when a new HTTP connection is established.
@@ -42,7 +42,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
         /// <param name="timestamp">Timestamp when the event was fired.</param>
         /// <param name="versionMajor">Major component of the connection's HTTP version.</param>
         /// <param name="versionMinor">Minor component of the connection's HTTP version.</param>
-        void OnConnectionEstablished(DateTime timestamp, int versionMajor, int versionMinor);
+        void OnConnectionEstablished(DateTime timestamp, int versionMajor, int versionMinor) { }
 
         /// <summary>
         /// Called when a request that hit the MaxConnectionsPerServer or MAX_CONCURRENT_STREAMS limit leaves the queue.
@@ -51,43 +51,43 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
         /// <param name="timeOnQueue">Time spent on queue.</param>
         /// <param name="versionMajor">Major component of the request's HTTP version.</param>
         /// <param name="versionMinor">Minor component of the request's HTTP version.</param>
-        void OnRequestLeftQueue(DateTime timestamp, TimeSpan timeOnQueue, int versionMajor, int versionMinor);
+        void OnRequestLeftQueue(DateTime timestamp, TimeSpan timeOnQueue, int versionMajor, int versionMinor) { }
 
         /// <summary>
         /// Called before sending the request headers.
         /// </summary>
         /// <param name="timestamp">Timestamp when the event was fired.</param>
-        void OnRequestHeadersStart(DateTime timestamp);
+        void OnRequestHeadersStart(DateTime timestamp) { }
 
         /// <summary>
         /// Called after sending the request headers.
         /// </summary>
         /// <param name="timestamp">Timestamp when the event was fired.</param>
-        void OnRequestHeadersStop(DateTime timestamp);
+        void OnRequestHeadersStop(DateTime timestamp) { }
 
         /// <summary>
         /// Called before sending the request content.
         /// </summary>
         /// <param name="timestamp">Timestamp when the event was fired.</param>
-        void OnRequestContentStart(DateTime timestamp);
+        void OnRequestContentStart(DateTime timestamp) { }
 
         /// <summary>
         /// Called after sending the request content.
         /// </summary>
         /// <param name="timestamp">Timestamp when the event was fired.</param>
         /// <param name="contentLength"></param>
-        void OnRequestContentStop(DateTime timestamp, long contentLength);
+        void OnRequestContentStop(DateTime timestamp, long contentLength) { }
 
         /// <summary>
         /// Called before reading the response headers.
         /// </summary>
         /// <param name="timestamp">Timestamp when the event was fired.</param>
-        void OnResponseHeadersStart(DateTime timestamp);
+        void OnResponseHeadersStart(DateTime timestamp) { }
 
         /// <summary>
         /// Called after reading all response headers.
         /// </summary>
         /// <param name="timestamp">Timestamp when the event was fired.</param>
-        void OnResponseHeadersStop(DateTime timestamp);
+        void OnResponseHeadersStop(DateTime timestamp) { }
     }
 }

--- a/src/ReverseProxy.TelemetryConsumption/Kestrel/IKestrelTelemetryConsumer.cs
+++ b/src/ReverseProxy.TelemetryConsumption/Kestrel/IKestrelTelemetryConsumer.cs
@@ -20,7 +20,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
         /// <param name="httpVersion">HTTP version of the request.</param>
         /// <param name="path">Path of the request.</param>
         /// <param name="method">HTTP method of the request.</param>
-        void OnRequestStart(DateTime timestamp, string connectionId, string requestId, string httpVersion, string path, string method);
+        void OnRequestStart(DateTime timestamp, string connectionId, string requestId, string httpVersion, string path, string method) { }
 
         /// <summary>
         /// Called at the end of a request.
@@ -31,7 +31,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
         /// <param name="httpVersion">HTTP version of the request.</param>
         /// <param name="path">Path of the request.</param>
         /// <param name="method">HTTP method of the request.</param>
-        void OnRequestStop(DateTime timestamp, string connectionId, string requestId, string httpVersion, string path, string method);
+        void OnRequestStop(DateTime timestamp, string connectionId, string requestId, string httpVersion, string path, string method) { }
 #else
         /// <summary>
         /// Called at the start of a request.
@@ -39,7 +39,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
         /// <param name="timestamp">Timestamp when the event was fired.</param>
         /// <param name="connectionId">ID of the connection.</param>
         /// <param name="requestId">ID of the request.</param>
-        void OnRequestStart(DateTime timestamp, string connectionId, string requestId);
+        void OnRequestStart(DateTime timestamp, string connectionId, string requestId) { }
 
         /// <summary>
         /// Called at the end of a request.
@@ -47,7 +47,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
         /// <param name="timestamp">Timestamp when the event was fired.</param>
         /// <param name="connectionId">ID of the connection.</param>
         /// <param name="requestId">ID of the request.</param>
-        void OnRequestStop(DateTime timestamp, string connectionId, string requestId);
+        void OnRequestStop(DateTime timestamp, string connectionId, string requestId) { }
 #endif
     }
 }

--- a/src/ReverseProxy.TelemetryConsumption/NameResolution/INameResolutionTelemetryConsumer.cs
+++ b/src/ReverseProxy.TelemetryConsumption/NameResolution/INameResolutionTelemetryConsumer.cs
@@ -15,18 +15,18 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
         /// </summary>
         /// <param name="timestamp">Timestamp when the event was fired.</param>
         /// <param name="hostNameOrAddress">Host name or address we are resolving.</param>
-        void OnResolutionStart(DateTime timestamp, string hostNameOrAddress);
+        void OnResolutionStart(DateTime timestamp, string hostNameOrAddress) { }
 
         /// <summary>
         /// Called after a name resolution.
         /// </summary>
         /// <param name="timestamp">Timestamp when the event was fired.</param>
-        void OnResolutionStop(DateTime timestamp);
+        void OnResolutionStop(DateTime timestamp) { }
 
         /// <summary>
         /// Called before <see cref="OnResolutionStop(DateTime)"/> if the name resolution failed.
         /// </summary>
         /// <param name="timestamp">Timestamp when the event was fired.</param>
-        void OnResolutionFailed(DateTime timestamp);
+        void OnResolutionFailed(DateTime timestamp) { }
     }
 }

--- a/src/ReverseProxy.TelemetryConsumption/NameResolution/NameResolutionEventListenerService.cs
+++ b/src/ReverseProxy.TelemetryConsumption/NameResolution/NameResolutionEventListenerService.cs
@@ -5,44 +5,21 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Yarp.ReverseProxy.Telemetry.Consumption
 {
-    internal sealed class NameResolutionEventListenerService : EventListener, IHostedService
+    internal sealed class NameResolutionEventListenerService : EventListenerService<NameResolutionEventListenerService, INameResolutionTelemetryConsumer, INameResolutionMetricsConsumer>
     {
-        private readonly ILogger<NameResolutionEventListenerService> _logger;
-        private readonly IServiceProvider _serviceProvider;
-        private readonly IHttpContextAccessor _httpContextAccessor;
-
         private NameResolutionMetrics _previousMetrics;
         private NameResolutionMetrics _currentMetrics = new();
         private int _eventCountersCount;
 
-        public NameResolutionEventListenerService(ILogger<NameResolutionEventListenerService> logger, IServiceProvider serviceProvider, IHttpContextAccessor httpContextAccessor)
-        {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
-            _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
-        }
+        protected override string EventSourceName => "System.Net.NameResolution";
 
-        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-
-        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-
-        protected override void OnEventSourceCreated(EventSource eventSource)
-        {
-            if (eventSource.Name == "System.Net.NameResolution")
-            {
-                var arguments = new Dictionary<string, string> { { "EventCounterIntervalSec", MetricsOptions.Interval.TotalSeconds.ToString() } };
-                EnableEvents(eventSource, EventLevel.LogAlways, EventKeywords.None, arguments);
-            }
-        }
+        public NameResolutionEventListenerService(ILogger<NameResolutionEventListenerService> logger, IEnumerable<INameResolutionTelemetryConsumer> telemetryConsumers, IEnumerable<INameResolutionMetricsConsumer> metricsConsumers)
+            : base(logger, telemetryConsumers, metricsConsumers)
+        { }
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
@@ -59,15 +36,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 return;
             }
 
-            var context = _httpContextAccessor?.HttpContext;
-            if (context is null)
-            {
-                return;
-            }
-
-            using var consumers = context.RequestServices.GetServices<INameResolutionTelemetryConsumer>().GetEnumerator();
-
-            if (!consumers.MoveNext())
+            if (TelemetryConsumers is null)
             {
                 return;
             }
@@ -80,33 +49,30 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                     Debug.Assert(eventData.EventName == "ResolutionStart" && payload.Count == 1);
                     {
                         var hostNameOrAddress = (string)payload[0];
-                        do
+                        foreach (var consumer in TelemetryConsumers)
                         {
-                            consumers.Current.OnResolutionStart(eventData.TimeStamp, hostNameOrAddress);
+                            consumer.OnResolutionStart(eventData.TimeStamp, hostNameOrAddress);
                         }
-                        while (consumers.MoveNext());
                     }
                     break;
 
                 case 2:
                     Debug.Assert(eventData.EventName == "ResolutionStop" && payload.Count == 0);
                     {
-                        do
+                        foreach (var consumer in TelemetryConsumers)
                         {
-                            consumers.Current.OnResolutionStop(eventData.TimeStamp);
+                            consumer.OnResolutionStop(eventData.TimeStamp);
                         }
-                        while (consumers.MoveNext());
                     }
                     break;
 
                 case 3:
                     Debug.Assert(eventData.EventName == "ResolutionFailed" && payload.Count == 0);
                     {
-                        do
+                        foreach (var consumer in TelemetryConsumers)
                         {
-                            consumers.Current.OnResolutionFailed(eventData.TimeStamp);
+                            consumer.OnResolutionFailed(eventData.TimeStamp);
                         }
-                        while (consumers.MoveNext());
                     }
                     break;
             }
@@ -114,6 +80,11 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
 
         private void OnEventCounters(EventWrittenEventArgs eventData)
         {
+            if (MetricsConsumers is null)
+            {
+                return;
+            }
+
             Debug.Assert(eventData.EventName == "EventCounters" && eventData.Payload.Count == 1);
             var counters = (IDictionary<string, object>)eventData.Payload[0];
 
@@ -151,14 +122,14 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 _previousMetrics = metrics;
                 _currentMetrics = new NameResolutionMetrics();
 
-                if (previous is null || _serviceProvider is null)
+                if (previous is null)
                 {
                     return;
                 }
 
                 try
                 {
-                    foreach (var consumer in _serviceProvider.GetServices<INameResolutionMetricsConsumer>())
+                    foreach (var consumer in MetricsConsumers)
                     {
                         consumer.OnNameResolutionMetrics(previous, metrics);
                     }
@@ -166,7 +137,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 catch (Exception ex)
                 {
                     // We can't let an uncaught exception propagate as that would crash the process
-                    _logger.LogError(ex, $"Uncaught exception occured while processing {nameof(NameResolutionMetrics)}.");
+                    Logger.LogError(ex, $"Uncaught exception occured while processing {nameof(NameResolutionMetrics)}.");
                 }
             }
         }

--- a/src/ReverseProxy.TelemetryConsumption/NetSecurity/INetSecurityTelemetryConsumer.cs
+++ b/src/ReverseProxy.TelemetryConsumption/NetSecurity/INetSecurityTelemetryConsumer.cs
@@ -17,14 +17,14 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
         /// <param name="timestamp">Timestamp when the event was fired.</param>
         /// <param name="isServer">Indicates whether we are authenticating as the server.</param>
         /// <param name="targetHost">Name of the host we are authenticating with.</param>
-        void OnHandshakeStart(DateTime timestamp, bool isServer, string targetHost);
+        void OnHandshakeStart(DateTime timestamp, bool isServer, string targetHost) { }
 
         /// <summary>
         /// Called after a handshake.
         /// </summary>
         /// <param name="timestamp">Timestamp when the event was fired.</param>
         /// <param name="protocol">The protocol established by the handshake.</param>
-        void OnHandshakeStop(DateTime timestamp, SslProtocols protocol);
+        void OnHandshakeStop(DateTime timestamp, SslProtocols protocol) { }
 
         /// <summary>
         /// Called before <see cref="OnHandshakeStop(DateTime, SslProtocols)"/> if the handshake failed.
@@ -33,6 +33,6 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
         /// <param name="isServer">Indicates whether we were authenticating as the server.</param>
         /// <param name="elapsed">Time elapsed since the start of the handshake.</param>
         /// <param name="exceptionMessage">Exception information for the handshake failure.</param>
-        void OnHandshakeFailed(DateTime timestamp, bool isServer, TimeSpan elapsed, string exceptionMessage);
+        void OnHandshakeFailed(DateTime timestamp, bool isServer, TimeSpan elapsed, string exceptionMessage) { }
     }
 }

--- a/src/ReverseProxy.TelemetryConsumption/Proxy/IProxyTelemetryConsumer.cs
+++ b/src/ReverseProxy.TelemetryConsumption/Proxy/IProxyTelemetryConsumer.cs
@@ -16,28 +16,28 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
         /// </summary>
         /// <param name="timestamp">Timestamp when the event was fired.</param>
         /// <param name="destinationPrefix"></param>
-        void OnProxyStart(DateTime timestamp, string destinationPrefix);
+        void OnProxyStart(DateTime timestamp, string destinationPrefix) { }
 
         /// <summary>
         /// Called after proxying a request.
         /// </summary>
         /// <param name="timestamp">Timestamp when the event was fired.</param>
         /// <param name="statusCode">The status code returned in the response.</param>
-        void OnProxyStop(DateTime timestamp, int statusCode);
+        void OnProxyStop(DateTime timestamp, int statusCode) { }
 
         /// <summary>
         /// Called before <see cref="OnProxyStop(DateTime, int)"/> if proxying the request failed.
         /// </summary>
         /// <param name="timestamp">Timestamp when the event was fired.</param>
         /// <param name="error"><see cref="ProxyError"/> information for the proxy failure.</param>
-        void OnProxyFailed(DateTime timestamp, ProxyError error);
+        void OnProxyFailed(DateTime timestamp, ProxyError error) { }
 
         /// <summary>
         /// Called when reaching a given stage of proxying a request.
         /// </summary>
         /// <param name="timestamp">Timestamp when the event was fired.</param>
         /// <param name="stage">Stage of the proxy operation.</param>
-        void OnProxyStage(DateTime timestamp, ProxyStage stage);
+        void OnProxyStage(DateTime timestamp, ProxyStage stage) { }
 
         /// <summary>
         /// Called periodically while a content transfer is active.
@@ -48,7 +48,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
         /// <param name="iops">Number of read/write pairs performed.</param>
         /// <param name="readTime">Time spent reading from the source.</param>
         /// <param name="writeTime">Time spent writing to the destination.</param>
-        void OnContentTransferring(DateTime timestamp, bool isRequest, long contentLength, long iops, TimeSpan readTime, TimeSpan writeTime);
+        void OnContentTransferring(DateTime timestamp, bool isRequest, long contentLength, long iops, TimeSpan readTime, TimeSpan writeTime) { }
 
         /// <summary>
         /// Called after transferring the request or response content.
@@ -60,7 +60,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
         /// <param name="readTime">Time spent reading from the source.</param>
         /// <param name="writeTime">Time spent writing to the destination.</param>
         /// <param name="firstReadTime">Time spent on the first read of the source.</param>
-        void OnContentTransferred(DateTime timestamp, bool isRequest, long contentLength, long iops, TimeSpan readTime, TimeSpan writeTime, TimeSpan firstReadTime);
+        void OnContentTransferred(DateTime timestamp, bool isRequest, long contentLength, long iops, TimeSpan readTime, TimeSpan writeTime, TimeSpan firstReadTime) { }
 
         /// <summary>
         /// Called before proxying a request.
@@ -69,6 +69,6 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
         /// <param name="clusterId">Cluster ID</param>
         /// <param name="routeId">Route ID</param>
         /// <param name="destinationId">Destination ID</param>
-        void OnProxyInvoke(DateTime timestamp, string clusterId, string routeId, string destinationId);
+        void OnProxyInvoke(DateTime timestamp, string clusterId, string routeId, string destinationId) { }
     }
 }

--- a/src/ReverseProxy.TelemetryConsumption/Proxy/ProxyEventListenerService.cs
+++ b/src/ReverseProxy.TelemetryConsumption/Proxy/ProxyEventListenerService.cs
@@ -5,45 +5,22 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Yarp.ReverseProxy.Service.Proxy;
 
 namespace Yarp.ReverseProxy.Telemetry.Consumption
 {
-    internal sealed class ProxyEventListenerService : EventListener, IHostedService
+    internal sealed class ProxyEventListenerService : EventListenerService<ProxyEventListenerService, IProxyTelemetryConsumer, IProxyMetricsConsumer>
     {
-        private readonly ILogger<ProxyEventListenerService> _logger;
-        private readonly IServiceProvider _serviceProvider;
-        private readonly IHttpContextAccessor _httpContextAccessor;
-
         private ProxyMetrics _previousMetrics;
         private ProxyMetrics _currentMetrics = new();
         private int _eventCountersCount;
 
-        public ProxyEventListenerService(ILogger<ProxyEventListenerService> logger, IServiceProvider serviceProvider, IHttpContextAccessor httpContextAccessor)
-        {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
-            _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
-        }
+        protected override string EventSourceName => "Yarp.ReverseProxy";
 
-        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-
-        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-
-        protected override void OnEventSourceCreated(EventSource eventSource)
-        {
-            if (eventSource.Name == "Yarp.ReverseProxy")
-            {
-                var arguments = new Dictionary<string, string> { { "EventCounterIntervalSec", MetricsOptions.Interval.TotalSeconds.ToString() } };
-                EnableEvents(eventSource, EventLevel.LogAlways, EventKeywords.None, arguments);
-            }
-        }
+        public ProxyEventListenerService(ILogger<ProxyEventListenerService> logger, IEnumerable<IProxyTelemetryConsumer> telemetryConsumers, IEnumerable<IProxyMetricsConsumer> metricsConsumers)
+            : base(logger, telemetryConsumers, metricsConsumers)
+        { }
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
@@ -60,15 +37,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 return;
             }
 
-            var context = _httpContextAccessor?.HttpContext;
-            if (context is null)
-            {
-                return;
-            }
-
-            using var consumers = context.RequestServices.GetServices<IProxyTelemetryConsumer>().GetEnumerator();
-
-            if (!consumers.MoveNext())
+            if (TelemetryConsumers is null)
             {
                 return;
             }
@@ -81,11 +50,10 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                     Debug.Assert(eventData.EventName == "ProxyStart" && payload.Count == 1);
                     {
                         var destinationPrefix = (string)payload[0];
-                        do
+                        foreach (var consumer in TelemetryConsumers)
                         {
-                            consumers.Current.OnProxyStart(eventData.TimeStamp, destinationPrefix);
+                            consumer.OnProxyStart(eventData.TimeStamp, destinationPrefix);
                         }
-                        while (consumers.MoveNext());
                     }
                     break;
 
@@ -93,11 +61,10 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                     Debug.Assert(eventData.EventName == "ProxyStop" && payload.Count == 1);
                     {
                         var statusCode = (int)payload[0];
-                        do
+                        foreach (var consumer in TelemetryConsumers)
                         {
-                            consumers.Current.OnProxyStop(eventData.TimeStamp, statusCode);
+                            consumer.OnProxyStop(eventData.TimeStamp, statusCode);
                         }
-                        while (consumers.MoveNext());
                     }
                     break;
 
@@ -105,11 +72,10 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                     Debug.Assert(eventData.EventName == "ProxyFailed" && payload.Count == 1);
                     {
                         var error = (ProxyError)payload[0];
-                        do
+                        foreach (var consumer in TelemetryConsumers)
                         {
-                            consumers.Current.OnProxyFailed(eventData.TimeStamp, error);
+                            consumer.OnProxyFailed(eventData.TimeStamp, error);
                         }
-                        while (consumers.MoveNext());
                     }
                     break;
 
@@ -117,11 +83,10 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                     Debug.Assert(eventData.EventName == "ProxyStage" && payload.Count == 1);
                     {
                         var proxyStage = (ProxyStage)payload[0];
-                        do
+                        foreach (var consumer in TelemetryConsumers)
                         {
-                            consumers.Current.OnProxyStage(eventData.TimeStamp, proxyStage);
+                            consumer.OnProxyStage(eventData.TimeStamp, proxyStage);
                         }
-                        while (consumers.MoveNext());
                     }
                     break;
 
@@ -133,11 +98,10 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                         var iops = (long)payload[2];
                         var readTime = new TimeSpan((long)payload[3]);
                         var writeTime = new TimeSpan((long)payload[4]);
-                        do
+                        foreach (var consumer in TelemetryConsumers)
                         {
-                            consumers.Current.OnContentTransferring(eventData.TimeStamp, isRequest, contentLength, iops, readTime, writeTime);
+                            consumer.OnContentTransferring(eventData.TimeStamp, isRequest, contentLength, iops, readTime, writeTime);
                         }
-                        while (consumers.MoveNext());
                     }
                     break;
 
@@ -150,11 +114,10 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                         var readTime = new TimeSpan((long)payload[3]);
                         var writeTime = new TimeSpan((long)payload[4]);
                         var firstReadTime = new TimeSpan((long)payload[5]);
-                        do
+                        foreach (var consumer in TelemetryConsumers)
                         {
-                            consumers.Current.OnContentTransferred(eventData.TimeStamp, isRequest, contentLength, iops, readTime, writeTime, firstReadTime);
+                            consumer.OnContentTransferred(eventData.TimeStamp, isRequest, contentLength, iops, readTime, writeTime, firstReadTime);
                         }
-                        while (consumers.MoveNext());
                     }
                     break;
 
@@ -164,11 +127,10 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                         var clusterId = (string)payload[0];
                         var routeId = (string)payload[1];
                         var destinationId = (string)payload[2];
-                        do
+                        foreach (var consumer in TelemetryConsumers)
                         {
-                            consumers.Current.OnProxyInvoke(eventData.TimeStamp, clusterId, routeId, destinationId);
+                            consumer.OnProxyInvoke(eventData.TimeStamp, clusterId, routeId, destinationId);
                         }
-                        while (consumers.MoveNext());
                     }
                     break;
             }
@@ -176,6 +138,11 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
 
         private void OnEventCounters(EventWrittenEventArgs eventData)
         {
+            if (MetricsConsumers is null)
+            {
+                return;
+            }
+
             Debug.Assert(eventData.EventName == "EventCounters" && eventData.Payload.Count == 1);
             var counters = (IDictionary<string, object>)eventData.Payload[0];
 
@@ -221,14 +188,14 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 _previousMetrics = metrics;
                 _currentMetrics = new ProxyMetrics();
 
-                if (previous is null || _serviceProvider is null)
+                if (previous is null)
                 {
                     return;
                 }
 
                 try
                 {
-                    foreach (var consumer in _serviceProvider.GetServices<IProxyMetricsConsumer>())
+                    foreach (var consumer in MetricsConsumers)
                     {
                         consumer.OnProxyMetrics(previous, metrics);
                     }
@@ -236,7 +203,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 catch (Exception ex)
                 {
                     // We can't let an uncaught exception propagate as that would crash the process
-                    _logger.LogError(ex, $"Uncaught exception occured while processing {nameof(ProxyMetrics)}.");
+                    Logger.LogError(ex, $"Uncaught exception occured while processing {nameof(ProxyMetrics)}.");
                 }
             }
         }

--- a/src/ReverseProxy.TelemetryConsumption/Sockets/ISocketsTelemetryConsumer.cs
+++ b/src/ReverseProxy.TelemetryConsumption/Sockets/ISocketsTelemetryConsumer.cs
@@ -16,13 +16,13 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
         /// </summary>
         /// <param name="timestamp">Timestamp when the event was fired.</param>
         /// <param name="address">Socket address we are connecting to.</param>
-        void OnConnectStart(DateTime timestamp, string address);
+        void OnConnectStart(DateTime timestamp, string address) { }
 
         /// <summary>
         /// Called after a Socket connect.
         /// </summary>
         /// <param name="timestamp">Timestamp when the event was fired.</param>
-        void OnConnectStop(DateTime timestamp);
+        void OnConnectStop(DateTime timestamp) { }
 
         /// <summary>
         /// Called before <see cref="OnConnectStop(DateTime)"/> if the connect failed.
@@ -30,6 +30,6 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
         /// <param name="timestamp">Timestamp when the event was fired.</param>
         /// <param name="error"><see cref="SocketError"/> information for the connect failure.</param>
         /// <param name="exceptionMessage">Exception information for the connect failure.</param>
-        void OnConnectFailed(DateTime timestamp, SocketError error, string exceptionMessage);
+        void OnConnectFailed(DateTime timestamp, SocketError error, string exceptionMessage) { }
     }
 }

--- a/src/ReverseProxy.TelemetryConsumption/TelemetryConsumptionExtensions.cs
+++ b/src/ReverseProxy.TelemetryConsumption/TelemetryConsumptionExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Yarp.ReverseProxy.Telemetry.Consumption;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -9,92 +11,137 @@ namespace Microsoft.Extensions.DependencyInjection
     {
 #if NET5_0
         /// <summary>
-        /// Shortcut for registering all (Proxy, Kestrel, Http, NameResolution, NetSecurity and Sockets) telemetry listeners.
+        /// Registers all telemetry listeners (Proxy, Kestrel, Http, NameResolution, NetSecurity and Sockets).
         /// </summary>
 #else
         /// <summary>
-        /// Shortcut for registering all (Proxy and Kestrel) telemetry listeners.
+        /// Registers all telemetry listeners (Proxy and Kestrel).
         /// </summary>
 #endif
         public static IServiceCollection AddTelemetryListeners(this IServiceCollection services)
         {
-            services.AddProxyTelemetryListener();
-            services.AddKestrelTelemetryListener();
+            services.AddHostedService(provider => ProxyEventListenerService.Create<ProxyEventListenerService>(provider));
+            services.AddHostedService(provider => KestrelEventListenerService.Create<KestrelEventListenerService>(provider));
 #if NET5_0
-            services.AddHttpTelemetryListener();
-            services.AddNameResolutionTelemetryListener();
-            services.AddNetSecurityTelemetryListener();
-            services.AddSocketsTelemetryListener();
+            services.AddHostedService(provider => HttpEventListenerService.Create<HttpEventListenerService>(provider));
+            services.AddHostedService(provider => NameResolutionEventListenerService.Create<NameResolutionEventListenerService>(provider));
+            services.AddHostedService(provider => NetSecurityEventListenerService.Create<NetSecurityEventListenerService>(provider));
+            services.AddHostedService(provider => SocketsEventListenerService.Create<SocketsEventListenerService>(provider));
 #endif
             return services;
         }
 
         /// <summary>
-        /// Registers a service responsible for calling <see cref="IProxyTelemetryConsumer"/>s and <see cref="IProxyMetricsConsumer"/>s.
+        /// Registers a consumer singleton for every I*TelemetryConsumer interface it implements.
         /// </summary>
-        public static IServiceCollection AddProxyTelemetryListener(this IServiceCollection services)
+        public static IServiceCollection AddTelemetryConsumer(this IServiceCollection services, object consumer)
         {
-            services.AddHttpContextAccessor();
-            services.AddHostedService<ProxyEventListenerService>();
-            return services;
-        }
+            var implementsAny = false;
+
+            if (consumer is IProxyTelemetryConsumer)
+            {
+                services.TryAddEnumerable(new ServiceDescriptor(typeof(IProxyTelemetryConsumer), consumer));
+                implementsAny = true;
+            }
+
+            if (consumer is IKestrelTelemetryConsumer)
+            {
+                services.TryAddEnumerable(new ServiceDescriptor(typeof(IKestrelTelemetryConsumer), consumer));
+                implementsAny = true;
+            }
 
 #if NET5_0
-        /// <summary>
-        /// Registers a service responsible for calling <see cref="IKestrelTelemetryConsumer"/>s and <see cref="IKestrelMetricsConsumer"/>s.
-        /// </summary>
-#else
-        /// <summary>
-        /// Registers a service responsible for calling <see cref="IKestrelTelemetryConsumer"/>s
-        /// </summary>
+            if (consumer is IHttpTelemetryConsumer)
+            {
+                services.TryAddEnumerable(new ServiceDescriptor(typeof(IHttpTelemetryConsumer), consumer));
+                implementsAny = true;
+            }
+
+            if (consumer is INameResolutionTelemetryConsumer)
+            {
+                services.TryAddEnumerable(new ServiceDescriptor(typeof(INameResolutionTelemetryConsumer), consumer));
+                implementsAny = true;
+            }
+
+            if (consumer is INetSecurityTelemetryConsumer)
+            {
+                services.TryAddEnumerable(new ServiceDescriptor(typeof(INetSecurityTelemetryConsumer), consumer));
+                implementsAny = true;
+            }
+
+            if (consumer is ISocketsTelemetryConsumer)
+            {
+                services.TryAddEnumerable(new ServiceDescriptor(typeof(ISocketsTelemetryConsumer), consumer));
+                implementsAny = true;
+            }
 #endif
-        public static IServiceCollection AddKestrelTelemetryListener(this IServiceCollection services)
-        {
-            services.AddHttpContextAccessor();
-            services.AddHostedService<KestrelEventListenerService>();
+
+            if (!implementsAny)
+            {
+                throw new ArgumentException("The consumer must implement at least one I*TelemetryConsumer interface.", nameof(consumer));
+            }
+
+            services.AddTelemetryListeners();
+
             return services;
         }
+
+        /// <summary>
+        /// Registers a <typeparamref name="TConsumer"/> singleton for every I*TelemetryConsumer interface it implements.
+        /// </summary>
+        public static IServiceCollection AddTelemetryConsumer<TConsumer>(this IServiceCollection services)
+            where TConsumer : class
+        {
+            var implementsAny = false;
+
+            if (typeof(IProxyTelemetryConsumer).IsAssignableFrom(typeof(TConsumer)))
+            {
+                services.TryAddEnumerable(new ServiceDescriptor(typeof(IProxyTelemetryConsumer), provider => provider.GetRequiredService<TConsumer>(), ServiceLifetime.Singleton));
+                implementsAny = true;
+            }
+
+            if (typeof(IKestrelTelemetryConsumer).IsAssignableFrom(typeof(TConsumer)))
+            {
+                services.TryAddEnumerable(new ServiceDescriptor(typeof(IKestrelTelemetryConsumer), provider => provider.GetRequiredService<TConsumer>(), ServiceLifetime.Singleton));
+                implementsAny = true;
+            }
 
 #if NET5_0
-        /// <summary>
-        /// Registers a service responsible for calling <see cref="IHttpTelemetryConsumer"/>s and <see cref="IHttpMetricsConsumer"/>s.
-        /// </summary>
-        public static IServiceCollection AddHttpTelemetryListener(this IServiceCollection services)
-        {
-            services.AddHttpContextAccessor();
-            services.AddHostedService<HttpEventListenerService>();
-            return services;
-        }
+            if (typeof(IHttpTelemetryConsumer).IsAssignableFrom(typeof(TConsumer)))
+            {
+                services.TryAddEnumerable(new ServiceDescriptor(typeof(IHttpTelemetryConsumer), provider => provider.GetRequiredService<TConsumer>(), ServiceLifetime.Singleton));
+                implementsAny = true;
+            }
 
-        /// <summary>
-        /// Registers a service responsible for calling <see cref="INameResolutionTelemetryConsumer"/>s and <see cref="INameResolutionMetricsConsumer"/>s.
-        /// </summary>
-        public static IServiceCollection AddNameResolutionTelemetryListener(this IServiceCollection services)
-        {
-            services.AddHttpContextAccessor();
-            services.AddHostedService<NameResolutionEventListenerService>();
-            return services;
-        }
+            if (typeof(INameResolutionTelemetryConsumer).IsAssignableFrom(typeof(TConsumer)))
+            {
+                services.TryAddEnumerable(new ServiceDescriptor(typeof(INameResolutionTelemetryConsumer), provider => provider.GetRequiredService<TConsumer>(), ServiceLifetime.Singleton));
+                implementsAny = true;
+            }
 
-        /// <summary>
-        /// Registers a service responsible for calling <see cref="INetSecurityTelemetryConsumer"/>s and <see cref="INetSecurityMetricsConsumer"/>s.
-        /// </summary>
-        public static IServiceCollection AddNetSecurityTelemetryListener(this IServiceCollection services)
-        {
-            services.AddHttpContextAccessor();
-            services.AddHostedService<NetSecurityEventListenerService>();
-            return services;
-        }
+            if (typeof(INetSecurityTelemetryConsumer).IsAssignableFrom(typeof(TConsumer)))
+            {
+                services.TryAddEnumerable(new ServiceDescriptor(typeof(INetSecurityTelemetryConsumer), provider => provider.GetRequiredService<TConsumer>(), ServiceLifetime.Singleton));
+                implementsAny = true;
+            }
 
-        /// <summary>
-        /// Registers a service responsible for calling <see cref="ISocketsTelemetryConsumer"/>s and <see cref="ISocketsMetricsConsumer"/>s.
-        /// </summary>
-        public static IServiceCollection AddSocketsTelemetryListener(this IServiceCollection services)
-        {
-            services.AddHttpContextAccessor();
-            services.AddHostedService<SocketsEventListenerService>();
-            return services;
-        }
+            if (typeof(ISocketsTelemetryConsumer).IsAssignableFrom(typeof(TConsumer)))
+            {
+                services.TryAddEnumerable(new ServiceDescriptor(typeof(ISocketsTelemetryConsumer), provider => provider.GetRequiredService<TConsumer>(), ServiceLifetime.Singleton));
+                implementsAny = true;
+            }
 #endif
+
+            if (!implementsAny)
+            {
+                throw new ArgumentException("TConsumer must implement at least one I*TelemetryConsumer interface.", nameof(TConsumer));
+            }
+
+            services.TryAddSingleton<TConsumer>();
+
+            services.AddTelemetryListeners();
+
+            return services;
+        }
     }
 }

--- a/src/ReverseProxy.TelemetryConsumption/TelemetryConsumptionExtensions.cs
+++ b/src/ReverseProxy.TelemetryConsumption/TelemetryConsumptionExtensions.cs
@@ -20,13 +20,13 @@ namespace Microsoft.Extensions.DependencyInjection
 #endif
         public static IServiceCollection AddTelemetryListeners(this IServiceCollection services)
         {
-            services.AddHostedService(provider => ProxyEventListenerService.Create<ProxyEventListenerService>(provider));
-            services.AddHostedService(provider => KestrelEventListenerService.Create<KestrelEventListenerService>(provider));
+            services.AddHostedService<ProxyEventListenerService>();
+            services.AddHostedService<KestrelEventListenerService>();
 #if NET5_0
-            services.AddHostedService(provider => HttpEventListenerService.Create<HttpEventListenerService>(provider));
-            services.AddHostedService(provider => NameResolutionEventListenerService.Create<NameResolutionEventListenerService>(provider));
-            services.AddHostedService(provider => NetSecurityEventListenerService.Create<NetSecurityEventListenerService>(provider));
-            services.AddHostedService(provider => SocketsEventListenerService.Create<SocketsEventListenerService>(provider));
+            services.AddHostedService<HttpEventListenerService>();
+            services.AddHostedService<NameResolutionEventListenerService>();
+            services.AddHostedService<NetSecurityEventListenerService>();
+            services.AddHostedService<SocketsEventListenerService>();
 #endif
             return services;
         }

--- a/testassets/ReverseProxy.Code/Startup.cs
+++ b/testassets/ReverseProxy.Code/Startup.cs
@@ -94,7 +94,7 @@ namespace Yarp.ReverseProxy.Sample
             services.AddHttpContextAccessor();
             services.AddSingleton<IProxyMetricsConsumer, ProxyMetricsConsumer>();
             services.AddScoped<IProxyTelemetryConsumer, ProxyTelemetryConsumer>();
-            services.AddProxyTelemetryListener();
+            services.AddTelemetryListeners();
         }
 
         /// <summary>


### PR DESCRIPTION
Replacement for #915, description is NOT the same

Removed the `AddProxyTelemetryListener`, `AddHttpTelemetryListener`, ... extension methods as they don't provide any benefit over just `AddTelemetryListeners` after this change.

The listeners no longer fetch consumers per request (`GetServices`) - instead they get the consumers injected in the constructor. This means the core listeners only respect singleton consumers.

If needed, we can expose wrappers/helpers that add scoped consumer lifetimes.

Added an abstract `EventListenerService` class as a base of all listeners.
It abstracts away the synchronization around enabling the EventSource based on parameters from the constructor.

The listener implementations now only enable the necessary `EventSource`s with the needed parameters. We will only enable events if a telemetry consumer is present & only enable event counters if a metrics consumer is present. Previously we would always enable events & metrics, even if only metrics were being used.

`EventSource` & `EventSourceListener` have a weird interaction where the `OnEventSourceCreated` may be called from the base constructor. That means parameters passed to the listener constructor can't control what happens in `OnEventSourceCreated`.
To work around that, the `EventSourceName` is taken from a property implemented by derived types instead of being a ctor argument.
Since only the ctor can decide on whether we need events/metrics, we delay calling `EnableEvents` until the ctor runs and inspects the service collection.
We avoid returning from `OnEventSourceCreated` before enabling the `EventSource` so that the first event isn't dropped.

A side-effect of the change to use singleton consumers is that this library now works with non-proxy scenarios out-of-the-box. For example, a user can register an `IHttpProxyTelemetryConsumer` and they will observe all Http events from HttpClients even outside the AspNetCore pipeline (as we are no longer bound by the HttpContext scope).

I added default interface implementations for all `I*TelemetryConsumer` methods. This makes it much easier to implement consumers that don't care about ALL the events - a user only overrides events they are interested in.


Metrics sample will be updated later as it targets a NuGet package.