### PR TITLE
Reduce counter contention

### DIFF
--- a/src/ReverseProxy/Service/HealthChecks/ConsecutiveFailuresHealthPolicy.cs
+++ b/src/ReverseProxy/Service/HealthChecks/ConsecutiveFailuresHealthPolicy.cs
@@ -68,7 +68,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             else
             {
                 // Failure
-                var currentFailureCount = count.Increment();
+                var currentFailureCount = count.IncrementAndGetValue();
                 newHealth = currentFailureCount < threshold ? DestinationHealth.Healthy : DestinationHealth.Unhealthy;
             }
 

--- a/src/ReverseProxy/Service/LoadBalancing/RoundRobinLoadBalancingPolicy.cs
+++ b/src/ReverseProxy/Service/LoadBalancing/RoundRobinLoadBalancingPolicy.cs
@@ -27,12 +27,12 @@ namespace Yarp.ReverseProxy.Service.LoadBalancing
             var counter = _counters.GetOrCreateValue(context.GetClusterInfo());
 
             // Increment returns the new value and we want the first return value to be 0.
-            var offset = counter.Increment() - 1;
+            var offset = counter.IncrementAndGetValue() - 1;
 
             // Preventing negative indicies from being computed by masking off sign.
             // Ordering of index selection is consistent across all offsets.
             // There may be a discontinuity when the sign of offset changes.
-            return availableDestinations[(offset & 0x7FFFFFFF) % availableDestinations.Count];
+            return availableDestinations[((int)(uint)offset & 0x7FFFFFFF) % availableDestinations.Count];
         }
     }
 }

--- a/src/ReverseProxy/Service/RuntimeModel/DestinationInfo.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/DestinationInfo.cs
@@ -51,7 +51,7 @@ namespace Yarp.ReverseProxy.RuntimeModel
         /// Keeps track of the total number of concurrent requests on this endpoint.
         /// The setter should only be used for testing purposes.
         /// </summary>
-        public int ConcurrentRequestCount
+        public long ConcurrentRequestCount
         {
             get => ConcurrencyCounter.Value;
             set => ConcurrencyCounter.Value = value;


### PR DESCRIPTION
Use a `ThreadLocal<long>` rather than operating with `Interlocked` on a single shared value; this will reduce cross core contention.

The downside is reading the value is allocating (as need to enumerate all the individual `ThreadLocal<long>` values)