### PR TITLE
Merge preview11 changes into main

### DIFF
--- a/.github/workflows/docfx_build.yml
+++ b/.github/workflows/docfx_build.yml
@@ -2,7 +2,7 @@ name: DocFX Build
 on:
   push:
     branches:
-      - release/docs
+      - release/latest
 jobs:
   build:
     name: Build
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: source
-          ref: release/docs
+          ref: release/latest
       # Run a build
       - name: Build docs
         run: "& ./eng/common/build.ps1 -restore -build -projects ./docs/docfx/docfx.csproj"

--- a/docs/docfx/articles/direct-proxying.md
+++ b/docs/docfx/articles/direct-proxying.md
@@ -28,7 +28,7 @@ It does not include:
 
 ## Example
 
-See [ReverseProxy.Direct.Sample](https://github.com/microsoft/reverse-proxy/tree/release/docs/samples/ReverseProxy.Direct.Sample) as a pre-built sample, or use the steps below.
+See [ReverseProxy.Direct.Sample](https://github.com/microsoft/reverse-proxy/tree/release/latest/samples/ReverseProxy.Direct.Sample) as a pre-built sample, or use the steps below.
 
 ### Create a new project
 

--- a/docs/docfx/articles/getting_started.md
+++ b/docs/docfx/articles/getting_started.md
@@ -9,7 +9,7 @@ YARP is designed as a library that provides the core proxy functionality which y
 
 YARP is implemented on top of .NET Core infrastructure and is usable on Windows, Linux or MacOS. Development can be done with the SDK and your favorite editor, [Microsoft Visual Studio](https://visualstudio.microsoft.com/vs/) or [Visual Studio Code](https://code.visualstudio.com/).
 
-YARP 1.0.0 Preview 10 supports ASP.NET Core 3.1 and 5.0. You can download the .NET 5 SDK from https://dotnet.microsoft.com/download/dotnet/5.0.
+YARP 1.0.0 Preview 11 supports ASP.NET Core 3.1 and 5.0. You can download the .NET 5 SDK from https://dotnet.microsoft.com/download/dotnet/5.0.
 Visual Studio support for .NET 5 is included in Visual Studio 2019 v16.8 or newer.
 
 A fully commented variant of the getting started app can be found at [Basic YARP Sample](https://github.com/microsoft/reverse-proxy/tree/main/samples/BasicYarpSample)
@@ -40,7 +40,7 @@ And then add:
  
  ```XML
 <ItemGroup> 
-  <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.10.*" />
+  <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.11.*" />
 </ItemGroup> 
 ```
 

--- a/docs/docfx/readme.md
+++ b/docs/docfx/readme.md
@@ -16,4 +16,4 @@ The docs are automatically built and published by a [GitHub Action](https://gith
 
 Doc edits for the current public release should go into that release's branch (e.g. `release/1.0.0-preview3`) and merged forward into `main` and `release/docs`.
 
-When publishing a new product version (e.g. `release/1.0.0-preview4`) `release/docs` should be reset to that position after the docs have been updated.
+When publishing a new product version (e.g. `release/1.0.0-preview4`) `release/latest` should be reset to that position after the docs have been updated.

--- a/docs/operations/Release.md
+++ b/docs/operations/Release.md
@@ -89,7 +89,7 @@ Some samples may include the package version as part of the references in the pr
 
 ## Publish the docs
 
-Reset the `release/docs` branch to the head of the current preview branch to publish the latest docs. See [docs](../docfx/readme.md).
+Reset the `release/latest` branch to the head of the current preview branch to publish the latest docs. See [docs](../docfx/readme.md).
 
 ## Publish the release notes
 

--- a/samples/BasicYarpSample/BasicYarpSample.csproj
+++ b/samples/BasicYarpSample/BasicYarpSample.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/BasicYarpSample/BasicYarpSample.csproj
+++ b/samples/BasicYarpSample/BasicYarpSample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.11.21222.6" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.11.21223.5" />
   </ItemGroup>
 
 </Project>

--- a/samples/BasicYarpSample/appsettings.json
+++ b/samples/BasicYarpSample/appsettings.json
@@ -34,7 +34,7 @@
     },
     // Clusters tell the proxy where and how to forward requests
     "Clusters": {
-      "example": {
+      "minimumcluster": {
         "Destinations": {
           "example.com": {
             "Address": "http://www.example.com/"

--- a/samples/Prometheus/ReverseProxy.Metrics-Promethius.Sample/ReverseProxy.Metrics.Promethius.Sample.csproj
+++ b/samples/Prometheus/ReverseProxy.Metrics-Promethius.Sample/ReverseProxy.Metrics.Promethius.Sample.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net5.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.Sample</RootNamespace>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Prometheus/ReverseProxy.Metrics-Promethius.Sample/ReverseProxy.Metrics.Promethius.Sample.csproj
+++ b/samples/Prometheus/ReverseProxy.Metrics-Promethius.Sample/ReverseProxy.Metrics.Promethius.Sample.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="prometheus-net" Version="4.1.1" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="4.1.1" />
-    <PackageReference Include="Yarp.ReverseProxy.Telemetry.Consumption" Version="1.0.0-preview.11.21222.6*" />
+    <PackageReference Include="Yarp.ReverseProxy.Telemetry.Consumption" Version="1.0.0-preview.11.21223.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.Auth.Sample/ReverseProxy.Auth.Sample.csproj
+++ b/samples/ReverseProxy.Auth.Sample/ReverseProxy.Auth.Sample.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.11.21222.6" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.11.21223.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.Auth.Sample/ReverseProxy.Auth.Sample.csproj
+++ b/samples/ReverseProxy.Auth.Sample/ReverseProxy.Auth.Sample.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.Sample</RootNamespace>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.Code.Sample/ReverseProxy.Code.Sample.csproj
+++ b/samples/ReverseProxy.Code.Sample/ReverseProxy.Code.Sample.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.11.21222.6" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.11.21223.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.Code.Sample/ReverseProxy.Code.Sample.csproj
+++ b/samples/ReverseProxy.Code.Sample/ReverseProxy.Code.Sample.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.Sample</RootNamespace>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.Config.Sample/ReverseProxy.Config.Sample.csproj
+++ b/samples/ReverseProxy.Config.Sample/ReverseProxy.Config.Sample.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.11.21222.6" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.11.21223.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.Config.Sample/ReverseProxy.Config.Sample.csproj
+++ b/samples/ReverseProxy.Config.Sample/ReverseProxy.Config.Sample.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.Sample</RootNamespace>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.ConfigFilter.Sample/ReverseProxy.ConfigFilter.Sample.csproj
+++ b/samples/ReverseProxy.ConfigFilter.Sample/ReverseProxy.ConfigFilter.Sample.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.11.21222.6" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.11.21223.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.ConfigFilter.Sample/ReverseProxy.ConfigFilter.Sample.csproj
+++ b/samples/ReverseProxy.ConfigFilter.Sample/ReverseProxy.ConfigFilter.Sample.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.Sample</RootNamespace>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.Direct.Sample/ReverseProxy.Direct.Sample.csproj
+++ b/samples/ReverseProxy.Direct.Sample/ReverseProxy.Direct.Sample.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.11.21222.6" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.11.21223.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.Direct.Sample/ReverseProxy.Direct.Sample.csproj
+++ b/samples/ReverseProxy.Direct.Sample/ReverseProxy.Direct.Sample.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.Sample</RootNamespace>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.Metrics.Sample/ReverseProxy.Metrics.Sample.csproj
+++ b/samples/ReverseProxy.Metrics.Sample/ReverseProxy.Metrics.Sample.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFrameworks>net5.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.Sample</RootNamespace>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.Metrics.Sample/ReverseProxy.Metrics.Sample.csproj
+++ b/samples/ReverseProxy.Metrics.Sample/ReverseProxy.Metrics.Sample.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Yarp.ReverseProxy.Telemetry.Consumption" Version="1.0.0-preview.11.21222.6*" />
+    <PackageReference Include="Yarp.ReverseProxy.Telemetry.Consumption" Version="1.0.0-preview.11.21223.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.ServiceFabric.Sample/ReverseProxy.ServiceFabric.Sample.csproj
+++ b/samples/ReverseProxy.ServiceFabric.Sample/ReverseProxy.ServiceFabric.Sample.csproj
@@ -1,10 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.Sample</RootNamespace>
     <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.ServiceFabric.Sample/ReverseProxy.ServiceFabric.Sample.csproj
+++ b/samples/ReverseProxy.ServiceFabric.Sample/ReverseProxy.ServiceFabric.Sample.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Yarp.ReverseProxy.ServiceFabric" Version="1.0.0-preview.11.21222.6" />
+    <PackageReference Include="Yarp.ReverseProxy.ServiceFabric" Version="1.0.0-preview.11.21223.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.Transforms.Sample/ReverseProxy.Transforms.Sample.csproj
+++ b/samples/ReverseProxy.Transforms.Sample/ReverseProxy.Transforms.Sample.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.11.21222.6" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.11.21223.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.Transforms.Sample/ReverseProxy.Transforms.Sample.csproj
+++ b/samples/ReverseProxy.Transforms.Sample/ReverseProxy.Transforms.Sample.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.Sample</RootNamespace>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#940

Brings over the rename from `release/docs` to `release/latest`.

Added `LangVersion` to samples to allow building them standalone (without our `Directory.Build.props` definitions).

Fixed a config issue for `BasicYarpSample` that would cause it to crash at startup.

Updated Samples' nuget package versions to the actual publicly released version.