### PR TITLE
conditional refs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,4 +17,8 @@
   <PropertyGroup>
     <MoqPublicKey>0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7</MoqPublicKey>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <SamplesReferenceProject>true</SamplesReferenceProject>
+  </PropertyGroup>
 </Project>

--- a/samples/BasicYarpSample/BasicYarpSample.csproj
+++ b/samples/BasicYarpSample/BasicYarpSample.csproj
@@ -4,8 +4,12 @@
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(SamplesReferenceProject)'!= 'true'">
     <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.11.21222.6" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(SamplesReferenceProject)'== 'true'">
+    <ProjectReference Include="..\..\src\ReverseProxy\Yarp.ReverseProxy.csproj" />
+</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Conditional references that use nuget or local reference depending on where they are built. If you move the sample out from the enlistment it uses nuget.

This would fix part of #935 