### PR TITLE
React to Telemetry Consumption API change and add tests

### DIFF
--- a/samples/ReverseProxy.Metrics.Sample/Startup.cs
+++ b/samples/ReverseProxy.Metrics.Sample/Startup.cs
@@ -38,14 +38,12 @@ namespace Yarp.Sample
             // Interface that collects general metrics about the proxy
             services.AddSingleton<IProxyMetricsConsumer, ProxyMetricsConsumer>();
 
-            // Registration of a listener to events for proxy telemetry 
-            services.AddSingleton<IProxyTelemetryConsumer, ProxyTelemetryConsumer>();
-            services.AddProxyTelemetryListener();
+            // Registration of a consumer to events for proxy telemetry
+            services.AddTelemetryConsumer<ProxyTelemetryConsumer>();
 
-            // Registration of a listener to events for HttpClient telemetry
-            // Note: this depends on changes implemented in .NET 5 
-            services.AddSingleton<IHttpTelemetryConsumer, HttpClientTelemetryConsumer>();
-            services.AddHttpTelemetryListener();
+            // Registration of a consumer to events for HttpClient telemetry
+            // Note: this depends on changes implemented in .NET 5
+            services.AddTelemetryConsumer<HttpClientTelemetryConsumer>();
         }
 
         /// <summary>

--- a/src/ReverseProxy.TelemetryConsumption/TelemetryConsumptionExtensions.cs
+++ b/src/ReverseProxy.TelemetryConsumption/TelemetryConsumptionExtensions.cs
@@ -96,38 +96,38 @@ namespace Microsoft.Extensions.DependencyInjection
 
             if (typeof(IProxyTelemetryConsumer).IsAssignableFrom(typeof(TConsumer)))
             {
-                services.TryAddEnumerable(new ServiceDescriptor(typeof(IProxyTelemetryConsumer), provider => provider.GetRequiredService<TConsumer>(), ServiceLifetime.Singleton));
+                services.AddSingleton(services => (IProxyTelemetryConsumer)services.GetRequiredService<TConsumer>());
                 implementsAny = true;
             }
 
             if (typeof(IKestrelTelemetryConsumer).IsAssignableFrom(typeof(TConsumer)))
             {
-                services.TryAddEnumerable(new ServiceDescriptor(typeof(IKestrelTelemetryConsumer), provider => provider.GetRequiredService<TConsumer>(), ServiceLifetime.Singleton));
+                services.AddSingleton(services => (IKestrelTelemetryConsumer)services.GetRequiredService<TConsumer>());
                 implementsAny = true;
             }
 
 #if NET5_0
             if (typeof(IHttpTelemetryConsumer).IsAssignableFrom(typeof(TConsumer)))
             {
-                services.TryAddEnumerable(new ServiceDescriptor(typeof(IHttpTelemetryConsumer), provider => provider.GetRequiredService<TConsumer>(), ServiceLifetime.Singleton));
+                services.AddSingleton(services => (IHttpTelemetryConsumer)services.GetRequiredService<TConsumer>());
                 implementsAny = true;
             }
 
             if (typeof(INameResolutionTelemetryConsumer).IsAssignableFrom(typeof(TConsumer)))
             {
-                services.TryAddEnumerable(new ServiceDescriptor(typeof(INameResolutionTelemetryConsumer), provider => provider.GetRequiredService<TConsumer>(), ServiceLifetime.Singleton));
+                services.AddSingleton(services => (INameResolutionTelemetryConsumer)services.GetRequiredService<TConsumer>());
                 implementsAny = true;
             }
 
             if (typeof(INetSecurityTelemetryConsumer).IsAssignableFrom(typeof(TConsumer)))
             {
-                services.TryAddEnumerable(new ServiceDescriptor(typeof(INetSecurityTelemetryConsumer), provider => provider.GetRequiredService<TConsumer>(), ServiceLifetime.Singleton));
+                services.AddSingleton(services => (INetSecurityTelemetryConsumer)services.GetRequiredService<TConsumer>());
                 implementsAny = true;
             }
 
             if (typeof(ISocketsTelemetryConsumer).IsAssignableFrom(typeof(TConsumer)))
             {
-                services.TryAddEnumerable(new ServiceDescriptor(typeof(ISocketsTelemetryConsumer), provider => provider.GetRequiredService<TConsumer>(), ServiceLifetime.Singleton));
+                services.AddSingleton(services => (ISocketsTelemetryConsumer)services.GetRequiredService<TConsumer>());
                 implementsAny = true;
             }
 #endif


### PR DESCRIPTION
Now that the build of #931 produced updated packages, react to the removal of `Add*TelemetryListener`.

Also adding tests for the helper APIs added in #928.