### PR TITLE
Make ITransformBuilder available for IHttpProxy 

### DIFF
--- a/src/ReverseProxy/Configuration/DependencyInjection/BuilderExtensions/IReverseProxyBuilderExtensions.cs
+++ b/src/ReverseProxy/Configuration/DependencyInjection/BuilderExtensions/IReverseProxyBuilderExtensions.cs
@@ -23,7 +23,6 @@ namespace Yarp.ReverseProxy.Configuration.DependencyInjection
         public static IReverseProxyBuilder AddConfigBuilder(this IReverseProxyBuilder builder)
         {
             builder.Services.TryAddSingleton<IConfigValidator, ConfigValidator>();
-            builder.Services.TryAddSingleton<ITransformBuilder, TransformBuilder>();
             builder.Services.TryAddSingleton<IRandomFactory, RandomFactory>();
             builder.AddTransformFactory<ForwardedTransformFactory>();
             builder.AddTransformFactory<HttpMethodTransformFactory>();

--- a/src/ReverseProxy/Configuration/DependencyInjection/ReverseProxyServiceCollectionExtensions.cs
+++ b/src/ReverseProxy/Configuration/DependencyInjection/ReverseProxyServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             services.TryAddSingleton<IClock, Clock>();
             services.TryAddSingleton<IHttpProxy, HttpProxy>();
+            services.TryAddSingleton<ITransformBuilder, TransformBuilder>();
             return services;
         }
 


### PR DESCRIPTION
Fixes #949 
ITransformBuilder recently added the Create API for use with IHttpProxy, but ITransformBuilder isn't actually registered in DI by AddHttpProxy. This moves the registration down a layer.

cc: @leastprivilege