### PR TITLE
Fix SDL config and update CredScan suppression

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -4,7 +4,7 @@
         {
             "_justification": "Legitimate key/cert used for testing",
             "file": [
-                "samples/BenchmarkApp/testCert.pfx",
+                "testassets/BenchmarkApp/testCert.pfx",
                 "test/TestCertificates/testCert.pfx",
                 "test/TestCertificates/aspnetdevcert.pfx",
                 "test/TestCertificates/https-aspnet.key",

--- a/eng/PoliCheckExclusions.xml
+++ b/eng/PoliCheckExclusions.xml
@@ -1,0 +1,2 @@
+<PoliCheckExclusions>
+</PoliCheckExclusions>


### PR DESCRIPTION
We don't have a `PoliCheckExclusions` file in this repo. Fixing that config uncovers the issue that the benchmark app key has moved since we added the CredScan suppression for it.