### PR TITLE
Route API renames

### DIFF
--- a/src/ReverseProxy.Kubernetes.Controller/Converters/YarpIngressContext.cs
+++ b/src/ReverseProxy.Kubernetes.Controller/Converters/YarpIngressContext.cs
@@ -17,7 +17,7 @@ namespace Yarp.ReverseProxy.Kubernetes.Controller.Services
 
         public YarpIngressOptions Options { get; set; } = new YarpIngressOptions();
         public Dictionary<string, ClusterTrasfer> ClusterTransfers { get; set; } = new Dictionary<string, ClusterTrasfer>();
-        public List<ProxyRoute> Routes { get; set; } = new List<ProxyRoute>();
+        public List<RouteConfig> Routes { get; set; } = new List<RouteConfig>();
         public List<Cluster> Clusters { get; set; } = new List<Cluster>();
         public IngressData Ingress { get; }
         public List<Endpoints> Endpoints { get; }

--- a/src/ReverseProxy.Kubernetes.Controller/Converters/YarpParser.cs
+++ b/src/ReverseProxy.Kubernetes.Controller/Converters/YarpParser.cs
@@ -102,7 +102,7 @@ namespace Yarp.ReverseProxy.Kubernetes.Controller.Converters
                         var pathMatch = FixupPathMatch(path);
                         var host = rule.Host;
 
-                        routes.Add(new ProxyRoute()
+                        routes.Add(new RouteConfig()
                         {
                             Match = new RouteMatch()
                             {

--- a/src/ReverseProxy.Kubernetes.Protocol/IUpdateConfig.cs
+++ b/src/ReverseProxy.Kubernetes.Protocol/IUpdateConfig.cs
@@ -8,6 +8,6 @@ namespace Yarp.ReverseProxy.Kubernetes.Protocol
 {
     public interface IUpdateConfig
     {
-        void Update(IReadOnlyList<ProxyRoute> routes, IReadOnlyList<Cluster> clusters);
+        void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters);
     }
 }

--- a/src/ReverseProxy.Kubernetes.Protocol/Message.cs
+++ b/src/ReverseProxy.Kubernetes.Protocol/Message.cs
@@ -24,7 +24,7 @@ namespace Yarp.ReverseProxy.Kubernetes.Protocol
         public string Key { get; set; }
 
 #pragma warning disable CA2227 // Collection properties should be read only
-        public List<ProxyRoute> Routes { get; set; }
+        public List<RouteConfig> Routes { get; set; }
 
         public List<Cluster> Cluster { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only

--- a/src/ReverseProxy.Kubernetes.Protocol/MessageConfigProvider.cs
+++ b/src/ReverseProxy.Kubernetes.Protocol/MessageConfigProvider.cs
@@ -20,7 +20,7 @@ namespace Yarp.ReverseProxy.Kubernetes.Protocol
 
         public IProxyConfig GetConfig() => _config;
 
-        public void Update(IReadOnlyList<ProxyRoute> routes, IReadOnlyList<Cluster> clusters)
+        public void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
         {
             var oldConfig = _config;
             _config = new MessageConfig(routes, clusters);
@@ -33,14 +33,14 @@ namespace Yarp.ReverseProxy.Kubernetes.Protocol
         {
             private readonly CancellationTokenSource _cts = new CancellationTokenSource();
 
-            public MessageConfig(IReadOnlyList<ProxyRoute> routes, IReadOnlyList<Cluster> clusters)
+            public MessageConfig(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
             {
                 Routes = routes;
                 Clusters = clusters;
                 ChangeToken = new CancellationChangeToken(_cts.Token);
             }
 
-            public IReadOnlyList<ProxyRoute> Routes { get; }
+            public IReadOnlyList<RouteConfig> Routes { get; }
 
             public IReadOnlyList<Cluster> Clusters { get; }
 

--- a/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Discoverer.cs
+++ b/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Discoverer.cs
@@ -48,7 +48,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
         }
 
         /// <inheritdoc/>
-        public async Task<(IReadOnlyList<ProxyRoute> Routes, IReadOnlyList<Cluster> Clusters)> DiscoverAsync(CancellationToken cancellation)
+        public async Task<(IReadOnlyList<RouteConfig> Routes, IReadOnlyList<Cluster> Clusters)> DiscoverAsync(CancellationToken cancellation)
         {
             // Take a snapshot of current options and use that consistently for this execution.
             var options = _optionsMonitor.CurrentValue;
@@ -56,7 +56,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
             _serviceFabricCaller.CleanUpExpired();
 
             var discoveredBackends = new Dictionary<string, Cluster>(StringComparer.Ordinal);
-            var discoveredRoutes = new List<ProxyRoute>();
+            var discoveredRoutes = new List<RouteConfig>();
             IEnumerable<ApplicationWrapper> applications;
 
             try

--- a/src/ReverseProxy.ServiceFabric/ServiceDiscovery/IDiscoverer.cs
+++ b/src/ReverseProxy.ServiceFabric/ServiceDiscovery/IDiscoverer.cs
@@ -10,13 +10,13 @@ namespace Yarp.ReverseProxy.ServiceFabric
 {
     /// <summary>
     /// Discovers Service Fabric services and builds the corresponding
-    /// <see cref="ProxyRoute"/> and <see cref="Cluster"/> instances that represent them.
+    /// <see cref="RouteConfig"/> and <see cref="Cluster"/> instances that represent them.
     /// </summary>
     internal interface IDiscoverer
     {
         /// <summary>
         /// Execute the discovery and update entities.
         /// </summary>
-        Task<(IReadOnlyList<ProxyRoute> Routes, IReadOnlyList<Cluster> Clusters)> DiscoverAsync(CancellationToken cancellation);
+        Task<(IReadOnlyList<RouteConfig> Routes, IReadOnlyList<Cluster> Clusters)> DiscoverAsync(CancellationToken cancellation);
     }
 }

--- a/src/ReverseProxy.ServiceFabric/ServiceDiscovery/ServiceFabricConfigProvider.cs
+++ b/src/ReverseProxy.ServiceFabric/ServiceDiscovery/ServiceFabricConfigProvider.cs
@@ -70,7 +70,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
                         if (_snapshot == null)
                         {
                             Log.StartWithoutInitialServiceFabricDiscovery(_logger);
-                            UpdateSnapshot(new List<ProxyRoute>(), new List<Cluster>());
+                            UpdateSnapshot(new List<RouteConfig>(), new List<Cluster>());
                         }
                     }
                 }
@@ -132,7 +132,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
             }
         }
 
-        private void UpdateSnapshot(IReadOnlyList<ProxyRoute> routes, IReadOnlyList<Cluster> clusters)
+        private void UpdateSnapshot(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
         {
             // Prevent overlapping updates
             lock (_lockObject)
@@ -162,7 +162,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
         // TODO: Perhaps YARP should provide this type?
         private sealed class ConfigurationSnapshot : IProxyConfig
         {
-            public IReadOnlyList<ProxyRoute> Routes { get; internal set; }
+            public IReadOnlyList<RouteConfig> Routes { get; internal set; }
 
             public IReadOnlyList<Cluster> Clusters { get; internal set; }
 

--- a/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Util/LabelsParser.cs
+++ b/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Util/LabelsParser.cs
@@ -61,7 +61,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
         }
 
         // TODO: optimize this method
-        internal static List<ProxyRoute> BuildRoutes(Uri serviceName, Dictionary<string, string> labels)
+        internal static List<RouteConfig> BuildRoutes(Uri serviceName, Dictionary<string, string> labels)
         {
             var backendId = GetClusterId(serviceName, labels);
 
@@ -94,7 +94,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
             }
 
             // Build the routes
-            var routes = new List<ProxyRoute>(routesNames.Count);
+            var routes = new List<RouteConfig>(routesNames.Count);
             foreach (var routeNamePair in routesNames)
             {
                 string hosts = null;
@@ -210,7 +210,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
                     }
                 }
 
-                var route = new ProxyRoute
+                var route = new RouteConfig
                 {
                     RouteId = $"{Uri.EscapeDataString(backendId)}:{Uri.EscapeDataString(routeNamePair.Value)}",
                     Match = new RouteMatch

--- a/src/ReverseProxy/Abstractions/Config/ForwardedTransformExtensions.cs
+++ b/src/ReverseProxy/Abstractions/Config/ForwardedTransformExtensions.cs
@@ -17,7 +17,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// Clones the route and adds the transform which will add X-Forwarded-* headers.
         /// </summary>
-        public static ProxyRoute WithTransformXForwarded(this ProxyRoute proxyRoute, string headerPrefix = "X-Forwarded-", bool useFor = true,
+        public static RouteConfig WithTransformXForwarded(this RouteConfig route, string headerPrefix = "X-Forwarded-", bool useFor = true,
             bool useHost = true, bool useProto = true, bool usePrefix = true, bool append = true)
         {
             var headers = new List<string>();
@@ -42,7 +42,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
                 headers.Add(ForwardedTransformFactory.ProtoKey);
             }
 
-            return proxyRoute.WithTransform(transform =>
+            return route.WithTransform(transform =>
             {
                 transform[ForwardedTransformFactory.XForwardedKey] = string.Join(',', headers);
                 transform[ForwardedTransformFactory.AppendKey] = append.ToString();
@@ -79,7 +79,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// Clones the route and adds the transform which will add the Forwarded header as defined by [RFC 7239](https://tools.ietf.org/html/rfc7239).
         /// </summary>
-        public static ProxyRoute WithTransformForwarded(this ProxyRoute proxyRoute, bool useHost = true, bool useProto = true,
+        public static RouteConfig WithTransformForwarded(this RouteConfig route, bool useHost = true, bool useProto = true,
             NodeFormat forFormat = NodeFormat.Random, NodeFormat byFormat = NodeFormat.Random, bool append = true)
         {
             var headers = new List<string>();
@@ -104,7 +104,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
                 headers.Add(ForwardedTransformFactory.ProtoKey);
             }
 
-            return proxyRoute.WithTransform(transform =>
+            return route.WithTransform(transform =>
             {
                 transform[ForwardedTransformFactory.ForwardedKey] = string.Join(',', headers);
                 transform[ForwardedTransformFactory.AppendKey] = append.ToString();
@@ -141,9 +141,9 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// Clones the route and adds the transform which will set the given header with the Base64 encoded client certificate.
         /// </summary>
-        public static ProxyRoute WithTransformClientCertHeader(this ProxyRoute proxyRoute, string headerName)
+        public static RouteConfig WithTransformClientCertHeader(this RouteConfig route, string headerName)
         {
-            return proxyRoute.WithTransform(transform =>
+            return route.WithTransform(transform =>
             {
                 transform[ForwardedTransformFactory.ClientCertKey] = headerName;
             });

--- a/src/ReverseProxy/Abstractions/Config/HttpMethodTransformExtensions.cs
+++ b/src/ReverseProxy/Abstractions/Config/HttpMethodTransformExtensions.cs
@@ -14,9 +14,9 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// Clones the route and adds the transform that will replace the HTTP method if it matches.
         /// </summary>
-        public static ProxyRoute WithTransformHttpMethodChange(this ProxyRoute proxyRoute, string fromHttpMethod, string toHttpMethod)
+        public static RouteConfig WithTransformHttpMethodChange(this RouteConfig route, string fromHttpMethod, string toHttpMethod)
         {
-            return proxyRoute.WithTransform(transform =>
+            return route.WithTransform(transform =>
             {
                 transform[HttpMethodTransformFactory.HttpMethodChangeKey] = fromHttpMethod;
                 transform[HttpMethodTransformFactory.SetKey] = toHttpMethod;

--- a/src/ReverseProxy/Abstractions/Config/IConfigValidator.cs
+++ b/src/ReverseProxy/Abstractions/Config/IConfigValidator.cs
@@ -16,7 +16,7 @@ namespace Yarp.ReverseProxy.Service
         /// <summary>
         /// Validates a route and returns all errors
         /// </summary>
-        ValueTask<IList<Exception>> ValidateRouteAsync(ProxyRoute route);
+        ValueTask<IList<Exception>> ValidateRouteAsync(RouteConfig route);
 
         /// <summary>
         /// Validates a cluster and returns all errors.

--- a/src/ReverseProxy/Abstractions/Config/IProxyConfig.cs
+++ b/src/ReverseProxy/Abstractions/Config/IProxyConfig.cs
@@ -15,7 +15,7 @@ namespace Yarp.ReverseProxy.Service
         /// <summary>
         /// Route information for matching requests to clusters.
         /// </summary>
-        IReadOnlyList<ProxyRoute> Routes { get; }
+        IReadOnlyList<RouteConfig> Routes { get; }
 
         /// <summary>
         /// Cluster information for where to proxy requests to.

--- a/src/ReverseProxy/Abstractions/Config/IProxyConfig.cs
+++ b/src/ReverseProxy/Abstractions/Config/IProxyConfig.cs
@@ -13,7 +13,7 @@ namespace Yarp.ReverseProxy.Service
     public interface IProxyConfig
     {
         /// <summary>
-        /// Route information for matching requests to clusters.
+        /// Routes matching requests to clusters.
         /// </summary>
         IReadOnlyList<RouteConfig> Routes { get; }
 

--- a/src/ReverseProxy/Abstractions/Config/IProxyConfigFilter.cs
+++ b/src/ReverseProxy/Abstractions/Config/IProxyConfigFilter.cs
@@ -13,16 +13,16 @@ namespace Yarp.ReverseProxy.Service
     public interface IProxyConfigFilter
     {
         /// <summary>
-        /// Allows modification of a Cluster configuration.
+        /// Allows modification of a cluster configuration.
         /// </summary>
         /// <param name="id">The id for the cluster.</param>
-        /// <param name="cluster">The Cluster instance to configure.</param>
+        /// <param name="cluster">The <see cref="Cluster"/> instance to configure.</param>
         ValueTask<Cluster> ConfigureClusterAsync(Cluster cluster, CancellationToken cancel);
 
         /// <summary>
         /// Allows modification of a route configuration.
         /// </summary>
-        /// <param name="route">The ProxyRoute instance to configure.</param>
-        ValueTask<ProxyRoute> ConfigureRouteAsync(ProxyRoute route, CancellationToken cancel);
+        /// <param name="route">The <see cref="RouteConfig"/> instance to configure.</param>
+        ValueTask<RouteConfig> ConfigureRouteAsync(RouteConfig route, CancellationToken cancel);
     }
 }

--- a/src/ReverseProxy/Abstractions/Config/ITransformBuilder.cs
+++ b/src/ReverseProxy/Abstractions/Config/ITransformBuilder.cs
@@ -18,7 +18,7 @@ namespace Yarp.ReverseProxy.Service
         /// Validates that each transform for the given route is known and has the expected parameters. All transforms are validated
         /// so all errors can be reported.
         /// </summary>
-        IReadOnlyList<Exception> ValidateRoute(ProxyRoute route);
+        IReadOnlyList<Exception> ValidateRoute(RouteConfig route);
 
         /// <summary>
         /// Validates that any cluster data needed for transforms is valid.
@@ -28,7 +28,7 @@ namespace Yarp.ReverseProxy.Service
         /// <summary>
         /// Builds the transforms for the given route into executable rules.
         /// </summary>
-        HttpTransformer Build(ProxyRoute route, Cluster cluster);
+        HttpTransformer Build(RouteConfig route, Cluster cluster);
 
         HttpTransformer Create(Action<TransformBuilderContext> action);
     }

--- a/src/ReverseProxy/Abstractions/Config/PathTransformExtensions.cs
+++ b/src/ReverseProxy/Abstractions/Config/PathTransformExtensions.cs
@@ -17,9 +17,9 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// Clones the route and adds the transform which sets the request path with the given value.
         /// </summary>
-        public static ProxyRoute WithTransformPathSet(this ProxyRoute proxyRoute, PathString path)
+        public static RouteConfig WithTransformPathSet(this RouteConfig route, PathString path)
         {
-            return proxyRoute.WithTransform(transform =>
+            return route.WithTransform(transform =>
             {
                 transform[PathTransformFactory.PathSetKey] = path.Value;
             });
@@ -37,9 +37,9 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// Clones the route and adds the transform which will prefix the request path with the given value.
         /// </summary>
-        public static ProxyRoute WithTransformPathPrefix(this ProxyRoute proxyRoute, PathString prefix)
+        public static RouteConfig WithTransformPathPrefix(this RouteConfig route, PathString prefix)
         {
-            return proxyRoute.WithTransform(transform =>
+            return route.WithTransform(transform =>
             {
                 transform[PathTransformFactory.PathPrefixKey] = prefix.Value;
             });
@@ -57,9 +57,9 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// Clones the route and adds the transform which will remove the matching prefix from the request path.
         /// </summary>
-        public static ProxyRoute WithTransformPathRemovePrefix(this ProxyRoute proxyRoute, PathString prefix)
+        public static RouteConfig WithTransformPathRemovePrefix(this RouteConfig route, PathString prefix)
         {
-            return proxyRoute.WithTransform(transform =>
+            return route.WithTransform(transform =>
             {
                 transform[PathTransformFactory.PathRemovePrefixKey] = prefix.Value;
             });
@@ -77,9 +77,9 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// Clones the route and adds the transform which will set the request path with the given value.
         /// </summary>
-        public static ProxyRoute WithTransformPathRouteValues(this ProxyRoute proxyRoute, PathString pattern)
+        public static RouteConfig WithTransformPathRouteValues(this RouteConfig route, PathString pattern)
         {
-            return proxyRoute.WithTransform(transform =>
+            return route.WithTransform(transform =>
             {
                 transform[PathTransformFactory.PathPatternKey] = pattern.Value;
             });

--- a/src/ReverseProxy/Abstractions/Config/ProxyRouteTransformExtensions.cs
+++ b/src/ReverseProxy/Abstractions/Config/ProxyRouteTransformExtensions.cs
@@ -15,7 +15,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// Clones the ProxyRoute and adds the transform.
         /// </summary>
         /// <returns>The cloned route with the new transform.</returns>
-        public static ProxyRoute WithTransform(this ProxyRoute proxyRoute, Action<IDictionary<string, string>> createTransform)
+        public static RouteConfig WithTransform(this RouteConfig route, Action<IDictionary<string, string>> createTransform)
         {
             if (createTransform is null)
             {
@@ -23,21 +23,21 @@ namespace Yarp.ReverseProxy.Abstractions.Config
             }
 
             List<IReadOnlyDictionary<string, string>> transforms;
-            if (proxyRoute.Transforms == null)
+            if (route.Transforms == null)
             {
                 transforms = new List<IReadOnlyDictionary<string, string>>();
             }
             else
             {
-                transforms = new List<IReadOnlyDictionary<string, string>>(proxyRoute.Transforms.Count + 1);
-                transforms.AddRange(proxyRoute.Transforms);
+                transforms = new List<IReadOnlyDictionary<string, string>>(route.Transforms.Count + 1);
+                transforms.AddRange(route.Transforms);
             }
 
             var transform = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             createTransform(transform);
             transforms.Add(transform);
 
-            return proxyRoute with { Transforms = transforms };
+            return route with { Transforms = transforms };
         }
     }
 }

--- a/src/ReverseProxy/Abstractions/Config/QueryTransformExtensions.cs
+++ b/src/ReverseProxy/Abstractions/Config/QueryTransformExtensions.cs
@@ -14,10 +14,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// Clones the route and adds the transform that will append or set the query parameter from the given value.
         /// </summary>
-        public static ProxyRoute WithTransformQueryValue(this ProxyRoute proxyRoute, string queryKey, string value, bool append = true)
+        public static RouteConfig WithTransformQueryValue(this RouteConfig route, string queryKey, string value, bool append = true)
         {
             var type = append ? QueryTransformFactory.AppendKey : QueryTransformFactory.SetKey;
-            return proxyRoute.WithTransform(transform =>
+            return route.WithTransform(transform =>
             {
                 transform[QueryTransformFactory.QueryValueParameterKey] = queryKey;
                 transform[type] = value;
@@ -38,10 +38,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// Clones the route and adds the transform that will append or set the query parameter from a route value.
         /// </summary>
-        public static ProxyRoute WithTransformQueryRouteValue(this ProxyRoute proxyRoute, string queryKey, string routeValueKey, bool append = true)
+        public static RouteConfig WithTransformQueryRouteValue(this RouteConfig route, string queryKey, string routeValueKey, bool append = true)
         {
             var type = append ? QueryTransformFactory.AppendKey : QueryTransformFactory.SetKey;
-            return proxyRoute.WithTransform(transform =>
+            return route.WithTransform(transform =>
             {
                 transform[QueryTransformFactory.QueryRouteParameterKey] = queryKey;
                 transform[type] = routeValueKey;
@@ -62,9 +62,9 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// Clones the route and adds the transform that will remove the given query key.
         /// </summary>
-        public static ProxyRoute WithTransformQueryRemoveKey(this ProxyRoute proxyRoute, string queryKey)
+        public static RouteConfig WithTransformQueryRemoveKey(this RouteConfig route, string queryKey)
         {
-            return proxyRoute.WithTransform(transform =>
+            return route.WithTransform(transform =>
             {
                 transform[QueryTransformFactory.QueryRemoveParameterKey] = queryKey;
             });

--- a/src/ReverseProxy/Abstractions/Config/RequestHeadersTransformExtensions.cs
+++ b/src/ReverseProxy/Abstractions/Config/RequestHeadersTransformExtensions.cs
@@ -14,9 +14,9 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// Clones the route and adds the transform which will enable or suppress copying request headers to the proxy request.
         /// </summary>
-        public static ProxyRoute WithTransformCopyRequestHeaders(this ProxyRoute proxyRoute, bool copy = true)
+        public static RouteConfig WithTransformCopyRequestHeaders(this RouteConfig route, bool copy = true)
         {
-            return proxyRoute.WithTransform(transform =>
+            return route.WithTransform(transform =>
             {
                 transform[RequestHeadersTransformFactory.RequestHeadersCopyKey] = copy ? bool.TrueString : bool.FalseString;
             });
@@ -25,9 +25,9 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// Clones the route and adds the transform which will copy the incoming request Host header to the proxy request.
         /// </summary>
-        public static ProxyRoute WithTransformUseOriginalHostHeader(this ProxyRoute proxyRoute, bool useOriginal = true)
+        public static RouteConfig WithTransformUseOriginalHostHeader(this RouteConfig route, bool useOriginal = true)
         {
-            return proxyRoute.WithTransform(transform =>
+            return route.WithTransform(transform =>
             {
                 transform[RequestHeadersTransformFactory.RequestHeaderOriginalHostKey] = useOriginal ? bool.TrueString : bool.FalseString;
             });
@@ -36,10 +36,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// Clones the route and adds the transform which will append or set the request header.
         /// </summary>
-        public static ProxyRoute WithTransformRequestHeader(this ProxyRoute proxyRoute, string headerName, string value, bool append = true)
+        public static RouteConfig WithTransformRequestHeader(this RouteConfig route, string headerName, string value, bool append = true)
         {
             var type = append ? RequestHeadersTransformFactory.AppendKey : RequestHeadersTransformFactory.SetKey;
-            return proxyRoute.WithTransform(transform =>
+            return route.WithTransform(transform =>
             {
                 transform[RequestHeadersTransformFactory.RequestHeaderKey] = headerName;
                 transform[type] = value;

--- a/src/ReverseProxy/Abstractions/Config/ResponseTransformExtensions.cs
+++ b/src/ReverseProxy/Abstractions/Config/ResponseTransformExtensions.cs
@@ -14,9 +14,9 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// Clones the route and adds the transform which will enable or suppress copying response headers to the client response.
         /// </summary>
-        public static ProxyRoute WithTransformCopyResponseHeaders(this ProxyRoute proxyRoute, bool copy = true)
+        public static RouteConfig WithTransformCopyResponseHeaders(this RouteConfig route, bool copy = true)
         {
-            return proxyRoute.WithTransform(transform =>
+            return route.WithTransform(transform =>
             {
                 transform[ResponseTransformFactory.ResponseHeadersCopyKey] = copy ? bool.TrueString : bool.FalseString;
             });
@@ -25,9 +25,9 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// Clones the route and adds the transform which will enable or suppress copying response trailers to the client response.
         /// </summary>
-        public static ProxyRoute WithTransformCopyResponseTrailers(this ProxyRoute proxyRoute, bool copy = true)
+        public static RouteConfig WithTransformCopyResponseTrailers(this RouteConfig route, bool copy = true)
         {
-            return proxyRoute.WithTransform(transform =>
+            return route.WithTransform(transform =>
             {
                 transform[ResponseTransformFactory.ResponseTrailersCopyKey] = copy ? bool.TrueString : bool.FalseString;
             });
@@ -36,11 +36,11 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// Clones the route and adds the transform which will append or set the response header.
         /// </summary>
-        public static ProxyRoute WithTransformResponseHeader(this ProxyRoute proxyRoute, string headerName, string value, bool append = true, bool always = true)
+        public static RouteConfig WithTransformResponseHeader(this RouteConfig route, string headerName, string value, bool append = true, bool always = true)
         {
             var type = append ? ResponseTransformFactory.AppendKey : ResponseTransformFactory.SetKey;
             var when = always ? ResponseTransformFactory.AlwaysValue : ResponseTransformFactory.SuccessValue;
-            return proxyRoute.WithTransform(transform =>
+            return route.WithTransform(transform =>
             {
                 transform[ResponseTransformFactory.ResponseHeaderKey] = headerName;
                 transform[type] = value;
@@ -60,11 +60,11 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// Clones the route and adds the transform which will append or set the response trailer.
         /// </summary>
-        public static ProxyRoute WithTransformResponseTrailer(this ProxyRoute proxyRoute, string headerName, string value, bool append = true, bool always = true)
+        public static RouteConfig WithTransformResponseTrailer(this RouteConfig route, string headerName, string value, bool append = true, bool always = true)
         {
             var type = append ? ResponseTransformFactory.AppendKey : ResponseTransformFactory.SetKey;
             var when = always ? ResponseTransformFactory.AlwaysValue : ResponseTransformFactory.SuccessValue;
-            return proxyRoute.WithTransform(transform =>
+            return route.WithTransform(transform =>
             {
                 transform[ResponseTransformFactory.ResponseTrailerKey] = headerName;
                 transform[type] = value;

--- a/src/ReverseProxy/Abstractions/Config/RouteConfigTransformExtensions.cs
+++ b/src/ReverseProxy/Abstractions/Config/RouteConfigTransformExtensions.cs
@@ -7,12 +7,12 @@ using System.Collections.Generic;
 namespace Yarp.ReverseProxy.Abstractions.Config
 {
     /// <summary>
-    /// Extensions for adding transforms to ProxyRoute.
+    /// Extensions for adding transforms to <see cref="RouteConfig"/>.
     /// </summary>
-    public static class ProxyRouteTransformExtensions
+    public static class RouteConfigTransformExtensions
     {
         /// <summary>
-        /// Clones the ProxyRoute and adds the transform.
+        /// Clones the <see cref="RouteConfig"/> and adds the transform.
         /// </summary>
         /// <returns>The cloned route with the new transform.</returns>
         public static RouteConfig WithTransform(this RouteConfig route, Action<IDictionary<string, string>> createTransform)

--- a/src/ReverseProxy/Abstractions/Config/TransformBuilderContext.cs
+++ b/src/ReverseProxy/Abstractions/Config/TransformBuilderContext.cs
@@ -20,7 +20,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// The route these transforms will be associated with.
         /// </summary>
-        public ProxyRoute Route { get; init; }
+        public RouteConfig Route { get; init; }
 
         /// <summary>
         /// The cluster config the route is associated with.

--- a/src/ReverseProxy/Abstractions/Config/TransformRouteValidationContext.cs
+++ b/src/ReverseProxy/Abstractions/Config/TransformRouteValidationContext.cs
@@ -19,7 +19,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// The route these transforms are associated with.
         /// </summary>
-        public ProxyRoute Route { get; init; }
+        public RouteConfig Route { get; init; }
 
         /// <summary>
         /// The accumulated list of validation errors for this route.

--- a/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/RouteConfig.cs
+++ b/src/ReverseProxy/Abstractions/RouteDiscovery/Contract/RouteConfig.cs
@@ -11,7 +11,7 @@ namespace Yarp.ReverseProxy.Abstractions
     /// Describes a route that matches incoming requests based on a the <see cref="Match"/> criteria
     /// and proxies matching requests to the cluster identified by its <see cref="ClusterId"/>.
     /// </summary>
-    public sealed record ProxyRoute
+    public sealed record RouteConfig
     {
         /// <summary>
         /// Globally unique identifier of the route.
@@ -61,7 +61,7 @@ namespace Yarp.ReverseProxy.Abstractions
         public IReadOnlyList<IReadOnlyDictionary<string, string>> Transforms { get; init; }
 
         /// <inheritdoc />
-        public bool Equals(ProxyRoute other)
+        public bool Equals(RouteConfig other)
         {
             if (other == null)
             {

--- a/src/ReverseProxy/Configuration/ConfigurationConfigProvider.cs
+++ b/src/ReverseProxy/Configuration/ConfigurationConfigProvider.cs
@@ -165,18 +165,18 @@ namespace Yarp.ReverseProxy.Configuration
             };
         }
 
-        private static ProxyRoute CreateRoute(IConfigurationSection section)
+        private static RouteConfig CreateRoute(IConfigurationSection section)
         {
-            return new ProxyRoute
+            return new RouteConfig
             {
                 RouteId = section.Key,
-                Order = section.ReadInt32(nameof(ProxyRoute.Order)),
-                ClusterId = section[nameof(ProxyRoute.ClusterId)],
-                AuthorizationPolicy = section[nameof(ProxyRoute.AuthorizationPolicy)],
-                CorsPolicy = section[nameof(ProxyRoute.CorsPolicy)],
-                Metadata = section.GetSection(nameof(ProxyRoute.Metadata)).ReadStringDictionary(),
-                Transforms = CreateTransforms(section.GetSection(nameof(ProxyRoute.Transforms))),
-                Match = CreateRouteMatch(section.GetSection(nameof(ProxyRoute.Match))),
+                Order = section.ReadInt32(nameof(RouteConfig.Order)),
+                ClusterId = section[nameof(RouteConfig.ClusterId)],
+                AuthorizationPolicy = section[nameof(RouteConfig.AuthorizationPolicy)],
+                CorsPolicy = section[nameof(RouteConfig.CorsPolicy)],
+                Metadata = section.GetSection(nameof(RouteConfig.Metadata)).ReadStringDictionary(),
+                Transforms = CreateTransforms(section.GetSection(nameof(RouteConfig.Transforms))),
+                Match = CreateRouteMatch(section.GetSection(nameof(RouteConfig.Match))),
             };
         }
 

--- a/src/ReverseProxy/Configuration/ConfigurationSnapshot.cs
+++ b/src/ReverseProxy/Configuration/ConfigurationSnapshot.cs
@@ -10,11 +10,11 @@ namespace Yarp.ReverseProxy.Configuration
 {
     internal sealed class ConfigurationSnapshot : IProxyConfig
     {
-        public List<ProxyRoute> Routes { get; internal set; } = new List<ProxyRoute>();
+        public List<RouteConfig> Routes { get; internal set; } = new List<RouteConfig>();
 
         public List<Cluster> Clusters { get; internal set; } = new List<Cluster>();
 
-        IReadOnlyList<ProxyRoute> IProxyConfig.Routes => Routes;
+        IReadOnlyList<RouteConfig> IProxyConfig.Routes => Routes;
 
         IReadOnlyList<Cluster> IProxyConfig.Clusters => Clusters;
 

--- a/src/ReverseProxy/Middleware/HttpContextFeaturesExtensions.cs
+++ b/src/ReverseProxy/Middleware/HttpContextFeaturesExtensions.cs
@@ -20,22 +20,22 @@ namespace Microsoft.AspNetCore.Http
         /// </summary>
         public static ClusterInfo GetClusterInfo(this HttpContext context)
         {
-            var routeState = context.GetRouteState();
-            var cluster = routeState.Cluster ?? throw new InvalidOperationException($"The {typeof(RouteState).FullName} is missing the {typeof(ClusterInfo).FullName}.");
+            var routeModel = context.GetRouteModel();
+            var cluster = routeModel.Cluster ?? throw new InvalidOperationException($"The {typeof(RouteModel).FullName} is missing the {typeof(ClusterInfo).FullName}.");
             return cluster;
         }
 
         /// <summary>
-        /// Retrieves the <see cref="RouteState"/> instance associated with the current request.
+        /// Retrieves the <see cref="RouteModel"/> instance associated with the current request.
         /// </summary>
-        public static RouteState GetRouteState(this HttpContext context)
+        public static RouteModel GetRouteModel(this HttpContext context)
         {
             var proxyFeature = context.GetReverseProxyFeature();
 
-            var routeState = proxyFeature.RouteState
-                ?? throw new InvalidOperationException($"The {typeof(IReverseProxyFeature).FullName} is missing the {typeof(RouteState).FullName}.");
+            var routeModel = proxyFeature.Route
+                ?? throw new InvalidOperationException($"The {typeof(IReverseProxyFeature).FullName} is missing the {typeof(RouteModel).FullName}.");
 
-            return routeState;
+            return routeModel;
         }
 
         /// <summary>

--- a/src/ReverseProxy/Middleware/HttpContextFeaturesExtensions.cs
+++ b/src/ReverseProxy/Middleware/HttpContextFeaturesExtensions.cs
@@ -16,38 +16,38 @@ namespace Microsoft.AspNetCore.Http
     public static class HttpContextFeaturesExtensions
     {
         /// <summary>
-        /// Retrieves the ClusterInfo instance associated with the current request.
+        /// Retrieves the <see cref="ClusterInfo"/> instance associated with the current request.
         /// </summary>
         public static ClusterInfo GetClusterInfo(this HttpContext context)
         {
-            var routeConfig = context.GetRouteConfig();
-            var cluster = routeConfig.Cluster ?? throw new InvalidOperationException("Cluster unspecified.");
+            var routeState = context.GetRouteState();
+            var cluster = routeState.Cluster ?? throw new InvalidOperationException($"The {typeof(RouteState).FullName} is missing the {typeof(ClusterInfo).FullName}.");
             return cluster;
         }
 
         /// <summary>
-        /// Retrieves the RouteConfig instance associated with the current request.
+        /// Retrieves the <see cref="RouteState"/> instance associated with the current request.
         /// </summary>
-        public static RouteConfig GetRouteConfig(this HttpContext context)
+        public static RouteState GetRouteState(this HttpContext context)
         {
             var proxyFeature = context.GetReverseProxyFeature();
 
-            var routeConfig = proxyFeature.RouteSnapshot
-                ?? throw new InvalidOperationException($"Proxy feature is missing {typeof(RouteConfig).FullName}.");
+            var routeState = proxyFeature.RouteState
+                ?? throw new InvalidOperationException($"The {typeof(IReverseProxyFeature).FullName} is missing the {typeof(RouteState).FullName}.");
 
-            return routeConfig;
+            return routeState;
         }
 
         /// <summary>
-        /// Retrieves the IReverseProxyFeature instance associated with the current request.
+        /// Retrieves the <see cref="IReverseProxyFeature"/> instance associated with the current request.
         /// </summary>
         public static IReverseProxyFeature GetReverseProxyFeature(this HttpContext context)
         {
-            return context.Features.Get<IReverseProxyFeature>() ?? throw new InvalidOperationException("ReverseProxyFeature unspecified.");
+            return context.Features.Get<IReverseProxyFeature>() ?? throw new InvalidOperationException($"{typeof(IReverseProxyFeature).FullName} is missing.");
         }
 
         /// <summary>
-        /// Retrieves the IProxyErrorFeature instance associated with the current request, if any.
+        /// Retrieves the <see cref="IProxyErrorFeature"/> instance associated with the current request, if any.
         /// </summary>
         public static IProxyErrorFeature? GetProxyErrorFeature(this HttpContext context)
         {

--- a/src/ReverseProxy/Middleware/HttpContextFeaturesExtensions.cs
+++ b/src/ReverseProxy/Middleware/HttpContextFeaturesExtensions.cs
@@ -20,8 +20,8 @@ namespace Microsoft.AspNetCore.Http
         /// </summary>
         public static ClusterInfo GetClusterInfo(this HttpContext context)
         {
-            var routeModel = context.GetRouteModel();
-            var cluster = routeModel.Cluster ?? throw new InvalidOperationException($"The {typeof(RouteModel).FullName} is missing the {typeof(ClusterInfo).FullName}.");
+            var route = context.GetRouteModel();
+            var cluster = route.Cluster ?? throw new InvalidOperationException($"The {typeof(RouteModel).FullName} is missing the {typeof(ClusterInfo).FullName}.");
             return cluster;
         }
 
@@ -32,10 +32,10 @@ namespace Microsoft.AspNetCore.Http
         {
             var proxyFeature = context.GetReverseProxyFeature();
 
-            var routeModel = proxyFeature.Route
+            var route = proxyFeature.Route
                 ?? throw new InvalidOperationException($"The {typeof(IReverseProxyFeature).FullName} is missing the {typeof(RouteModel).FullName}.");
 
-            return routeModel;
+            return route;
         }
 
         /// <summary>

--- a/src/ReverseProxy/Middleware/IReverseProxyFeature.cs
+++ b/src/ReverseProxy/Middleware/IReverseProxyFeature.cs
@@ -12,9 +12,9 @@ namespace Yarp.ReverseProxy.Middleware
     public interface IReverseProxyFeature
     {
         /// <summary>
-        /// Route config for the current request.
+        /// Route state for the current request.
         /// </summary>
-        RouteConfig RouteSnapshot { get; }
+        RouteState RouteState { get; }
 
         /// <summary>
         /// Cluster config for the current request.

--- a/src/ReverseProxy/Middleware/IReverseProxyFeature.cs
+++ b/src/ReverseProxy/Middleware/IReverseProxyFeature.cs
@@ -14,7 +14,7 @@ namespace Yarp.ReverseProxy.Middleware
         /// <summary>
         /// Route state for the current request.
         /// </summary>
-        RouteState RouteState { get; }
+        RouteModel Route { get; }
 
         /// <summary>
         /// Cluster config for the current request.

--- a/src/ReverseProxy/Middleware/IReverseProxyFeature.cs
+++ b/src/ReverseProxy/Middleware/IReverseProxyFeature.cs
@@ -12,7 +12,7 @@ namespace Yarp.ReverseProxy.Middleware
     public interface IReverseProxyFeature
     {
         /// <summary>
-        /// Route state for the current request.
+        /// The route model for the current request.
         /// </summary>
         RouteModel Route { get; }
 

--- a/src/ReverseProxy/Middleware/PassiveHealthCheckMiddleware.cs
+++ b/src/ReverseProxy/Middleware/PassiveHealthCheckMiddleware.cs
@@ -36,7 +36,7 @@ namespace Yarp.ReverseProxy.Middleware
             }
 
             var policy = _policies.GetRequiredServiceById(options.Policy, HealthCheckConstants.PassivePolicy.TransportFailureRate);
-            var cluster = context.GetRouteConfig().Cluster;
+            var cluster = context.GetRouteState().Cluster;
             policy.RequestProxied(cluster, proxyFeature.ProxiedDestination, context);
         }
     }

--- a/src/ReverseProxy/Middleware/PassiveHealthCheckMiddleware.cs
+++ b/src/ReverseProxy/Middleware/PassiveHealthCheckMiddleware.cs
@@ -36,7 +36,7 @@ namespace Yarp.ReverseProxy.Middleware
             }
 
             var policy = _policies.GetRequiredServiceById(options.Policy, HealthCheckConstants.PassivePolicy.TransportFailureRate);
-            var cluster = context.GetRouteState().Cluster;
+            var cluster = context.GetRouteModel().Cluster;
             policy.RequestProxied(cluster, proxyFeature.ProxiedDestination, context);
         }
     }

--- a/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
+++ b/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
@@ -43,8 +43,8 @@ namespace Yarp.ReverseProxy.Middleware
             var destinations = reverseProxyFeature.AvailableDestinations
                 ?? throw new InvalidOperationException($"The {nameof(IReverseProxyFeature)} Destinations collection was not set.");
 
-            var routeState = context.GetRouteState();
-            var cluster = routeState.Cluster;
+            var route = context.GetRouteModel();
+            var cluster = route.Cluster;
 
             if (destinations.Count == 0)
             {
@@ -75,10 +75,10 @@ namespace Yarp.ReverseProxy.Middleware
                 cluster.ConcurrencyCounter.Increment();
                 destination.ConcurrencyCounter.Increment();
 
-                ProxyTelemetry.Log.ProxyInvoke(cluster.ClusterId, routeState.ProxyRoute.RouteId, destination.DestinationId);
+                ProxyTelemetry.Log.ProxyInvoke(cluster.ClusterId, route.Config.RouteId, destination.DestinationId);
 
                 var clusterConfig = reverseProxyFeature.ClusterSnapshot;
-                await _httpProxy.ProxyAsync(context, destinationConfig.Options.Address, clusterConfig.HttpClient, clusterConfig.Options.HttpRequest, routeState.Transformer);
+                await _httpProxy.ProxyAsync(context, destinationConfig.Options.Address, clusterConfig.HttpClient, clusterConfig.Options.HttpRequest, route.Transformer);
             }
             finally
             {

--- a/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
+++ b/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
@@ -43,8 +43,8 @@ namespace Yarp.ReverseProxy.Middleware
             var destinations = reverseProxyFeature.AvailableDestinations
                 ?? throw new InvalidOperationException($"The {nameof(IReverseProxyFeature)} Destinations collection was not set.");
 
-            var routeConfig = context.GetRouteConfig();
-            var cluster = routeConfig.Cluster;
+            var routeState = context.GetRouteState();
+            var cluster = routeState.Cluster;
 
             if (destinations.Count == 0)
             {
@@ -75,10 +75,10 @@ namespace Yarp.ReverseProxy.Middleware
                 cluster.ConcurrencyCounter.Increment();
                 destination.ConcurrencyCounter.Increment();
 
-                ProxyTelemetry.Log.ProxyInvoke(cluster.ClusterId, routeConfig.ProxyRoute.RouteId, destination.DestinationId);
+                ProxyTelemetry.Log.ProxyInvoke(cluster.ClusterId, routeState.ProxyRoute.RouteId, destination.DestinationId);
 
                 var clusterConfig = reverseProxyFeature.ClusterSnapshot;
-                await _httpProxy.ProxyAsync(context, destinationConfig.Options.Address, clusterConfig.HttpClient, clusterConfig.Options.HttpRequest, routeConfig.Transformer);
+                await _httpProxy.ProxyAsync(context, destinationConfig.Options.Address, clusterConfig.HttpClient, clusterConfig.Options.HttpRequest, routeState.Transformer);
             }
             finally
             {

--- a/src/ReverseProxy/Middleware/ProxyPipelineInitializerMiddleware.cs
+++ b/src/ReverseProxy/Middleware/ProxyPipelineInitializerMiddleware.cs
@@ -29,8 +29,8 @@ namespace Yarp.ReverseProxy.Middleware
             var endpoint = context.GetEndpoint()
                ?? throw new InvalidOperationException($"Routing Endpoint wasn't set for the current request.");
 
-            var routeConfig = endpoint.Metadata.GetMetadata<RouteConfig>()
-                ?? throw new InvalidOperationException($"Routing Endpoint is missing {typeof(RouteConfig).FullName} metadata.");
+            var routeConfig = endpoint.Metadata.GetMetadata<RouteState>()
+                ?? throw new InvalidOperationException($"Routing Endpoint is missing {typeof(RouteState).FullName} metadata.");
 
             var cluster = routeConfig.Cluster;
             // TODO: Validate on load https://github.com/microsoft/reverse-proxy/issues/797
@@ -44,7 +44,7 @@ namespace Yarp.ReverseProxy.Middleware
             var dynamicState = cluster.DynamicState;
             context.Features.Set<IReverseProxyFeature>(new ReverseProxyFeature
             {
-                RouteSnapshot = routeConfig,
+                RouteState = routeConfig,
                 ClusterSnapshot = cluster.Config,
                 AllDestinations = dynamicState.AllDestinations,
                 AvailableDestinations = dynamicState.HealthyDestinations

--- a/src/ReverseProxy/Middleware/ProxyPipelineInitializerMiddleware.cs
+++ b/src/ReverseProxy/Middleware/ProxyPipelineInitializerMiddleware.cs
@@ -29,14 +29,14 @@ namespace Yarp.ReverseProxy.Middleware
             var endpoint = context.GetEndpoint()
                ?? throw new InvalidOperationException($"Routing Endpoint wasn't set for the current request.");
 
-            var routeConfig = endpoint.Metadata.GetMetadata<RouteState>()
-                ?? throw new InvalidOperationException($"Routing Endpoint is missing {typeof(RouteState).FullName} metadata.");
+            var route = endpoint.Metadata.GetMetadata<RouteModel>()
+                ?? throw new InvalidOperationException($"Routing Endpoint is missing {typeof(RouteModel).FullName} metadata.");
 
-            var cluster = routeConfig.Cluster;
+            var cluster = route.Cluster;
             // TODO: Validate on load https://github.com/microsoft/reverse-proxy/issues/797
             if (cluster == null)
             {
-                Log.NoClusterFound(_logger, routeConfig.ProxyRoute.RouteId);
+                Log.NoClusterFound(_logger, route.Config.RouteId);
                 context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
                 return Task.CompletedTask;
             }
@@ -44,7 +44,7 @@ namespace Yarp.ReverseProxy.Middleware
             var dynamicState = cluster.DynamicState;
             context.Features.Set<IReverseProxyFeature>(new ReverseProxyFeature
             {
-                RouteState = routeConfig,
+                Route = route,
                 ClusterSnapshot = cluster.Config,
                 AllDestinations = dynamicState.AllDestinations,
                 AvailableDestinations = dynamicState.HealthyDestinations

--- a/src/ReverseProxy/Middleware/ReverseProxyFeature.cs
+++ b/src/ReverseProxy/Middleware/ReverseProxyFeature.cs
@@ -12,7 +12,7 @@ namespace Yarp.ReverseProxy.Middleware
     public class ReverseProxyFeature : IReverseProxyFeature
     {
         /// <inheritdoc/>
-        public RouteState RouteState { get; init; }
+        public RouteModel Route { get; init; }
 
         /// <inheritdoc/>
         public ClusterConfig ClusterSnapshot { get; set; }
@@ -25,6 +25,5 @@ namespace Yarp.ReverseProxy.Middleware
 
         /// <inheritdoc/>
         public DestinationInfo ProxiedDestination { get; set; }
-
     }
 }

--- a/src/ReverseProxy/Middleware/ReverseProxyFeature.cs
+++ b/src/ReverseProxy/Middleware/ReverseProxyFeature.cs
@@ -12,7 +12,7 @@ namespace Yarp.ReverseProxy.Middleware
     public class ReverseProxyFeature : IReverseProxyFeature
     {
         /// <inheritdoc/>
-        public RouteConfig RouteSnapshot { get; init; }
+        public RouteState RouteState { get; init; }
 
         /// <inheritdoc/>
         public ClusterConfig ClusterSnapshot { get; set; }

--- a/src/ReverseProxy/Service/Config/ConfigValidator.cs
+++ b/src/ReverseProxy/Service/Config/ConfigValidator.cs
@@ -56,7 +56,7 @@ namespace Yarp.ReverseProxy.Service
         }
 
         // Note this performs all validation steps without short circuiting in order to report all possible errors.
-        public async ValueTask<IList<Exception>> ValidateRouteAsync(ProxyRoute route)
+        public async ValueTask<IList<Exception>> ValidateRouteAsync(RouteConfig route)
         {
             _ = route ?? throw new ArgumentNullException(nameof(route));
             var errors = new List<Exception>();

--- a/src/ReverseProxy/Service/Config/TransformBuilder.cs
+++ b/src/ReverseProxy/Service/Config/TransformBuilder.cs
@@ -32,7 +32,7 @@ namespace Yarp.ReverseProxy.Service.Config
         }
 
         /// <inheritdoc/>
-        public IReadOnlyList<Exception> ValidateRoute(ProxyRoute route)
+        public IReadOnlyList<Exception> ValidateRoute(RouteConfig route)
         {
             var context = new TransformRouteValidationContext()
             {
@@ -92,13 +92,13 @@ namespace Yarp.ReverseProxy.Service.Config
         }
 
         /// <inheritdoc/>
-        public HttpTransformer Build(ProxyRoute route, Cluster cluster)
+        public HttpTransformer Build(RouteConfig route, Cluster cluster)
         {
             return BuildInternal(route, cluster);
         }
 
         // This is separate from Build for testing purposes.
-        internal StructuredTransformer BuildInternal(ProxyRoute route, Cluster cluster)
+        internal StructuredTransformer BuildInternal(RouteConfig route, Cluster cluster)
         {
             var rawTransforms = route.Transforms;
 

--- a/src/ReverseProxy/Service/DynamicEndpoint/ProxyEndpointFactory.cs
+++ b/src/ReverseProxy/Service/DynamicEndpoint/ProxyEndpointFactory.cs
@@ -27,7 +27,7 @@ namespace Yarp.ReverseProxy
 
         private RequestDelegate _pipeline;
 
-        public Endpoint CreateEndpoint(RouteConfig route, IReadOnlyList<Action<EndpointBuilder>> conventions)
+        public Endpoint CreateEndpoint(RouteState route, IReadOnlyList<Action<EndpointBuilder>> conventions)
         {
             var proxyRoute = route.ProxyRoute;
             var proxyMatch = proxyRoute.Match;

--- a/src/ReverseProxy/Service/DynamicEndpoint/ProxyEndpointFactory.cs
+++ b/src/ReverseProxy/Service/DynamicEndpoint/ProxyEndpointFactory.cs
@@ -27,33 +27,33 @@ namespace Yarp.ReverseProxy
 
         private RequestDelegate _pipeline;
 
-        public Endpoint CreateEndpoint(RouteState route, IReadOnlyList<Action<EndpointBuilder>> conventions)
+        public Endpoint CreateEndpoint(RouteModel route, IReadOnlyList<Action<EndpointBuilder>> conventions)
         {
-            var proxyRoute = route.ProxyRoute;
-            var proxyMatch = proxyRoute.Match;
+            var config = route.Config;
+            var match = config.Match;
 
             // Catch-all pattern when no path was specified
-            var pathPattern = string.IsNullOrEmpty(proxyMatch.Path) ? "/{**catchall}" : proxyMatch.Path;
+            var pathPattern = string.IsNullOrEmpty(match.Path) ? "/{**catchall}" : match.Path;
 
             var endpointBuilder = new RouteEndpointBuilder(
                 requestDelegate: _pipeline ?? throw new InvalidOperationException("The pipeline hasn't been provided yet."),
                 routePattern: RoutePatternFactory.Parse(pathPattern),
-                order: proxyRoute.Order.GetValueOrDefault())
+                order: config.Order.GetValueOrDefault())
             {
-                DisplayName = proxyRoute.RouteId
+                DisplayName = config.RouteId
             };
 
             endpointBuilder.Metadata.Add(route);
 
-            if (proxyMatch.Hosts != null && proxyMatch.Hosts.Count != 0)
+            if (match.Hosts != null && match.Hosts.Count != 0)
             {
-                endpointBuilder.Metadata.Add(new HostAttribute(proxyMatch.Hosts.ToArray()));
+                endpointBuilder.Metadata.Add(new HostAttribute(match.Hosts.ToArray()));
             }
 
-            if (proxyRoute.Match.Headers != null && proxyRoute.Match.Headers.Count > 0)
+            if (config.Match.Headers != null && config.Match.Headers.Count > 0)
             {
-                var matchers = new List<HeaderMatcher>(proxyRoute.Match.Headers.Count);
-                foreach (var header in proxyRoute.Match.Headers)
+                var matchers = new List<HeaderMatcher>(config.Match.Headers.Count);
+                foreach (var header in config.Match.Headers)
                 {
                     matchers.Add(new HeaderMatcher(header.Name, header.Values, header.Mode, header.IsCaseSensitive));
                 }
@@ -62,19 +62,19 @@ namespace Yarp.ReverseProxy
             }
 
             bool acceptCorsPreflight;
-            if (string.Equals(CorsConstants.Default, proxyRoute.CorsPolicy, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(CorsConstants.Default, config.CorsPolicy, StringComparison.OrdinalIgnoreCase))
             {
                 endpointBuilder.Metadata.Add(_defaultCors);
                 acceptCorsPreflight = true;
             }
-            else if (string.Equals(CorsConstants.Disable, proxyRoute.CorsPolicy, StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(CorsConstants.Disable, config.CorsPolicy, StringComparison.OrdinalIgnoreCase))
             {
                 endpointBuilder.Metadata.Add(_disableCors);
                 acceptCorsPreflight = true;
             }
-            else if (!string.IsNullOrEmpty(proxyRoute.CorsPolicy))
+            else if (!string.IsNullOrEmpty(config.CorsPolicy))
             {
-                endpointBuilder.Metadata.Add(new EnableCorsAttribute(proxyRoute.CorsPolicy));
+                endpointBuilder.Metadata.Add(new EnableCorsAttribute(config.CorsPolicy));
                 acceptCorsPreflight = true;
             }
             else
@@ -82,22 +82,22 @@ namespace Yarp.ReverseProxy
                 acceptCorsPreflight = false;
             }
 
-            if (proxyMatch.Methods != null && proxyMatch.Methods.Count > 0)
+            if (match.Methods != null && match.Methods.Count > 0)
             {
-                endpointBuilder.Metadata.Add(new HttpMethodMetadata(proxyMatch.Methods, acceptCorsPreflight));
+                endpointBuilder.Metadata.Add(new HttpMethodMetadata(match.Methods, acceptCorsPreflight));
             }
 
-            if (string.Equals(AuthorizationConstants.Default, proxyRoute.AuthorizationPolicy, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(AuthorizationConstants.Default, config.AuthorizationPolicy, StringComparison.OrdinalIgnoreCase))
             {
                 endpointBuilder.Metadata.Add(_defaultAuthorization);
             }
-            else if (string.Equals(AuthorizationConstants.Anonymous, proxyRoute.AuthorizationPolicy, StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(AuthorizationConstants.Anonymous, config.AuthorizationPolicy, StringComparison.OrdinalIgnoreCase))
             {
                 endpointBuilder.Metadata.Add(_allowAnonymous);
             }
-            else if (!string.IsNullOrEmpty(proxyRoute.AuthorizationPolicy))
+            else if (!string.IsNullOrEmpty(config.AuthorizationPolicy))
             {
-                endpointBuilder.Metadata.Add(new AuthorizeAttribute(proxyRoute.AuthorizationPolicy));
+                endpointBuilder.Metadata.Add(new AuthorizeAttribute(config.AuthorizationPolicy));
             }
 
             for (var i = 0; i < conventions.Count; i++)

--- a/src/ReverseProxy/Service/DynamicEndpoint/ProxyEndpointFactory.cs
+++ b/src/ReverseProxy/Service/DynamicEndpoint/ProxyEndpointFactory.cs
@@ -50,10 +50,10 @@ namespace Yarp.ReverseProxy
                 endpointBuilder.Metadata.Add(new HostAttribute(match.Hosts.ToArray()));
             }
 
-            if (config.Match.Headers != null && config.Match.Headers.Count > 0)
+            if (match.Headers != null && match.Headers.Count > 0)
             {
-                var matchers = new List<HeaderMatcher>(config.Match.Headers.Count);
-                foreach (var header in config.Match.Headers)
+                var matchers = new List<HeaderMatcher>(match.Headers.Count);
+                foreach (var header in match.Headers)
                 {
                     matchers.Add(new HeaderMatcher(header.Name, header.Values, header.Mode, header.IsCaseSensitive));
                 }

--- a/src/ReverseProxy/Service/DynamicEndpoint/ReverseProxyConventionBuilder.cs
+++ b/src/ReverseProxy/Service/DynamicEndpoint/ReverseProxyConventionBuilder.cs
@@ -61,9 +61,9 @@ namespace Yarp.ReverseProxy
 
             void Action(EndpointBuilder endpointBuilder)
             {
-                var routeState = endpointBuilder.Metadata.OfType<RouteState>().Single();
+                var route = endpointBuilder.Metadata.OfType<RouteModel>().Single();
                 var conventionBuilder = new EndpointBuilderConventionBuilder(endpointBuilder);
-                convention(conventionBuilder, routeState.ProxyRoute);
+                convention(conventionBuilder, route.Config);
             }
 
             Add(Action);
@@ -82,10 +82,10 @@ namespace Yarp.ReverseProxy
 
             void Action(EndpointBuilder endpointBuilder)
             {
-                var routeState = endpointBuilder.Metadata.OfType<RouteState>().Single();
+                var route = endpointBuilder.Metadata.OfType<RouteModel>().Single();
 
-                var cluster = routeState.Cluster?.Config.Options;
-                var proxyRoute = routeState.ProxyRoute;
+                var cluster = route.Cluster?.Config.Options;
+                var proxyRoute = route.Config;
                 var conventionBuilder = new EndpointBuilderConventionBuilder(endpointBuilder);
                 convention(conventionBuilder, proxyRoute, cluster);
             }

--- a/src/ReverseProxy/Service/DynamicEndpoint/ReverseProxyConventionBuilder.cs
+++ b/src/ReverseProxy/Service/DynamicEndpoint/ReverseProxyConventionBuilder.cs
@@ -61,9 +61,9 @@ namespace Yarp.ReverseProxy
 
             void Action(EndpointBuilder endpointBuilder)
             {
-                var routeConfig = endpointBuilder.Metadata.OfType<RouteConfig>().Single();
+                var routeState = endpointBuilder.Metadata.OfType<RouteState>().Single();
                 var conventionBuilder = new EndpointBuilderConventionBuilder(endpointBuilder);
-                convention(conventionBuilder, routeConfig.ProxyRoute);
+                convention(conventionBuilder, routeState.ProxyRoute);
             }
 
             Add(Action);
@@ -82,10 +82,10 @@ namespace Yarp.ReverseProxy
 
             void Action(EndpointBuilder endpointBuilder)
             {
-                var routeConfig = endpointBuilder.Metadata.OfType<RouteConfig>().Single();
+                var routeState = endpointBuilder.Metadata.OfType<RouteState>().Single();
 
-                var cluster = routeConfig.Cluster?.Config.Options;
-                var proxyRoute = routeConfig.ProxyRoute;
+                var cluster = routeState.Cluster?.Config.Options;
+                var proxyRoute = routeState.ProxyRoute;
                 var conventionBuilder = new EndpointBuilderConventionBuilder(endpointBuilder);
                 convention(conventionBuilder, proxyRoute, cluster);
             }

--- a/src/ReverseProxy/Service/DynamicEndpoint/ReverseProxyConventionBuilder.cs
+++ b/src/ReverseProxy/Service/DynamicEndpoint/ReverseProxyConventionBuilder.cs
@@ -55,7 +55,7 @@ namespace Yarp.ReverseProxy
         /// </summary>
         /// <param name="convention">The convention to add to the builder.</param>
         /// <returns></returns>
-        public ReverseProxyConventionBuilder ConfigureEndpoints(Action<IEndpointConventionBuilder, ProxyRoute> convention)
+        public ReverseProxyConventionBuilder ConfigureEndpoints(Action<IEndpointConventionBuilder, RouteConfig> convention)
         {
             _ = convention ?? throw new ArgumentNullException(nameof(convention));
 
@@ -76,7 +76,7 @@ namespace Yarp.ReverseProxy
         /// </summary>
         /// <param name="convention">The convention to add to the builder.</param>
         /// <returns></returns>
-        public ReverseProxyConventionBuilder ConfigureEndpoints(Action<IEndpointConventionBuilder, ProxyRoute, Cluster> convention)
+        public ReverseProxyConventionBuilder ConfigureEndpoints(Action<IEndpointConventionBuilder, RouteConfig, Cluster> convention)
         {
             _ = convention ?? throw new ArgumentNullException(nameof(convention));
 

--- a/src/ReverseProxy/Service/DynamicEndpoint/ReverseProxyConventionBuilder.cs
+++ b/src/ReverseProxy/Service/DynamicEndpoint/ReverseProxyConventionBuilder.cs
@@ -82,12 +82,12 @@ namespace Yarp.ReverseProxy
 
             void Action(EndpointBuilder endpointBuilder)
             {
-                var route = endpointBuilder.Metadata.OfType<RouteModel>().Single();
+                var routeModel = endpointBuilder.Metadata.OfType<RouteModel>().Single();
 
-                var cluster = route.Cluster?.Config.Options;
-                var config = route.Config;
+                var clusterConfig = routeModel.Cluster?.Config.Options;
+                var routeConfig = routeModel.Config;
                 var conventionBuilder = new EndpointBuilderConventionBuilder(endpointBuilder);
-                convention(conventionBuilder, config, cluster);
+                convention(conventionBuilder, routeConfig, clusterConfig);
             }
 
             Add(Action);

--- a/src/ReverseProxy/Service/DynamicEndpoint/ReverseProxyConventionBuilder.cs
+++ b/src/ReverseProxy/Service/DynamicEndpoint/ReverseProxyConventionBuilder.cs
@@ -85,9 +85,9 @@ namespace Yarp.ReverseProxy
                 var route = endpointBuilder.Metadata.OfType<RouteModel>().Single();
 
                 var cluster = route.Cluster?.Config.Options;
-                var proxyRoute = route.Config;
+                var config = route.Config;
                 var conventionBuilder = new EndpointBuilderConventionBuilder(endpointBuilder);
-                convention(conventionBuilder, proxyRoute, cluster);
+                convention(conventionBuilder, config, cluster);
             }
 
             Add(Action);

--- a/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
@@ -507,15 +507,15 @@ namespace Yarp.ReverseProxy.Service.Management
                 else
                 {
                     var newModel = BuildRouteModel(incomingRoute, cluster);
-                    var newRoute = new RouteState(incomingRoute.RouteId)
+                    var newState = new RouteState(incomingRoute.RouteId)
                     {
                         Model = newModel,
                         ClusterRevision = cluster?.Revision,
                     };
-                    var added = _routes.TryAdd(newRoute.RouteId, newRoute);
+                    var added = _routes.TryAdd(newState.RouteId, newState);
                     Debug.Assert(added);
                     changed = true;
-                    Log.RouteAdded(_logger, newRoute.RouteId);
+                    Log.RouteAdded(_logger, newState.RouteId);
                 }
             }
 

--- a/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
@@ -36,7 +36,7 @@ namespace Yarp.ReverseProxy.Service.Management
         private readonly IProxyConfigProvider _provider;
         private readonly IClusterChangeListener[] _clusterChangeListeners;
         private readonly ConcurrentDictionary<string, ClusterInfo> _clusters = new(StringComparer.OrdinalIgnoreCase);
-        private readonly ConcurrentDictionary<string, RouteEntity> _routes = new(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, RouteState> _routes = new(StringComparer.OrdinalIgnoreCase);
         private readonly IProxyConfigFilter[] _filters;
         private readonly IConfigValidator _configValidator;
         private readonly IProxyHttpClientFactory _httpClientFactory;
@@ -507,7 +507,7 @@ namespace Yarp.ReverseProxy.Service.Management
                 else
                 {
                     var newModel = BuildRouteModel(incomingRoute, cluster);
-                    var newRoute = new RouteEntity(incomingRoute.RouteId)
+                    var newRoute = new RouteState(incomingRoute.RouteId)
                     {
                         Model = newModel,
                         ClusterRevision = cluster?.Revision,

--- a/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
@@ -118,7 +118,7 @@ namespace Yarp.ReverseProxy.Service.Management
                 var endpoint = existingRoute.Value.CachedEndpoint;
                 if (endpoint == null)
                 {
-                    endpoint = _proxyEndpointFactory.CreateEndpoint(existingRoute.Value.Config, _conventions);
+                    endpoint = _proxyEndpointFactory.CreateEndpoint(existingRoute.Value.State, _conventions);
                     existingRoute.Value.CachedEndpoint = endpoint;
                 }
                 endpoints.Add(endpoint);
@@ -494,11 +494,11 @@ namespace Yarp.ReverseProxy.Service.Management
 
                 if (_routes.TryGetValue(incomingRoute.RouteId, out var currentRoute))
                 {
-                    if (currentRoute.Config.HasConfigChanged(incomingRoute, cluster, currentRoute.ClusterRevision))
+                    if (currentRoute.State.HasConfigChanged(incomingRoute, cluster, currentRoute.ClusterRevision))
                     {
                         currentRoute.CachedEndpoint = null; // Recreate endpoint
-                        var newConfig = BuildRouteConfig(incomingRoute, cluster);
-                        currentRoute.Config = newConfig;
+                        var newState = BuildRouteState(incomingRoute, cluster);
+                        currentRoute.State = newState;
                         currentRoute.ClusterRevision = cluster?.Revision;
                         changed = true;
                         Log.RouteChanged(_logger, currentRoute.RouteId);
@@ -506,10 +506,10 @@ namespace Yarp.ReverseProxy.Service.Management
                 }
                 else
                 {
-                    var newConfig = BuildRouteConfig(incomingRoute, cluster);
+                    var newState = BuildRouteState(incomingRoute, cluster);
                     var newRoute = new RouteEntity(incomingRoute.RouteId)
                     {
-                        Config = newConfig,
+                        State = newState,
                         ClusterRevision = cluster?.Revision,
                     };
                     var added = _routes.TryAdd(newRoute.RouteId, newRoute);
@@ -529,7 +529,7 @@ namespace Yarp.ReverseProxy.Service.Management
                     //
                     // NOTE 2: Removing the route from _routes is safe and existing
                     // ASP .NET Core endpoints will continue to work with their existing behavior since
-                    // their copy of `RouteConfig` is immutable and remains operational in whichever state is was in.
+                    // their copy of `RouteState` is immutable and remains operational in whichever state is was in.
                     Log.RouteRemoved(_logger, routeId);
                     var removed = _routes.TryRemove(routeId, out var _);
                     Debug.Assert(removed);
@@ -570,11 +570,11 @@ namespace Yarp.ReverseProxy.Service.Management
             }
         }
 
-        private RouteConfig BuildRouteConfig(ProxyRoute source, ClusterInfo cluster)
+        private RouteState BuildRouteState(ProxyRoute source, ClusterInfo cluster)
         {
             var transforms = _transformBuilder.Build(source, cluster?.Config?.Options);
 
-            var newRouteConfig = new RouteConfig(
+            var newRouteConfig = new RouteState(
                 source,
                 cluster,
                 transforms);

--- a/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
@@ -221,15 +221,15 @@ namespace Yarp.ReverseProxy.Service.Management
             return routesChanged;
         }
 
-        private async Task<(IList<ProxyRoute>, IList<Exception>)> VerifyRoutesAsync(IReadOnlyList<ProxyRoute> routes, CancellationToken cancellation)
+        private async Task<(IList<RouteConfig>, IList<Exception>)> VerifyRoutesAsync(IReadOnlyList<RouteConfig> routes, CancellationToken cancellation)
         {
             if (routes == null)
             {
-                return (Array.Empty<ProxyRoute>(), Array.Empty<Exception>());
+                return (Array.Empty<RouteConfig>(), Array.Empty<Exception>());
             }
 
             var seenRouteIds = new HashSet<string>();
-            var configuredRoutes = new List<ProxyRoute>(routes?.Count ?? 0);
+            var configuredRoutes = new List<RouteConfig>(routes?.Count ?? 0);
             var errors = new List<Exception>();
 
             foreach (var r in routes)
@@ -478,7 +478,7 @@ namespace Yarp.ReverseProxy.Service.Management
             return changed;
         }
 
-        private bool UpdateRuntimeRoutes(IList<ProxyRoute> incomingRoutes)
+        private bool UpdateRuntimeRoutes(IList<RouteConfig> incomingRoutes)
         {
             var desiredRoutes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var changed = false;
@@ -570,7 +570,7 @@ namespace Yarp.ReverseProxy.Service.Management
             }
         }
 
-        private RouteState BuildRouteState(ProxyRoute source, ClusterInfo cluster)
+        private RouteState BuildRouteState(RouteConfig source, ClusterInfo cluster)
         {
             var transforms = _transformBuilder.Build(source, cluster?.Config?.Options);
 

--- a/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
@@ -36,7 +36,7 @@ namespace Yarp.ReverseProxy.Service.Management
         private readonly IProxyConfigProvider _provider;
         private readonly IClusterChangeListener[] _clusterChangeListeners;
         private readonly ConcurrentDictionary<string, ClusterInfo> _clusters = new(StringComparer.OrdinalIgnoreCase);
-        private readonly ConcurrentDictionary<string, RouteInfo> _routes = new(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, RouteEntity> _routes = new(StringComparer.OrdinalIgnoreCase);
         private readonly IProxyConfigFilter[] _filters;
         private readonly IConfigValidator _configValidator;
         private readonly IProxyHttpClientFactory _httpClientFactory;
@@ -507,7 +507,7 @@ namespace Yarp.ReverseProxy.Service.Management
                 else
                 {
                     var newConfig = BuildRouteConfig(incomingRoute, cluster);
-                    var newRoute = new RouteInfo(incomingRoute.RouteId)
+                    var newRoute = new RouteEntity(incomingRoute.RouteId)
                     {
                         Config = newConfig,
                         ClusterRevision = cluster?.Revision,

--- a/src/ReverseProxy/Service/RuntimeModel/RouteEntity.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/RouteEntity.cs
@@ -14,11 +14,11 @@ namespace Yarp.ReverseProxy.RuntimeModel
     /// references that can be updated atomically and which will always have latest information.
     /// All members are thread safe.
     /// </remarks>
-    internal sealed class RouteInfo
+    internal sealed class RouteEntity
     {
         private volatile RouteConfig _config;
 
-        public RouteInfo(string routeId)
+        public RouteEntity(string routeId)
         {
             if (string.IsNullOrEmpty(routeId))
             {

--- a/src/ReverseProxy/Service/RuntimeModel/RouteEntity.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/RouteEntity.cs
@@ -10,13 +10,13 @@ namespace Yarp.ReverseProxy.RuntimeModel
     /// Representation of a route for use at runtime.
     /// </summary>
     /// <remarks>
-    /// Note that while this class is immutable, specific members such as <see cref="State"/> hold mutable
+    /// Note that while this class is immutable, specific members such as <see cref="Model"/> hold mutable
     /// references that can be updated atomically and which will always have latest information.
     /// All members are thread safe.
     /// </remarks>
     internal sealed class RouteEntity
     {
-        private volatile RouteState _state;
+        private volatile RouteModel _model;
 
         public RouteEntity(string routeId)
         {
@@ -33,10 +33,10 @@ namespace Yarp.ReverseProxy.RuntimeModel
         /// Encapsulates parts of a route that can change atomically
         /// in reaction to config changes.
         /// </summary>
-        internal RouteState State
+        internal RouteModel Model
         {
-            get => _state;
-            set => _state = value ?? throw new ArgumentNullException(nameof(value));
+            get => _model;
+            set => _model = value ?? throw new ArgumentNullException(nameof(value));
         }
 
         /// <summary>

--- a/src/ReverseProxy/Service/RuntimeModel/RouteEntity.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/RouteEntity.cs
@@ -10,13 +10,13 @@ namespace Yarp.ReverseProxy.RuntimeModel
     /// Representation of a route for use at runtime.
     /// </summary>
     /// <remarks>
-    /// Note that while this class is immutable, specific members such as <see cref="Config"/> hold mutable
+    /// Note that while this class is immutable, specific members such as <see cref="State"/> hold mutable
     /// references that can be updated atomically and which will always have latest information.
     /// All members are thread safe.
     /// </remarks>
     internal sealed class RouteEntity
     {
-        private volatile RouteConfig _config;
+        private volatile RouteState _state;
 
         public RouteEntity(string routeId)
         {
@@ -33,10 +33,10 @@ namespace Yarp.ReverseProxy.RuntimeModel
         /// Encapsulates parts of a route that can change atomically
         /// in reaction to config changes.
         /// </summary>
-        internal RouteConfig Config
+        internal RouteState State
         {
-            get => _config;
-            set => _config = value ?? throw new ArgumentNullException(nameof(value));
+            get => _state;
+            set => _state = value ?? throw new ArgumentNullException(nameof(value));
         }
 
         /// <summary>

--- a/src/ReverseProxy/Service/RuntimeModel/RouteModel.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/RouteModel.cs
@@ -13,20 +13,20 @@ namespace Yarp.ReverseProxy.RuntimeModel
     /// </summary>
     /// <remarks>
     /// All members must remain immutable to avoid thread safety issues.
-    /// Instead, instances of <see cref="RouteState"/> are replaced
+    /// Instead, instances of <see cref="RouteModel"/> are replaced
     /// in their entirety when values need to change.
     /// </remarks>
-    public sealed class RouteState
+    public sealed class RouteModel
     {
         /// <summary>
         /// Creates a new instance.
         /// </summary>
-        public RouteState(
-            RouteConfig proxyRoute,
+        public RouteModel(
+            RouteConfig config,
             ClusterInfo cluster,
             HttpTransformer transformer)
         {
-            ProxyRoute = proxyRoute ?? throw new ArgumentNullException(nameof(proxyRoute));
+            Config = config ?? throw new ArgumentNullException(nameof(config));
             Cluster = cluster;
             Transformer = transformer;
         }
@@ -45,11 +45,11 @@ namespace Yarp.ReverseProxy.RuntimeModel
         /// <summary>
         /// The configuration data used to build this route.
         /// </summary>
-        public RouteConfig ProxyRoute { get; }
+        public RouteConfig Config { get; }
 
         internal bool HasConfigChanged(RouteConfig newConfig, ClusterInfo cluster, int? routeRevision)
         {
-            return Cluster != cluster || routeRevision != cluster?.Revision || !ProxyRoute.Equals(newConfig);
+            return Cluster != cluster || routeRevision != cluster?.Revision || !Config.Equals(newConfig);
         }
     }
 }

--- a/src/ReverseProxy/Service/RuntimeModel/RouteState.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/RouteState.cs
@@ -9,16 +9,11 @@ namespace Yarp.ReverseProxy.RuntimeModel
     /// <summary>
     /// Representation of a route for use at runtime.
     /// </summary>
-    /// <remarks>
-    /// Note that while this class is immutable, specific members such as <see cref="Model"/> hold mutable
-    /// references that can be updated atomically and which will always have latest information.
-    /// All members are thread safe.
-    /// </remarks>
-    internal sealed class RouteEntity
+    internal sealed class RouteState
     {
         private volatile RouteModel _model;
 
-        public RouteEntity(string routeId)
+        public RouteState(string routeId)
         {
             if (string.IsNullOrEmpty(routeId))
             {

--- a/src/ReverseProxy/Service/RuntimeModel/RouteState.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/RouteState.cs
@@ -22,7 +22,7 @@ namespace Yarp.ReverseProxy.RuntimeModel
         /// Creates a new instance.
         /// </summary>
         public RouteState(
-            ProxyRoute proxyRoute,
+            RouteConfig proxyRoute,
             ClusterInfo cluster,
             HttpTransformer transformer)
         {
@@ -45,9 +45,9 @@ namespace Yarp.ReverseProxy.RuntimeModel
         /// <summary>
         /// The configuration data used to build this route.
         /// </summary>
-        public ProxyRoute ProxyRoute { get; }
+        public RouteConfig ProxyRoute { get; }
 
-        internal bool HasConfigChanged(ProxyRoute newConfig, ClusterInfo cluster, int? routeRevision)
+        internal bool HasConfigChanged(RouteConfig newConfig, ClusterInfo cluster, int? routeRevision)
         {
             return Cluster != cluster || routeRevision != cluster?.Revision || !ProxyRoute.Equals(newConfig);
         }

--- a/src/ReverseProxy/Service/RuntimeModel/RouteState.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/RouteState.cs
@@ -13,15 +13,15 @@ namespace Yarp.ReverseProxy.RuntimeModel
     /// </summary>
     /// <remarks>
     /// All members must remain immutable to avoid thread safety issues.
-    /// Instead, instances of <see cref="RouteConfig"/> are replaced
+    /// Instead, instances of <see cref="RouteState"/> are replaced
     /// in their entirety when values need to change.
     /// </remarks>
-    public sealed class RouteConfig
+    public sealed class RouteState
     {
         /// <summary>
-        /// Creates a new RouteConfig instance.
+        /// Creates a new instance.
         /// </summary>
-        public RouteConfig(
+        public RouteState(
             ProxyRoute proxyRoute,
             ClusterInfo cluster,
             HttpTransformer transformer)

--- a/test/ReverseProxy.FunctionalTests/Common/InMemoryConfigProvider.cs
+++ b/test/ReverseProxy.FunctionalTests/Common/InMemoryConfigProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class InMemoryConfigProviderExtensions
     {
-        public static IReverseProxyBuilder LoadFromMemory(this IReverseProxyBuilder builder, IReadOnlyList<ProxyRoute> routes, IReadOnlyList<Cluster> clusters)
+        public static IReverseProxyBuilder LoadFromMemory(this IReverseProxyBuilder builder, IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
         {
             builder.Services.AddSingleton<IProxyConfigProvider>(new InMemoryConfigProvider(routes, clusters));
             return builder;
@@ -26,14 +26,14 @@ namespace Yarp.ReverseProxy.Configuration
     {
         private volatile InMemoryConfig _config;
 
-        public InMemoryConfigProvider(IReadOnlyList<ProxyRoute> routes, IReadOnlyList<Cluster> clusters)
+        public InMemoryConfigProvider(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
         {
             _config = new InMemoryConfig(routes, clusters);
         }
 
         public IProxyConfig GetConfig() => _config;
 
-        public void Update(IReadOnlyList<ProxyRoute> routes, IReadOnlyList<Cluster> clusters)
+        public void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
         {
             var oldConfig = _config;
             _config = new InMemoryConfig(routes, clusters);
@@ -44,14 +44,14 @@ namespace Yarp.ReverseProxy.Configuration
         {
             private readonly CancellationTokenSource _cts = new CancellationTokenSource();
 
-            public InMemoryConfig(IReadOnlyList<ProxyRoute> routes, IReadOnlyList<Cluster> clusters)
+            public InMemoryConfig(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
             {
                 Routes = routes;
                 Clusters = clusters;
                 ChangeToken = new CancellationChangeToken(_cts.Token);
             }
 
-            public IReadOnlyList<ProxyRoute> Routes { get; }
+            public IReadOnlyList<RouteConfig> Routes { get; }
 
             public IReadOnlyList<Cluster> Clusters { get; }
 

--- a/test/ReverseProxy.FunctionalTests/Common/TestEnvironment.cs
+++ b/test/ReverseProxy.FunctionalTests/Common/TestEnvironment.cs
@@ -86,7 +86,7 @@ namespace Yarp.ReverseProxy.Common
             return CreateHost(protocols, false, requestHeaderEncoding,
                 services =>
                 {
-                    var proxyRoute = new ProxyRoute
+                    var proxyRoute = new RouteConfig
                     {
                         RouteId = "route1",
                         ClusterId = clusterId,

--- a/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/DiscovererTests.cs
+++ b/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/DiscovererTests.cs
@@ -52,7 +52,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
                 .Setup(v => v.ValidateClusterAsync(It.IsAny<Cluster>()))
                 .ReturnsAsync(() => new List<Exception>());
             Mock<IConfigValidator>()
-                .Setup(v => v.ValidateRouteAsync(It.IsAny<ProxyRoute>()))
+                .Setup(v => v.ValidateRouteAsync(It.IsAny<RouteConfig>()))
                 .ReturnsAsync(() => new List<Exception>());
         }
 
@@ -193,7 +193,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
                 ClusterWithDestinations(_testServiceName, labels3,
                     SFTestHelpers.BuildDestinationFromReplica(replica3)),
             };
-            var expectedRoutes = new List<ProxyRoute>();
+            var expectedRoutes = new List<RouteConfig>();
             expectedRoutes.AddRange(LabelsParser.BuildRoutes(_testServiceName, labels1));
             expectedRoutes.AddRange(LabelsParser.BuildRoutes(_testServiceName, labels2));
             expectedRoutes.AddRange(LabelsParser.BuildRoutes(_testServiceName, labels3));
@@ -305,7 +305,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
                 ClusterWithDestinations(_testServiceName, labels,
                     SFTestHelpers.BuildDestinationFromReplica(replica)),
             };
-            var expectedRoutes = new List<ProxyRoute>();
+            var expectedRoutes = new List<RouteConfig>();
 
             clusters.Should().BeEquivalentTo(expectedClusters);
             routes.Should().BeEmpty();
@@ -587,7 +587,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
             return LabelsParser.BuildCluster(serviceName, labels, newDestinations);
         }
 
-        private async Task<(IReadOnlyList<ProxyRoute> Routes, IReadOnlyList<Cluster> Clusters)> RunScenarioAsync()
+        private async Task<(IReadOnlyList<RouteConfig> Routes, IReadOnlyList<Cluster> Clusters)> RunScenarioAsync()
         {
             if (_scenarioOptions == null)
             {

--- a/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/Util/LabelsParserTests.cs
+++ b/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/Util/LabelsParserTests.cs
@@ -275,9 +275,9 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
 
             var routes = LabelsParser.BuildRoutes(_testServiceName, labels);
 
-            var expectedRoutes = new List<ProxyRoute>
+            var expectedRoutes = new List<RouteConfig>
             {
-                new ProxyRoute
+                new RouteConfig
                 {
                     RouteId = "MyCoolClusterId:MyRoute",
                     Match = new RouteMatch
@@ -338,9 +338,9 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
 
             var routes = LabelsParser.BuildRoutes(_testServiceName, labels);
 
-            var expectedRoutes = new List<ProxyRoute>
+            var expectedRoutes = new List<RouteConfig>
             {
-                new ProxyRoute
+                new RouteConfig
                 {
                     RouteId = "MyCoolClusterId:MyRoute",
                     Match = new RouteMatch
@@ -368,9 +368,9 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
 
             var routes = LabelsParser.BuildRoutes(_testServiceName, labels);
 
-            var expectedRoutes = new List<ProxyRoute>
+            var expectedRoutes = new List<RouteConfig>
             {
-                new ProxyRoute
+                new RouteConfig
                 {
                     RouteId = "MyCoolClusterId:MyRoute",
                     Match = new RouteMatch
@@ -402,9 +402,9 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
 
             var routes = LabelsParser.BuildRoutes(_testServiceName, labels);
 
-            var expectedRoutes = new List<ProxyRoute>
+            var expectedRoutes = new List<RouteConfig>
             {
-                new ProxyRoute
+                new RouteConfig
                 {
                     RouteId = $"{Uri.EscapeDataString(_testServiceName.ToString())}:MyRoute",
                     Match = new RouteMatch
@@ -429,9 +429,9 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
 
             var routes = LabelsParser.BuildRoutes(_testServiceName, labels);
 
-            var expectedRoutes = new List<ProxyRoute>
+            var expectedRoutes = new List<RouteConfig>
             {
-                new ProxyRoute
+                new RouteConfig
                 {
                     RouteId = $"{Uri.EscapeDataString(_testServiceName.ToString())}:MyRoute",
                     Match = new RouteMatch
@@ -455,7 +455,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
                 { "YARP.Routes.MyRoute.Order", "this is no number" },
             };
 
-            Func<List<ProxyRoute>> func = () => LabelsParser.BuildRoutes(_testServiceName, labels);
+            Func<List<RouteConfig>> func = () => LabelsParser.BuildRoutes(_testServiceName, labels);
 
             func.Should()
                 .Throw<ConfigException>()
@@ -479,9 +479,9 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
 
             var routes = LabelsParser.BuildRoutes(_testServiceName, labels);
 
-            var expectedRoutes = new List<ProxyRoute>
+            var expectedRoutes = new List<RouteConfig>
             {
-                new ProxyRoute
+                new RouteConfig
                 {
                     RouteId = $"MyCoolClusterId:{routeName}",
                     Match = new RouteMatch
@@ -517,7 +517,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
             };
             labels[invalidKey] = value;
 
-            Func<List<ProxyRoute>> func = () => LabelsParser.BuildRoutes(_testServiceName, labels);
+            Func<List<RouteConfig>> func = () => LabelsParser.BuildRoutes(_testServiceName, labels);
 
             func.Should()
                 .Throw<ConfigException>()
@@ -539,7 +539,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
             };
             labels[invalidKey] = value;
 
-            Func<List<ProxyRoute>> func = () => LabelsParser.BuildRoutes(_testServiceName, labels);
+            Func<List<RouteConfig>> func = () => LabelsParser.BuildRoutes(_testServiceName, labels);
 
             func.Should()
                 .Throw<ConfigException>()
@@ -563,7 +563,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
             labels[invalidKey] = value;
 
             // Act
-            Func<List<ProxyRoute>> func = () => LabelsParser.BuildRoutes(_testServiceName, labels);
+            Func<List<RouteConfig>> func = () => LabelsParser.BuildRoutes(_testServiceName, labels);
 
             // Assert
             func.Should()
@@ -586,7 +586,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
             labels[invalidKey] = value;
 
             // Act
-            Func<List<ProxyRoute>> func = () => LabelsParser.BuildRoutes(_testServiceName, labels);
+            Func<List<RouteConfig>> func = () => LabelsParser.BuildRoutes(_testServiceName, labels);
 
             // Assert
             func.Should()
@@ -611,9 +611,9 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
 
             var routes = LabelsParser.BuildRoutes(_testServiceName, labels);
 
-            var expectedRoutes = new List<ProxyRoute>
+            var expectedRoutes = new List<RouteConfig>
             {
-                new ProxyRoute
+                new RouteConfig
                 {
                     RouteId = $"MyCoolClusterId:MyRoute0",
                     Match = new RouteMatch
@@ -661,9 +661,9 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
 
             var routes = LabelsParser.BuildRoutes(_testServiceName, labels);
 
-            var expectedRoutes = new List<ProxyRoute>
+            var expectedRoutes = new List<RouteConfig>
             {
-                new ProxyRoute
+                new RouteConfig
                 {
                     RouteId = "MyCoolClusterId:MyRoute",
                     Match = new RouteMatch
@@ -699,9 +699,9 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
 
             var routes = LabelsParser.BuildRoutes(_testServiceName, labels);
 
-            var expectedRoutes = new List<ProxyRoute>
+            var expectedRoutes = new List<RouteConfig>
             {
-                new ProxyRoute
+                new RouteConfig
                 {
                     RouteId = "MyCoolClusterId:MyRoute",
                     Match = new RouteMatch
@@ -713,7 +713,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
                     ClusterId = "MyCoolClusterId",
                     Metadata = new Dictionary<string, string> { { "Foo", "Bar" } },
                 },
-                new ProxyRoute
+                new RouteConfig
                 {
                     RouteId = "MyCoolClusterId:CoolRoute",
                     Match = new RouteMatch
@@ -724,7 +724,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
                     ClusterId = "MyCoolClusterId",
                     Metadata = new Dictionary<string, string>(),
                 },
-                new ProxyRoute
+                new RouteConfig
                 {
                     RouteId = "MyCoolClusterId:EvenCoolerRoute",
                     Match = new RouteMatch

--- a/test/ReverseProxy.Tests/Abstractions/Config/ForwardedTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/Config/ForwardedTransformExtensionsTests.cs
@@ -25,7 +25,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(true, true, false, false, false)]
         public void WithTransformXForwarded(bool useFor, bool useHost, bool useProto, bool usePrefix, bool append)
         {
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             proxyRoute = proxyRoute.WithTransformXForwarded("prefix-", useFor, useHost, useProto, usePrefix, append);
 
             var builderContext = ValidateAndBuild(proxyRoute, _factory);
@@ -112,7 +112,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(NodeFormat.None, false, true, NodeFormat.IpAndPort, false)]
         public void WithTransformForwarded(NodeFormat forFormat, bool useHost, bool useProto, NodeFormat byFormat, bool append)
         {
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             proxyRoute = proxyRoute.WithTransformForwarded(useHost, useProto, forFormat, byFormat, append);
 
             var builderContext = ValidateAndBuild(proxyRoute, _factory, CreateServices());
@@ -165,7 +165,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [Fact]
         public void WithTransformClientCertHeader()
         {
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             proxyRoute = proxyRoute.WithTransformClientCertHeader("name");
 
             var builderContext = ValidateAndBuild(proxyRoute, _factory);

--- a/test/ReverseProxy.Tests/Abstractions/Config/ForwardedTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/Config/ForwardedTransformExtensionsTests.cs
@@ -25,10 +25,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(true, true, false, false, false)]
         public void WithTransformXForwarded(bool useFor, bool useHost, bool useProto, bool usePrefix, bool append)
         {
-            var proxyRoute = new RouteConfig();
-            proxyRoute = proxyRoute.WithTransformXForwarded("prefix-", useFor, useHost, useProto, usePrefix, append);
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformXForwarded("prefix-", useFor, useHost, useProto, usePrefix, append);
 
-            var builderContext = ValidateAndBuild(proxyRoute, _factory);
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
 
             ValidateXForwarded(builderContext, useFor, useHost, useProto, usePrefix, append);
         }
@@ -112,10 +112,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(NodeFormat.None, false, true, NodeFormat.IpAndPort, false)]
         public void WithTransformForwarded(NodeFormat forFormat, bool useHost, bool useProto, NodeFormat byFormat, bool append)
         {
-            var proxyRoute = new RouteConfig();
-            proxyRoute = proxyRoute.WithTransformForwarded(useHost, useProto, forFormat, byFormat, append);
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformForwarded(useHost, useProto, forFormat, byFormat, append);
 
-            var builderContext = ValidateAndBuild(proxyRoute, _factory, CreateServices());
+            var builderContext = ValidateAndBuild(routeConfig, _factory, CreateServices());
 
             ValidateForwarded(builderContext, useHost, useProto, forFormat, byFormat, append);
         }
@@ -165,10 +165,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [Fact]
         public void WithTransformClientCertHeader()
         {
-            var proxyRoute = new RouteConfig();
-            proxyRoute = proxyRoute.WithTransformClientCertHeader("name");
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformClientCertHeader("name");
 
-            var builderContext = ValidateAndBuild(proxyRoute, _factory);
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
 
             var transform = Assert.Single(builderContext.RequestTransforms);
             var certTransform = Assert.IsType<RequestHeaderClientCertTransform>(transform);

--- a/test/ReverseProxy.Tests/Abstractions/Config/HttpMethodTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/Config/HttpMethodTransformExtensionsTests.cs
@@ -16,10 +16,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [Fact]
         public void WithTransformHttpMethodChange()
         {
-            var proxyRoute = new RouteConfig();
-            proxyRoute = proxyRoute.WithTransformHttpMethodChange(HttpMethods.Put, HttpMethods.Post);
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformHttpMethodChange(HttpMethods.Put, HttpMethods.Post);
 
-            var builderContext = ValidateAndBuild(proxyRoute, _factory);
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
 
             ValidateHttpMethod(builderContext);
         }

--- a/test/ReverseProxy.Tests/Abstractions/Config/HttpMethodTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/Config/HttpMethodTransformExtensionsTests.cs
@@ -16,7 +16,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [Fact]
         public void WithTransformHttpMethodChange()
         {
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             proxyRoute = proxyRoute.WithTransformHttpMethodChange(HttpMethods.Put, HttpMethods.Post);
 
             var builderContext = ValidateAndBuild(proxyRoute, _factory);

--- a/test/ReverseProxy.Tests/Abstractions/Config/PathTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/Config/PathTransformExtensionsTests.cs
@@ -27,10 +27,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [Fact]
         public void WithTransformPathSet()
         {
-            var proxyRoute = new RouteConfig();
-            proxyRoute = proxyRoute.WithTransformPathSet(new PathString("/path#"));
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformPathSet(new PathString("/path#"));
 
-            var builderContext = ValidateAndBuild(proxyRoute, _factory);
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
 
             ValidatePathSet(builderContext);
         }
@@ -55,10 +55,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [Fact]
         public void WithTransformPathRemovePrefix()
         {
-            var proxyRoute = new RouteConfig();
-            proxyRoute = proxyRoute.WithTransformPathRemovePrefix(new PathString("/path#"));
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformPathRemovePrefix(new PathString("/path#"));
 
-            var builderContext = ValidateAndBuild(proxyRoute, _factory);
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
 
             ValidatePathRemovePrefix(builderContext);
         }
@@ -83,10 +83,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [Fact]
         public void WithTransformPathPrefix()
         {
-            var proxyRoute = new RouteConfig();
-            proxyRoute = proxyRoute.WithTransformPathPrefix(new PathString("/path#"));
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformPathPrefix(new PathString("/path#"));
 
-            var builderContext = ValidateAndBuild(proxyRoute, _factory);
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
 
             ValidatePathPrefix(builderContext);
         }
@@ -111,10 +111,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [Fact]
         public void WithTransformPathRouteValues()
         {
-            var proxyRoute = new RouteConfig();
-            proxyRoute = proxyRoute.WithTransformPathRouteValues(new PathString("/path#"));
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformPathRouteValues(new PathString("/path#"));
 
-            var builderContext = ValidateAndBuild(proxyRoute, _factory);
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
 
             ValidatePathRouteValues(builderContext);
         }

--- a/test/ReverseProxy.Tests/Abstractions/Config/PathTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/Config/PathTransformExtensionsTests.cs
@@ -27,7 +27,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [Fact]
         public void WithTransformPathSet()
         {
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             proxyRoute = proxyRoute.WithTransformPathSet(new PathString("/path#"));
 
             var builderContext = ValidateAndBuild(proxyRoute, _factory);
@@ -55,7 +55,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [Fact]
         public void WithTransformPathRemovePrefix()
         {
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             proxyRoute = proxyRoute.WithTransformPathRemovePrefix(new PathString("/path#"));
 
             var builderContext = ValidateAndBuild(proxyRoute, _factory);
@@ -83,7 +83,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [Fact]
         public void WithTransformPathPrefix()
         {
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             proxyRoute = proxyRoute.WithTransformPathPrefix(new PathString("/path#"));
 
             var builderContext = ValidateAndBuild(proxyRoute, _factory);
@@ -111,7 +111,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [Fact]
         public void WithTransformPathRouteValues()
         {
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             proxyRoute = proxyRoute.WithTransformPathRouteValues(new PathString("/path#"));
 
             var builderContext = ValidateAndBuild(proxyRoute, _factory);

--- a/test/ReverseProxy.Tests/Abstractions/Config/QueryTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/Config/QueryTransformExtensionsTests.cs
@@ -16,10 +16,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(true)]
         public void WithTransformQueryRouteValue(bool append)
         {
-            var proxyRoute = new RouteConfig();
-            proxyRoute = proxyRoute.WithTransformQueryRouteValue("key", "value", append);
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformQueryRouteValue("key", "value", append);
 
-            var builderContext = ValidateAndBuild(proxyRoute, _factory);
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
 
             ValidateQueryRouteParameter(append, builderContext);
         }
@@ -50,10 +50,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(true)]
         public void WithTransformQueryValue(bool append)
         {
-            var proxyRoute = new RouteConfig();
-            proxyRoute = proxyRoute.WithTransformQueryValue("key", "value", append);
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformQueryValue("key", "value", append);
 
-            var builderContext = ValidateAndBuild(proxyRoute, _factory);
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
 
             ValidateQueryValue(append, builderContext);
         }
@@ -82,10 +82,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [Fact]
         public void WithTransformQueryRemoveKey()
         {
-            var proxyRoute = new RouteConfig();
-            proxyRoute = proxyRoute.WithTransformQueryRemoveKey("key");
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformQueryRemoveKey("key");
 
-            var builderContext = ValidateAndBuild(proxyRoute, _factory);
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
 
             ValidateQueryRemoveKey(builderContext);
         }

--- a/test/ReverseProxy.Tests/Abstractions/Config/QueryTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/Config/QueryTransformExtensionsTests.cs
@@ -16,7 +16,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(true)]
         public void WithTransformQueryRouteValue(bool append)
         {
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             proxyRoute = proxyRoute.WithTransformQueryRouteValue("key", "value", append);
 
             var builderContext = ValidateAndBuild(proxyRoute, _factory);
@@ -50,7 +50,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(true)]
         public void WithTransformQueryValue(bool append)
         {
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             proxyRoute = proxyRoute.WithTransformQueryValue("key", "value", append);
 
             var builderContext = ValidateAndBuild(proxyRoute, _factory);
@@ -82,7 +82,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [Fact]
         public void WithTransformQueryRemoveKey()
         {
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             proxyRoute = proxyRoute.WithTransformQueryRemoveKey("key");
 
             var builderContext = ValidateAndBuild(proxyRoute, _factory);

--- a/test/ReverseProxy.Tests/Abstractions/Config/RequestHeadersTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/Config/RequestHeadersTransformExtensionsTests.cs
@@ -17,10 +17,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(false)]
         public void WithTransformCopyRequestHeaders(bool copy)
         {
-            var proxyRoute = new RouteConfig();
-            proxyRoute = proxyRoute.WithTransformCopyRequestHeaders(copy);
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformCopyRequestHeaders(copy);
 
-            var builderContext = ValidateAndBuild(proxyRoute, _factory);
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
 
             Assert.Equal(copy, builderContext.CopyRequestHeaders);
         }
@@ -30,10 +30,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(false)]
         public void WithTransformUseOriginalHostHeader(bool useOriginal)
         {
-            var proxyRoute = new RouteConfig();
-            proxyRoute = proxyRoute.WithTransformUseOriginalHostHeader(useOriginal);
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformUseOriginalHostHeader(useOriginal);
 
-            var builderContext = ValidateAndBuild(proxyRoute, _factory);
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
 
             var transform = Assert.Single(builderContext.RequestTransforms);
             var hostTransform = Assert.IsType<RequestHeaderOriginalHostTransform>(transform);
@@ -46,10 +46,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(false)]
         public void WithTransformRequestHeader(bool append)
         {
-            var proxyRoute = new RouteConfig();
-            proxyRoute = proxyRoute.WithTransformRequestHeader("name", "value", append);
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformRequestHeader("name", "value", append);
 
-            var builderContext = ValidateAndBuild(proxyRoute, _factory);
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
 
             ValidateRequestHeader(append, builderContext);
         }

--- a/test/ReverseProxy.Tests/Abstractions/Config/RequestHeadersTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/Config/RequestHeadersTransformExtensionsTests.cs
@@ -17,7 +17,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(false)]
         public void WithTransformCopyRequestHeaders(bool copy)
         {
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             proxyRoute = proxyRoute.WithTransformCopyRequestHeaders(copy);
 
             var builderContext = ValidateAndBuild(proxyRoute, _factory);
@@ -30,7 +30,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(false)]
         public void WithTransformUseOriginalHostHeader(bool useOriginal)
         {
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             proxyRoute = proxyRoute.WithTransformUseOriginalHostHeader(useOriginal);
 
             var builderContext = ValidateAndBuild(proxyRoute, _factory);
@@ -46,7 +46,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(false)]
         public void WithTransformRequestHeader(bool append)
         {
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             proxyRoute = proxyRoute.WithTransformRequestHeader("name", "value", append);
 
             var builderContext = ValidateAndBuild(proxyRoute, _factory);

--- a/test/ReverseProxy.Tests/Abstractions/Config/ResponseTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/Config/ResponseTransformExtensionsTests.cs
@@ -16,7 +16,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(false)]
         public void WithTransformCopyResponseHeaders(bool copy)
         {
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             proxyRoute = proxyRoute.WithTransformCopyResponseHeaders(copy);
 
             var builderContext = ValidateAndBuild(proxyRoute, _factory);
@@ -29,7 +29,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(false)]
         public void WithTransformCopyResponseTrailers(bool copy)
         {
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             proxyRoute = proxyRoute.WithTransformCopyResponseTrailers(copy);
 
             var builderContext = ValidateAndBuild(proxyRoute, _factory);
@@ -44,7 +44,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(true, true)]
         public void WithTransformResponseHeader(bool append, bool always)
         {
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             proxyRoute = proxyRoute.WithTransformResponseHeader("name", "value", append, always);
 
             var builderContext = ValidateAndBuild(proxyRoute, _factory);
@@ -82,7 +82,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(true, true)]
         public void WithTransformResponseTrailer(bool append, bool always)
         {
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             proxyRoute = proxyRoute.WithTransformResponseTrailer("name", "value", append, always);
 
             var builderContext = ValidateAndBuild(proxyRoute, _factory);

--- a/test/ReverseProxy.Tests/Abstractions/Config/ResponseTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/Config/ResponseTransformExtensionsTests.cs
@@ -16,10 +16,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(false)]
         public void WithTransformCopyResponseHeaders(bool copy)
         {
-            var proxyRoute = new RouteConfig();
-            proxyRoute = proxyRoute.WithTransformCopyResponseHeaders(copy);
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformCopyResponseHeaders(copy);
 
-            var builderContext = ValidateAndBuild(proxyRoute, _factory);
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
 
             Assert.Equal(copy, builderContext.CopyResponseHeaders);
         }
@@ -29,10 +29,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(false)]
         public void WithTransformCopyResponseTrailers(bool copy)
         {
-            var proxyRoute = new RouteConfig();
-            proxyRoute = proxyRoute.WithTransformCopyResponseTrailers(copy);
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformCopyResponseTrailers(copy);
 
-            var builderContext = ValidateAndBuild(proxyRoute, _factory);
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
 
             Assert.Equal(copy, builderContext.CopyResponseTrailers);
         }
@@ -44,10 +44,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(true, true)]
         public void WithTransformResponseHeader(bool append, bool always)
         {
-            var proxyRoute = new RouteConfig();
-            proxyRoute = proxyRoute.WithTransformResponseHeader("name", "value", append, always);
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformResponseHeader("name", "value", append, always);
 
-            var builderContext = ValidateAndBuild(proxyRoute, _factory);
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
 
             ValidateResponseHeader(builderContext, append, always);
         }
@@ -82,10 +82,10 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         [InlineData(true, true)]
         public void WithTransformResponseTrailer(bool append, bool always)
         {
-            var proxyRoute = new RouteConfig();
-            proxyRoute = proxyRoute.WithTransformResponseTrailer("name", "value", append, always);
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformResponseTrailer("name", "value", append, always);
 
-            var builderContext = ValidateAndBuild(proxyRoute, _factory);
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
 
             ValidateResponseTrailer(builderContext, append, always);
         }

--- a/test/ReverseProxy.Tests/Abstractions/Config/TransformExtentionsTestsBase.cs
+++ b/test/ReverseProxy.Tests/Abstractions/Config/TransformExtentionsTestsBase.cs
@@ -14,11 +14,11 @@ namespace Yarp.ReverseProxy.Abstractions.Config
             Services = services,
         };
 
-        protected static TransformBuilderContext ValidateAndBuild(RouteConfig proxyRoute, ITransformFactory factory, IServiceProvider serviceProvider = null)
+        protected static TransformBuilderContext ValidateAndBuild(RouteConfig routeConfig, ITransformFactory factory, IServiceProvider serviceProvider = null)
         {
-            var transformValues = Assert.Single(proxyRoute.Transforms);
+            var transformValues = Assert.Single(routeConfig.Transforms);
 
-            var validationContext = new TransformRouteValidationContext { Route = proxyRoute };
+            var validationContext = new TransformRouteValidationContext { Route = routeConfig };
             Assert.True(factory.Validate(validationContext, transformValues));
             Assert.Empty(validationContext.Errors);
 

--- a/test/ReverseProxy.Tests/Abstractions/Config/TransformExtentionsTestsBase.cs
+++ b/test/ReverseProxy.Tests/Abstractions/Config/TransformExtentionsTestsBase.cs
@@ -10,11 +10,11 @@ namespace Yarp.ReverseProxy.Abstractions.Config
     {
         protected static TransformBuilderContext CreateBuilderContext(IServiceProvider services = null) => new()
         {
-            Route = new ProxyRoute(),
+            Route = new RouteConfig(),
             Services = services,
         };
 
-        protected static TransformBuilderContext ValidateAndBuild(ProxyRoute proxyRoute, ITransformFactory factory, IServiceProvider serviceProvider = null)
+        protected static TransformBuilderContext ValidateAndBuild(RouteConfig proxyRoute, ITransformFactory factory, IServiceProvider serviceProvider = null)
         {
             var transformValues = Assert.Single(proxyRoute.Transforms);
 

--- a/test/ReverseProxy.Tests/Abstractions/RouteDiscovery/Contract/ProxyRouteTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/RouteDiscovery/Contract/ProxyRouteTests.cs
@@ -11,7 +11,7 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
         [Fact]
         public void Equals_Positive()
         {
-            var a = new ProxyRoute()
+            var a = new RouteConfig()
             {
                 AuthorizationPolicy = "a",
                 ClusterId = "c",
@@ -39,7 +39,7 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
                 Order = 1,
                 RouteId = "R",
             };
-            var b = new ProxyRoute()
+            var b = new RouteConfig()
             {
                 AuthorizationPolicy = "a",
                 ClusterId = "c",
@@ -76,7 +76,7 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
         [Fact]
         public void Equals_Negative()
         {
-            var a = new ProxyRoute()
+            var a = new RouteConfig()
             {
                 AuthorizationPolicy = "a",
                 ClusterId = "c",
@@ -124,7 +124,7 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
         [Fact]
         public void Equals_Null_False()
         {
-            Assert.False(new ProxyRoute().Equals(null));
+            Assert.False(new RouteConfig().Equals(null));
         }
     }
 }

--- a/test/ReverseProxy.Tests/Common/InMemoryConfigProvider.cs
+++ b/test/ReverseProxy.Tests/Common/InMemoryConfigProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class InMemoryConfigProviderExtensions
     {
-        public static IReverseProxyBuilder LoadFromMemory(this IReverseProxyBuilder builder, IReadOnlyList<ProxyRoute> routes, IReadOnlyList<Cluster> clusters)
+        public static IReverseProxyBuilder LoadFromMemory(this IReverseProxyBuilder builder, IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
         {
             builder.Services.AddSingleton<IProxyConfigProvider>(new InMemoryConfigProvider(routes, clusters));
             return builder;
@@ -26,14 +26,14 @@ namespace Yarp.ReverseProxy.Configuration
     {
         private volatile InMemoryConfig _config;
 
-        public InMemoryConfigProvider(IReadOnlyList<ProxyRoute> routes, IReadOnlyList<Cluster> clusters)
+        public InMemoryConfigProvider(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
         {
             _config = new InMemoryConfig(routes, clusters);
         }
 
         public IProxyConfig GetConfig() => _config;
 
-        public void Update(IReadOnlyList<ProxyRoute> routes, IReadOnlyList<Cluster> clusters)
+        public void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
         {
             var oldConfig = _config;
             _config = new InMemoryConfig(routes, clusters);
@@ -44,14 +44,14 @@ namespace Yarp.ReverseProxy.Configuration
         {
             private readonly CancellationTokenSource _cts = new CancellationTokenSource();
 
-            public InMemoryConfig(IReadOnlyList<ProxyRoute> routes, IReadOnlyList<Cluster> clusters)
+            public InMemoryConfig(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
             {
                 Routes = routes;
                 Clusters = clusters;
                 ChangeToken = new CancellationChangeToken(_cts.Token);
             }
 
-            public IReadOnlyList<ProxyRoute> Routes { get; }
+            public IReadOnlyList<RouteConfig> Routes { get; }
 
             public IReadOnlyList<Cluster> Clusters { get; }
 

--- a/test/ReverseProxy.Tests/Configuration/ConfigurationConfigProviderTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigurationConfigProviderTests.cs
@@ -118,7 +118,7 @@ namespace Yarp.ReverseProxy.Configuration
             },
             Routes =
             {
-                new ProxyRoute
+                new RouteConfig
                 {
                     RouteId = "routeA",
                     ClusterId = "cluster1",
@@ -147,7 +147,7 @@ namespace Yarp.ReverseProxy.Configuration
                     },
                     Metadata = new Dictionary<string, string> { { "routeA-K1", "routeA-V1" }, { "routeA-K2", "routeA-V2" } }
                 },
-                new ProxyRoute
+                new RouteConfig
                 {
                     RouteId = "routeB",
                     ClusterId = "cluster2",

--- a/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
+++ b/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
@@ -86,7 +86,7 @@ namespace Yarp.ReverseProxy.DynamicEndpoint
         private static RouteEndpointBuilder CreateEndpointBuilder(ProxyRoute proxyRoute, Cluster cluster)
         {
             var endpointBuilder = new RouteEndpointBuilder(context => Task.CompletedTask, RoutePatternFactory.Parse(""), 0);
-            var routeConfig = new RouteConfig(
+            var routeConfig = new RouteState(
                 proxyRoute,
                 new ClusterInfo("cluster-1")
                 {

--- a/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
+++ b/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
@@ -86,7 +86,7 @@ namespace Yarp.ReverseProxy.DynamicEndpoint
         private static RouteEndpointBuilder CreateEndpointBuilder(RouteConfig proxyRoute, Cluster cluster)
         {
             var endpointBuilder = new RouteEndpointBuilder(context => Task.CompletedTask, RoutePatternFactory.Parse(""), 0);
-            var routeConfig = new RouteState(
+            var routeConfig = new RouteModel(
                 proxyRoute,
                 new ClusterInfo("cluster-1")
                 {

--- a/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
+++ b/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
@@ -27,9 +27,9 @@ namespace Yarp.ReverseProxy.DynamicEndpoint
                 configured = true;
             });
 
-            var proxyRoute = new RouteConfig();
+            var routeConfig = new RouteConfig();
             var cluster = new Cluster();
-            var endpointBuilder = CreateEndpointBuilder(proxyRoute, cluster);
+            var endpointBuilder = CreateEndpointBuilder(routeConfig, cluster);
 
             var action = Assert.Single(conventions);
             action(endpointBuilder);
@@ -50,9 +50,9 @@ namespace Yarp.ReverseProxy.DynamicEndpoint
                 configured = true;
             });
 
-            var proxyRoute = new RouteConfig();
+            var routeConfig = new RouteConfig();
             var cluster = new Cluster();
-            var endpointBuilder = CreateEndpointBuilder(proxyRoute, cluster);
+            var endpointBuilder = CreateEndpointBuilder(routeConfig, cluster);
 
             var action = Assert.Single(conventions);
             action(endpointBuilder);
@@ -73,9 +73,9 @@ namespace Yarp.ReverseProxy.DynamicEndpoint
                 configured = true;
             });
 
-            var proxyRoute = new RouteConfig();
+            var routeConfig = new RouteConfig();
             var cluster = new Cluster();
-            var endpointBuilder = CreateEndpointBuilder(proxyRoute, cluster);
+            var endpointBuilder = CreateEndpointBuilder(routeConfig, cluster);
 
             var action = Assert.Single(conventions);
             action(endpointBuilder);
@@ -83,11 +83,11 @@ namespace Yarp.ReverseProxy.DynamicEndpoint
             Assert.True(configured);
         }
 
-        private static RouteEndpointBuilder CreateEndpointBuilder(RouteConfig proxyRoute, Cluster cluster)
+        private static RouteEndpointBuilder CreateEndpointBuilder(RouteConfig routeConfig, Cluster cluster)
         {
             var endpointBuilder = new RouteEndpointBuilder(context => Task.CompletedTask, RoutePatternFactory.Parse(""), 0);
             var routeConfig = new RouteModel(
-                proxyRoute,
+                routeConfig,
                 new ClusterInfo("cluster-1")
                 {
                     Config = new ClusterConfig(cluster, default)

--- a/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
+++ b/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
@@ -27,7 +27,7 @@ namespace Yarp.ReverseProxy.DynamicEndpoint
                 configured = true;
             });
 
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             var cluster = new Cluster();
             var endpointBuilder = CreateEndpointBuilder(proxyRoute, cluster);
 
@@ -50,7 +50,7 @@ namespace Yarp.ReverseProxy.DynamicEndpoint
                 configured = true;
             });
 
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             var cluster = new Cluster();
             var endpointBuilder = CreateEndpointBuilder(proxyRoute, cluster);
 
@@ -73,7 +73,7 @@ namespace Yarp.ReverseProxy.DynamicEndpoint
                 configured = true;
             });
 
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             var cluster = new Cluster();
             var endpointBuilder = CreateEndpointBuilder(proxyRoute, cluster);
 
@@ -83,7 +83,7 @@ namespace Yarp.ReverseProxy.DynamicEndpoint
             Assert.True(configured);
         }
 
-        private static RouteEndpointBuilder CreateEndpointBuilder(ProxyRoute proxyRoute, Cluster cluster)
+        private static RouteEndpointBuilder CreateEndpointBuilder(RouteConfig proxyRoute, Cluster cluster)
         {
             var endpointBuilder = new RouteEndpointBuilder(context => Task.CompletedTask, RoutePatternFactory.Parse(""), 0);
             var routeConfig = new RouteState(

--- a/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
+++ b/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
@@ -86,7 +86,7 @@ namespace Yarp.ReverseProxy.DynamicEndpoint
         private static RouteEndpointBuilder CreateEndpointBuilder(RouteConfig routeConfig, Cluster cluster)
         {
             var endpointBuilder = new RouteEndpointBuilder(context => Task.CompletedTask, RoutePatternFactory.Parse(""), 0);
-            var routeConfig = new RouteModel(
+            var routeModel = new RouteModel(
                 routeConfig,
                 new ClusterInfo("cluster-1")
                 {
@@ -94,7 +94,7 @@ namespace Yarp.ReverseProxy.DynamicEndpoint
                 },
                 HttpTransformer.Default);
 
-            endpointBuilder.Metadata.Add(routeConfig);
+            endpointBuilder.Metadata.Add(routeModel);
 
             return endpointBuilder;
         }

--- a/test/ReverseProxy.Tests/IntegrationTests/RoutingTests.cs
+++ b/test/ReverseProxy.Tests/IntegrationTests/RoutingTests.cs
@@ -25,7 +25,7 @@ namespace Yarp.ReverseProxy.IntegrationTests
         {
             var routes = new[]
             {
-                new ProxyRoute()
+                new RouteConfig()
                 {
                     RouteId = "route1",
                     ClusterId = "cluster1",
@@ -51,7 +51,7 @@ namespace Yarp.ReverseProxy.IntegrationTests
         {
             var routes = new[]
             {
-                new ProxyRoute()
+                new RouteConfig()
                 {
                     RouteId = "route1",
                     ClusterId = "cluster1",
@@ -77,7 +77,7 @@ namespace Yarp.ReverseProxy.IntegrationTests
         {
             var routes = new[]
             {
-                new ProxyRoute()
+                new RouteConfig()
                 {
                     RouteId = "route1",
                     ClusterId = "cluster1",
@@ -131,7 +131,7 @@ namespace Yarp.ReverseProxy.IntegrationTests
         {
             var routes = new[]
             {
-                new ProxyRoute()
+                new RouteConfig()
                 {
                     RouteId = "route1",
                     ClusterId = "cluster1",
@@ -148,7 +148,7 @@ namespace Yarp.ReverseProxy.IntegrationTests
                         }
                     }
                 },
-                new ProxyRoute()
+                new RouteConfig()
                 {
                     RouteId = "route2",
                     ClusterId = "cluster1",
@@ -165,7 +165,7 @@ namespace Yarp.ReverseProxy.IntegrationTests
                         }
                     }
                 },
-                new ProxyRoute()
+                new RouteConfig()
                 {
                     RouteId = "route3",
                     ClusterId = "cluster1",
@@ -242,13 +242,13 @@ namespace Yarp.ReverseProxy.IntegrationTests
         {
             var routes = new[]
             {
-                new ProxyRoute()
+                new RouteConfig()
                 {
                     RouteId = "route1",
                     ClusterId = "cluster1",
                     Match = new RouteMatch { Path = "/route1" }
                 },
-                new ProxyRoute()
+                new RouteConfig()
                 {
                     RouteId = "route2",
                     ClusterId = "cluster1",
@@ -258,7 +258,7 @@ namespace Yarp.ReverseProxy.IntegrationTests
                         Methods = new[] { "GET" },
                     }
                 },
-                new ProxyRoute()
+                new RouteConfig()
                 {
                     RouteId = "route3",
                     ClusterId = "cluster1",
@@ -267,7 +267,7 @@ namespace Yarp.ReverseProxy.IntegrationTests
                         Hosts = new[] { "localhost" }
                     }
                 },
-                new ProxyRoute()
+                new RouteConfig()
                 {
                     RouteId = "route4",
                     ClusterId = "cluster1",
@@ -320,7 +320,7 @@ namespace Yarp.ReverseProxy.IntegrationTests
             Assert.Equal("route4", response.Headers.GetValues("route").SingleOrDefault());
         }
 
-        public static Task<IHost> CreateHostAsync(IReadOnlyList<ProxyRoute> routes)
+        public static Task<IHost> CreateHostAsync(IReadOnlyList<RouteConfig> routes)
         {
             var clusters = new[]
             {

--- a/test/ReverseProxy.Tests/Middleware/LoadBalancerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/LoadBalancerMiddlewareTests.cs
@@ -195,7 +195,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
                 });
             context.Features.Set(cluster);
 
-            var routeConfig = new RouteState(new ProxyRoute(), cluster, transformer: null);
+            var routeConfig = new RouteState(new RouteConfig(), cluster, transformer: null);
             var endpoint = new Endpoint(default, new EndpointMetadataCollection(routeConfig), string.Empty);
             context.SetEndpoint(endpoint);
 

--- a/test/ReverseProxy.Tests/Middleware/LoadBalancerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/LoadBalancerMiddlewareTests.cs
@@ -195,7 +195,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
                 });
             context.Features.Set(cluster);
 
-            var routeConfig = new RouteState(new RouteConfig(), cluster, transformer: null);
+            var routeConfig = new RouteModel(new RouteConfig(), cluster, transformer: null);
             var endpoint = new Endpoint(default, new EndpointMetadataCollection(routeConfig), string.Empty);
             context.SetEndpoint(endpoint);
 

--- a/test/ReverseProxy.Tests/Middleware/LoadBalancerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/LoadBalancerMiddlewareTests.cs
@@ -195,7 +195,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
                 });
             context.Features.Set(cluster);
 
-            var routeConfig = new RouteConfig(new ProxyRoute(), cluster, transformer: null);
+            var routeConfig = new RouteState(new ProxyRoute(), cluster, transformer: null);
             var endpoint = new Endpoint(default, new EndpointMetadataCollection(routeConfig), string.Empty);
             context.SetEndpoint(endpoint);
 

--- a/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
@@ -115,7 +115,7 @@ namespace Yarp.ReverseProxy.Middleware
             {
                 ProxiedDestination = destination,
                 ClusterSnapshot = clusterInfo.Config,
-                RouteSnapshot = new RouteConfig(new ProxyRoute(), clusterInfo, HttpTransformer.Default),
+                RouteState = new RouteState(new ProxyRoute(), clusterInfo, HttpTransformer.Default),
             };
         }
 

--- a/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
@@ -115,7 +115,7 @@ namespace Yarp.ReverseProxy.Middleware
             {
                 ProxiedDestination = destination,
                 ClusterSnapshot = clusterInfo.Config,
-                RouteState = new RouteState(new ProxyRoute(), clusterInfo, HttpTransformer.Default),
+                RouteState = new RouteState(new RouteConfig(), clusterInfo, HttpTransformer.Default),
             };
         }
 

--- a/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
@@ -115,7 +115,7 @@ namespace Yarp.ReverseProxy.Middleware
             {
                 ProxiedDestination = destination,
                 ClusterSnapshot = clusterInfo.Config,
-                RouteState = new RouteState(new RouteConfig(), clusterInfo, HttpTransformer.Default),
+                Route = new RouteModel(new RouteConfig(), clusterInfo, HttpTransformer.Default),
             };
         }
 

--- a/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
@@ -57,7 +57,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
                 {
                     Config = new DestinationConfig(new Destination { Address = "https://localhost:123/a/b/" })
                 });
-            var routeConfig = new RouteConfig(
+            var routeConfig = new RouteState(
                 proxyRoute: new ProxyRoute() { RouteId = "Route-1" },
                 cluster: cluster1,
                 transformer: null);
@@ -67,7 +67,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             {
                     AvailableDestinations = new List<DestinationInfo>() { destination1 }.AsReadOnly(),
                     ClusterSnapshot = clusterConfig,
-                    RouteSnapshot = routeConfig,
+                    RouteState = routeConfig,
                 });
             httpContext.Features.Set(cluster1);
 
@@ -137,7 +137,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             var httpClient = new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object);
             var cluster1 = new ClusterInfo(clusterId: "cluster1");
             var clusterConfig = new ClusterConfig(new Cluster(), httpClient);
-            var routeConfig = new RouteConfig(
+            var routeConfig = new RouteState(
                 proxyRoute: new ProxyRoute(),
                 cluster: cluster1,
                 transformer: null);
@@ -146,7 +146,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
                 {
                     AvailableDestinations = Array.Empty<DestinationInfo>(),
                     ClusterSnapshot = clusterConfig,
-                    RouteSnapshot = routeConfig,
+                    RouteState = routeConfig,
                 });
 
             Mock<IHttpProxy>()

--- a/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
@@ -57,8 +57,8 @@ namespace Yarp.ReverseProxy.Middleware.Tests
                 {
                     Config = new DestinationConfig(new Destination { Address = "https://localhost:123/a/b/" })
                 });
-            var routeConfig = new RouteState(
-                proxyRoute: new RouteConfig() { RouteId = "Route-1" },
+            var routeConfig = new RouteModel(
+                config: new RouteConfig() { RouteId = "Route-1" },
                 cluster: cluster1,
                 transformer: null);
 
@@ -67,7 +67,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             {
                     AvailableDestinations = new List<DestinationInfo>() { destination1 }.AsReadOnly(),
                     ClusterSnapshot = clusterConfig,
-                    RouteState = routeConfig,
+                    Route = routeConfig,
                 });
             httpContext.Features.Set(cluster1);
 
@@ -122,7 +122,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             var invoke = Assert.Single(events, e => e.EventName == "ProxyInvoke");
             Assert.Equal(3, invoke.Payload.Count);
             Assert.Equal(cluster1.ClusterId, (string)invoke.Payload[0]);
-            Assert.Equal(routeConfig.ProxyRoute.RouteId, (string)invoke.Payload[1]);
+            Assert.Equal(routeConfig.Config.RouteId, (string)invoke.Payload[1]);
             Assert.Equal(destination1.DestinationId, (string)invoke.Payload[2]);
         }
 
@@ -137,8 +137,8 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             var httpClient = new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object);
             var cluster1 = new ClusterInfo(clusterId: "cluster1");
             var clusterConfig = new ClusterConfig(new Cluster(), httpClient);
-            var routeConfig = new RouteState(
-                proxyRoute: new RouteConfig(),
+            var routeConfig = new RouteModel(
+                config: new RouteConfig(),
                 cluster: cluster1,
                 transformer: null);
             httpContext.Features.Set<IReverseProxyFeature>(
@@ -146,7 +146,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
                 {
                     AvailableDestinations = Array.Empty<DestinationInfo>(),
                     ClusterSnapshot = clusterConfig,
-                    RouteState = routeConfig,
+                    Route = routeConfig,
                 });
 
             Mock<IHttpProxy>()

--- a/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
@@ -58,7 +58,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
                     Config = new DestinationConfig(new Destination { Address = "https://localhost:123/a/b/" })
                 });
             var routeConfig = new RouteState(
-                proxyRoute: new ProxyRoute() { RouteId = "Route-1" },
+                proxyRoute: new RouteConfig() { RouteId = "Route-1" },
                 cluster: cluster1,
                 transformer: null);
 
@@ -138,7 +138,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             var cluster1 = new ClusterInfo(clusterId: "cluster1");
             var clusterConfig = new ClusterConfig(new Cluster(), httpClient);
             var routeConfig = new RouteState(
-                proxyRoute: new ProxyRoute(),
+                proxyRoute: new RouteConfig(),
                 cluster: cluster1,
                 transformer: null);
             httpContext.Features.Set<IReverseProxyFeature>(

--- a/test/ReverseProxy.Tests/Middleware/ProxyPipelineInitializerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyPipelineInitializerMiddlewareTests.cs
@@ -46,7 +46,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             cluster1.ProcessDestinationChanges();
 
             var aspNetCoreEndpoints = new List<Endpoint>();
-            var routeConfig = new RouteConfig(
+            var routeConfig = new RouteState(
                 proxyRoute: new ProxyRoute(),
                 cluster1,
                 transformer: null);
@@ -99,7 +99,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             cluster1.ProcessDestinationChanges();
 
             var aspNetCoreEndpoints = new List<Endpoint>();
-            var routeConfig = new RouteConfig(
+            var routeConfig = new RouteState(
                 proxyRoute: new ProxyRoute(),
                 cluster: cluster1,
                 transformer: null);
@@ -120,7 +120,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             Assert.Equal(StatusCodes.Status418ImATeapot, httpContext.Response.StatusCode);
         }
 
-        private static Endpoint CreateAspNetCoreEndpoint(RouteConfig routeConfig)
+        private static Endpoint CreateAspNetCoreEndpoint(RouteState routeConfig)
         {
             var endpointBuilder = new RouteEndpointBuilder(
                 requestDelegate: httpContext => Task.CompletedTask,

--- a/test/ReverseProxy.Tests/Middleware/ProxyPipelineInitializerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyPipelineInitializerMiddlewareTests.cs
@@ -46,8 +46,8 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             cluster1.ProcessDestinationChanges();
 
             var aspNetCoreEndpoints = new List<Endpoint>();
-            var routeConfig = new RouteState(
-                proxyRoute: new RouteConfig(),
+            var routeConfig = new RouteModel(
+                config: new RouteConfig(),
                 cluster1,
                 transformer: null);
             var aspNetCoreEndpoint = CreateAspNetCoreEndpoint(routeConfig);
@@ -99,8 +99,8 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             cluster1.ProcessDestinationChanges();
 
             var aspNetCoreEndpoints = new List<Endpoint>();
-            var routeConfig = new RouteState(
-                proxyRoute: new RouteConfig(),
+            var routeConfig = new RouteModel(
+                config: new RouteConfig(),
                 cluster: cluster1,
                 transformer: null);
             var aspNetCoreEndpoint = CreateAspNetCoreEndpoint(routeConfig);
@@ -120,7 +120,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             Assert.Equal(StatusCodes.Status418ImATeapot, httpContext.Response.StatusCode);
         }
 
-        private static Endpoint CreateAspNetCoreEndpoint(RouteState routeConfig)
+        private static Endpoint CreateAspNetCoreEndpoint(RouteModel routeConfig)
         {
             var endpointBuilder = new RouteEndpointBuilder(
                 requestDelegate: httpContext => Task.CompletedTask,

--- a/test/ReverseProxy.Tests/Middleware/ProxyPipelineInitializerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyPipelineInitializerMiddlewareTests.cs
@@ -47,7 +47,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
 
             var aspNetCoreEndpoints = new List<Endpoint>();
             var routeConfig = new RouteState(
-                proxyRoute: new ProxyRoute(),
+                proxyRoute: new RouteConfig(),
                 cluster1,
                 transformer: null);
             var aspNetCoreEndpoint = CreateAspNetCoreEndpoint(routeConfig);
@@ -100,7 +100,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
 
             var aspNetCoreEndpoints = new List<Endpoint>();
             var routeConfig = new RouteState(
-                proxyRoute: new ProxyRoute(),
+                proxyRoute: new RouteConfig(),
                 cluster: cluster1,
                 transformer: null);
             var aspNetCoreEndpoint = CreateAspNetCoreEndpoint(routeConfig);

--- a/test/ReverseProxy.Tests/Middleware/SessionAffinityMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/SessionAffinityMiddlewareTests.cs
@@ -200,8 +200,8 @@ namespace Yarp.ReverseProxy.Middleware
 
         internal Endpoint GetEndpoint(ClusterInfo cluster)
         {
-            var proxyRoute = new RouteConfig();
-            var routeConfig = new RouteModel(proxyRoute, cluster, HttpTransformer.Default);
+            var routeConfig = new RouteConfig();
+            var routeConfig = new RouteModel(routeConfig, cluster, HttpTransformer.Default);
             var endpoint = new Endpoint(default, new EndpointMetadataCollection(routeConfig), string.Empty);
             return endpoint;
         }

--- a/test/ReverseProxy.Tests/Middleware/SessionAffinityMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/SessionAffinityMiddlewareTests.cs
@@ -200,7 +200,7 @@ namespace Yarp.ReverseProxy.Middleware
 
         internal Endpoint GetEndpoint(ClusterInfo cluster)
         {
-            var proxyRoute = new ProxyRoute();
+            var proxyRoute = new RouteConfig();
             var routeConfig = new RouteState(proxyRoute, cluster, HttpTransformer.Default);
             var endpoint = new Endpoint(default, new EndpointMetadataCollection(routeConfig), string.Empty);
             return endpoint;

--- a/test/ReverseProxy.Tests/Middleware/SessionAffinityMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/SessionAffinityMiddlewareTests.cs
@@ -201,8 +201,8 @@ namespace Yarp.ReverseProxy.Middleware
         internal Endpoint GetEndpoint(ClusterInfo cluster)
         {
             var routeConfig = new RouteConfig();
-            var routeConfig = new RouteModel(routeConfig, cluster, HttpTransformer.Default);
-            var endpoint = new Endpoint(default, new EndpointMetadataCollection(routeConfig), string.Empty);
+            var routeModel = new RouteModel(routeConfig, cluster, HttpTransformer.Default);
+            var endpoint = new Endpoint(default, new EndpointMetadataCollection(routeModel), string.Empty);
             return endpoint;
         }
     }

--- a/test/ReverseProxy.Tests/Middleware/SessionAffinityMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/SessionAffinityMiddlewareTests.cs
@@ -201,7 +201,7 @@ namespace Yarp.ReverseProxy.Middleware
         internal Endpoint GetEndpoint(ClusterInfo cluster)
         {
             var proxyRoute = new ProxyRoute();
-            var routeConfig = new RouteConfig(proxyRoute, cluster, HttpTransformer.Default);
+            var routeConfig = new RouteState(proxyRoute, cluster, HttpTransformer.Default);
             var endpoint = new Endpoint(default, new EndpointMetadataCollection(routeConfig), string.Empty);
             return endpoint;
         }

--- a/test/ReverseProxy.Tests/Middleware/SessionAffinityMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/SessionAffinityMiddlewareTests.cs
@@ -201,7 +201,7 @@ namespace Yarp.ReverseProxy.Middleware
         internal Endpoint GetEndpoint(ClusterInfo cluster)
         {
             var proxyRoute = new RouteConfig();
-            var routeConfig = new RouteState(proxyRoute, cluster, HttpTransformer.Default);
+            var routeConfig = new RouteModel(proxyRoute, cluster, HttpTransformer.Default);
             var endpoint = new Endpoint(default, new EndpointMetadataCollection(routeConfig), string.Empty);
             return endpoint;
         }

--- a/test/ReverseProxy.Tests/Service/Config/ConfigValidatorTests.cs
+++ b/test/ReverseProxy.Tests/Service/Config/ConfigValidatorTests.cs
@@ -55,7 +55,7 @@ namespace Yarp.ReverseProxy.Service.Tests
         [InlineData("a-b.b-c.example.com", null, null)]
         public async Task Accepts_ValidRules(string host, string path, string methods)
         {
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 Match = new RouteMatch
@@ -80,7 +80,7 @@ namespace Yarp.ReverseProxy.Service.Tests
         [InlineData(null)]
         public async Task Rejects_MissingRouteId(string routeId)
         {
-            var route = new ProxyRoute { RouteId = routeId };
+            var route = new RouteConfig { RouteId = routeId };
 
             var services = CreateServices();
             var validator = services.GetRequiredService<IConfigValidator>();
@@ -94,7 +94,7 @@ namespace Yarp.ReverseProxy.Service.Tests
         [Fact]
         public async Task Rejects_MissingMatch()
         {
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 ClusterId = "cluster1",
@@ -116,7 +116,7 @@ namespace Yarp.ReverseProxy.Service.Tests
         [InlineData("Xn--nicode-2ya")]
         public async Task Rejects_InvalidHost(string host)
         {
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 Match = new RouteMatch
@@ -143,7 +143,7 @@ namespace Yarp.ReverseProxy.Service.Tests
         [InlineData("", "")]
         public async Task Rejects_MissingHostAndPath(string host, string path)
         {
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 ClusterId = "cluster1",
@@ -170,7 +170,7 @@ namespace Yarp.ReverseProxy.Service.Tests
         [InlineData("/{ab/c}")]
         public async Task Rejects_InvalidPath(string path)
         {
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 Match = new RouteMatch()
@@ -194,7 +194,7 @@ namespace Yarp.ReverseProxy.Service.Tests
         [InlineData("gett")]
         public async Task Rejects_InvalidMethod(string methods)
         {
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 Match = new RouteMatch
@@ -218,7 +218,7 @@ namespace Yarp.ReverseProxy.Service.Tests
         [InlineData("get,post,get")]
         public async Task Rejects_DuplicateMethod(string methods)
         {
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 Match = new RouteMatch
@@ -240,7 +240,7 @@ namespace Yarp.ReverseProxy.Service.Tests
         [Fact]
         public async Task Accepts_RouteHeader()
         {
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 Match = new RouteMatch
@@ -269,7 +269,7 @@ namespace Yarp.ReverseProxy.Service.Tests
         [Fact]
         public async Task Accepts_RouteHeader_ExistsWithNoValue()
         {
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 Match = new RouteMatch
@@ -298,7 +298,7 @@ namespace Yarp.ReverseProxy.Service.Tests
         [Fact]
         public async Task Rejects_NullRouteHeader()
         {
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 Match = new RouteMatch
@@ -331,7 +331,7 @@ namespace Yarp.ReverseProxy.Service.Tests
                 Values = value == null ? null : new[] { value },
             };
 
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 Match = new RouteMatch
@@ -357,7 +357,7 @@ namespace Yarp.ReverseProxy.Service.Tests
         [InlineData("defaulT")]
         public async Task Accepts_ReservedAuthorizationPolicy(string policy)
         {
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 AuthorizationPolicy = policy,
@@ -379,7 +379,7 @@ namespace Yarp.ReverseProxy.Service.Tests
         [Fact]
         public async Task Accepts_CustomAuthorizationPolicy()
         {
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 AuthorizationPolicy = "custom",
@@ -407,7 +407,7 @@ namespace Yarp.ReverseProxy.Service.Tests
         [Fact]
         public async Task Rejects_UnknownAuthorizationPolicy()
         {
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 AuthorizationPolicy = "unknown",
@@ -429,7 +429,7 @@ namespace Yarp.ReverseProxy.Service.Tests
         [InlineData("Anonymous")]
         public async Task Rejects_ReservedAuthorizationPolicyIsUsed(string authorizationPolicy)
         {
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 AuthorizationPolicy = authorizationPolicy,
@@ -462,7 +462,7 @@ namespace Yarp.ReverseProxy.Service.Tests
         [InlineData("disAble")]
         public async Task Accepts_ReservedCorsPolicy(string policy)
         {
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 CorsPolicy = policy,
@@ -484,7 +484,7 @@ namespace Yarp.ReverseProxy.Service.Tests
         [Fact]
         public async Task Accepts_CustomCorsPolicy()
         {
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 CorsPolicy = "custom",
@@ -512,7 +512,7 @@ namespace Yarp.ReverseProxy.Service.Tests
         [Fact]
         public async Task Rejects_UnknownCorsPolicy()
         {
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 CorsPolicy = "unknown",
@@ -534,7 +534,7 @@ namespace Yarp.ReverseProxy.Service.Tests
         [InlineData("Disable")]
         public async Task Rejects_ReservedCorsPolicyIsUsed(string corsPolicy)
         {
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 CorsPolicy = corsPolicy,

--- a/test/ReverseProxy.Tests/Service/Config/TransformBuilderTests.cs
+++ b/test/ReverseProxy.Tests/Service/Config/TransformBuilderTests.cs
@@ -41,7 +41,7 @@ namespace Yarp.ReverseProxy.Service.Config
         {
             var transformBuilder = CreateTransformBuilder();
 
-            var route = new ProxyRoute { Transforms = transforms };
+            var route = new RouteConfig { Transforms = transforms };
             var errors = transformBuilder.ValidateRoute(route);
             Assert.Empty(errors);
 
@@ -115,7 +115,7 @@ namespace Yarp.ReverseProxy.Service.Config
                 new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), // Empty
             };
 
-            var route = new ProxyRoute() { Transforms = transforms };
+            var route = new RouteConfig() { Transforms = transforms };
             var errors = transformBuilder.ValidateRoute(route);
             var error = Assert.Single(errors);
             Assert.Equal("Unknown transform: ", error.Message);
@@ -142,7 +142,7 @@ namespace Yarp.ReverseProxy.Service.Config
                 },
             };
 
-            var route = new ProxyRoute() { Transforms = transforms };
+            var route = new RouteConfig() { Transforms = transforms };
             var errors = transformBuilder.ValidateRoute(route);
             //All errors reported
             Assert.Equal(2, errors.Count);
@@ -162,7 +162,7 @@ namespace Yarp.ReverseProxy.Service.Config
             var builder = new TransformBuilder(new ServiceCollection().BuildServiceProvider(),
                 new[] { factory1, factory2, factory3 }, Array.Empty<ITransformProvider>());
 
-            var route = new ProxyRoute().WithTransform(transform =>
+            var route = new RouteConfig().WithTransform(transform =>
             {
                 transform["2"] = "B";
             });
@@ -189,7 +189,7 @@ namespace Yarp.ReverseProxy.Service.Config
             var builder = new TransformBuilder(new ServiceCollection().BuildServiceProvider(),
                 Array.Empty<ITransformFactory>(), new[] { provider1, provider2, provider3 });
 
-            var route = new ProxyRoute();
+            var route = new RouteConfig();
             var errors = builder.ValidateRoute(route);
             Assert.Empty(errors);
             Assert.Equal(1, provider1.ValidateRouteCalls);
@@ -227,7 +227,7 @@ namespace Yarp.ReverseProxy.Service.Config
                 },
             };
 
-            var route = new ProxyRoute() { Transforms = transforms };
+            var route = new RouteConfig() { Transforms = transforms };
             var errors = transformBuilder.ValidateRoute(route);
             Assert.Empty(errors);
 
@@ -273,7 +273,7 @@ namespace Yarp.ReverseProxy.Service.Config
                 });
             }
 
-            var route = new ProxyRoute() { Transforms = transforms };
+            var route = new RouteConfig() { Transforms = transforms };
             var errors = transformBuilder.ValidateRoute(route);
             Assert.Empty(errors);
 
@@ -358,7 +358,7 @@ namespace Yarp.ReverseProxy.Service.Config
                 });
             }
 
-            var route = new ProxyRoute() { Transforms = transforms };
+            var route = new RouteConfig() { Transforms = transforms };
             var errors = transformBuilder.ValidateRoute(route);
             Assert.Empty(errors);
 
@@ -391,7 +391,7 @@ namespace Yarp.ReverseProxy.Service.Config
                 },
             };
 
-            var route = new ProxyRoute() { Transforms = transforms };
+            var route = new RouteConfig() { Transforms = transforms };
             var errors = transformBuilder.ValidateRoute(route);
             Assert.Empty(errors);
 

--- a/test/ReverseProxy.Tests/Service/DynamicEndpoint/ProxyEndpointFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Service/DynamicEndpoint/ProxyEndpointFactoryTests.cs
@@ -51,7 +51,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Order = 12,
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteInfo("route1");
+            var routeInfo = new RouteEntity("route1");
 
             var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeInfo, route, cluster);
 
@@ -68,7 +68,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             Assert.Equal("example.com", hostMetadata.Hosts[0]);
         }
 
-        private (RouteEndpoint routeEndpoint, RouteConfig routeConfig) CreateEndpoint(ProxyEndpointFactory factory, RouteInfo routeInfo, ProxyRoute proxyRoute, ClusterInfo clusterInfo)
+        private (RouteEndpoint routeEndpoint, RouteConfig routeConfig) CreateEndpoint(ProxyEndpointFactory factory, RouteEntity routeInfo, ProxyRoute proxyRoute, ClusterInfo clusterInfo)
         {
             routeInfo.ClusterRevision = clusterInfo.Revision;
             var routeConfig = new RouteConfig(proxyRoute, clusterInfo, HttpTransformer.Default);
@@ -97,7 +97,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Order = 12,
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteInfo("route1");
+            var routeInfo = new RouteEntity("route1");
 
             var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeInfo, route, cluster);
 
@@ -131,7 +131,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Order = 12,
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteInfo("route1");
+            var routeInfo = new RouteEntity("route1");
 
             var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeInfo, route, cluster);
 
@@ -165,7 +165,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Order = 12,
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteInfo("route1");
+            var routeInfo = new RouteEntity("route1");
 
             var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeInfo, route, cluster);
 
@@ -194,7 +194,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Match = new RouteMatch()
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteInfo("route1");
+            var routeInfo = new RouteEntity("route1");
 
             var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeInfo, route, cluster);
 
@@ -226,7 +226,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Order = 12,
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteInfo("route1");
+            var routeInfo = new RouteEntity("route1");
 
             Action action = () => CreateEndpoint(factory, routeInfo, route, cluster);
 
@@ -248,7 +248,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Match = new RouteMatch(),
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteInfo("route1");
+            var routeInfo = new RouteEntity("route1");
 
             var (routeEndpoint, _) = CreateEndpoint(factory, routeInfo, route, cluster);
 
@@ -271,7 +271,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Match = new RouteMatch(),
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteInfo("route1");
+            var routeInfo = new RouteEntity("route1");
 
             var (routeEndpoint, _) = CreateEndpoint(factory, routeInfo, route, cluster);
 
@@ -293,7 +293,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Match = new RouteMatch(),
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteInfo("route1");
+            var routeInfo = new RouteEntity("route1");
 
             var (routeEndpoint, _) = CreateEndpoint(factory, routeInfo, route, cluster);
 
@@ -315,7 +315,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Match = new RouteMatch(),
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteInfo("route1");
+            var routeInfo = new RouteEntity("route1");
 
             var (routeEndpoint, _) = CreateEndpoint(factory, routeInfo, route, cluster);
 
@@ -338,7 +338,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Match = new RouteMatch(),
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteInfo("route1");
+            var routeInfo = new RouteEntity("route1");
 
             var (routeEndpoint, _) = CreateEndpoint(factory, routeInfo, route, cluster);
 
@@ -362,7 +362,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Match = new RouteMatch(),
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteInfo("route1");
+            var routeInfo = new RouteEntity("route1");
 
             var (routeEndpoint, _) = CreateEndpoint(factory, routeInfo, route, cluster);
 
@@ -386,7 +386,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Match = new RouteMatch(),
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteInfo("route1");
+            var routeInfo = new RouteEntity("route1");
 
             var (routeEndpoint, _) = CreateEndpoint(factory, routeInfo, route, cluster);
 
@@ -408,7 +408,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Match = new RouteMatch(),
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteInfo("route1");
+            var routeInfo = new RouteEntity("route1");
 
             var (routeEndpoint, _) = CreateEndpoint(factory, routeInfo, route, cluster);
 
@@ -442,7 +442,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 },
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteInfo("route1");
+            var routeInfo = new RouteEntity("route1");
 
             var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeInfo, route, cluster);
 
@@ -492,7 +492,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 },
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteInfo("route1");
+            var routeInfo = new RouteEntity("route1");
 
             var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeInfo, route, cluster);
 

--- a/test/ReverseProxy.Tests/Service/DynamicEndpoint/ProxyEndpointFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Service/DynamicEndpoint/ProxyEndpointFactoryTests.cs
@@ -57,7 +57,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
 
             Assert.Same(cluster, routeConfig.Cluster);
             Assert.Equal("route1", routeEndpoint.DisplayName);
-            Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteState>());
+            Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteModel>());
             Assert.Equal("/a", routeEndpoint.RoutePattern.RawText);
             Assert.Equal(12, routeEndpoint.Order);
             Assert.False(routeConfig.HasConfigChanged(route, cluster, routeInfo.ClusterRevision));
@@ -68,10 +68,10 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             Assert.Equal("example.com", hostMetadata.Hosts[0]);
         }
 
-        private (RouteEndpoint routeEndpoint, RouteState routeConfig) CreateEndpoint(ProxyEndpointFactory factory, RouteEntity routeInfo, RouteConfig proxyRoute, ClusterInfo clusterInfo)
+        private (RouteEndpoint routeEndpoint, RouteModel routeConfig) CreateEndpoint(ProxyEndpointFactory factory, RouteEntity routeInfo, RouteConfig proxyRoute, ClusterInfo clusterInfo)
         {
             routeInfo.ClusterRevision = clusterInfo.Revision;
-            var routeConfig = new RouteState(proxyRoute, clusterInfo, HttpTransformer.Default);
+            var routeConfig = new RouteModel(proxyRoute, clusterInfo, HttpTransformer.Default);
 
             var endpoint = factory.CreateEndpoint(routeConfig, Array.Empty<Action<EndpointBuilder>>());
 
@@ -103,7 +103,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
 
             Assert.Same(cluster, routeConfig.Cluster);
             Assert.Equal("route1", routeEndpoint.DisplayName);
-            Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteState>());
+            Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteModel>());
             Assert.Equal("/{**catchall}", routeEndpoint.RoutePattern.RawText);
             Assert.Equal(12, routeEndpoint.Order);
             Assert.False(routeConfig.HasConfigChanged(route, cluster, routeInfo.ClusterRevision));
@@ -137,7 +137,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
 
             Assert.Same(cluster, routeConfig.Cluster);
             Assert.Equal("route1", routeEndpoint.DisplayName);
-            Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteState>());
+            Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteModel>());
             Assert.Equal("/{**catchall}", routeEndpoint.RoutePattern.RawText);
             Assert.Equal(12, routeEndpoint.Order);
             Assert.False(routeConfig.HasConfigChanged(route, cluster, routeInfo.ClusterRevision));
@@ -171,7 +171,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
 
             Assert.Same(cluster, routeConfig.Cluster);
             Assert.Equal("route1", routeEndpoint.DisplayName);
-            Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteState>());
+            Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteModel>());
             Assert.Equal("/a", routeEndpoint.RoutePattern.RawText);
             Assert.Equal(12, routeEndpoint.Order);
             Assert.False(routeConfig.HasConfigChanged(route, cluster, routeInfo.ClusterRevision));
@@ -200,7 +200,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
 
             Assert.Same(cluster, routeConfig.Cluster);
             Assert.Equal("route1", routeEndpoint.DisplayName);
-            Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteState>());
+            Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteModel>());
             Assert.Equal("/{**catchall}", routeEndpoint.RoutePattern.RawText);
             Assert.Equal(12, routeEndpoint.Order);
             Assert.False(routeConfig.HasConfigChanged(route, cluster, routeInfo.ClusterRevision));

--- a/test/ReverseProxy.Tests/Service/DynamicEndpoint/ProxyEndpointFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Service/DynamicEndpoint/ProxyEndpointFactoryTests.cs
@@ -51,16 +51,16 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Order = 12,
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteEntity("route1");
+            var routeState = new RouteState("route1");
 
-            var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeInfo, route, cluster);
+            var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeState, route, cluster);
 
             Assert.Same(cluster, routeConfig.Cluster);
             Assert.Equal("route1", routeEndpoint.DisplayName);
             Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteModel>());
             Assert.Equal("/a", routeEndpoint.RoutePattern.RawText);
             Assert.Equal(12, routeEndpoint.Order);
-            Assert.False(routeConfig.HasConfigChanged(route, cluster, routeInfo.ClusterRevision));
+            Assert.False(routeConfig.HasConfigChanged(route, cluster, routeState.ClusterRevision));
 
             var hostMetadata = routeEndpoint.Metadata.GetMetadata<HostAttribute>();
             Assert.NotNull(hostMetadata);
@@ -68,9 +68,9 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             Assert.Equal("example.com", hostMetadata.Hosts[0]);
         }
 
-        private (RouteEndpoint routeEndpoint, RouteModel routeConfig) CreateEndpoint(ProxyEndpointFactory factory, RouteEntity routeInfo, RouteConfig proxyRoute, ClusterInfo clusterInfo)
+        private (RouteEndpoint routeEndpoint, RouteModel routeConfig) CreateEndpoint(ProxyEndpointFactory factory, RouteState routeState, RouteConfig proxyRoute, ClusterInfo clusterInfo)
         {
-            routeInfo.ClusterRevision = clusterInfo.Revision;
+            routeState.ClusterRevision = clusterInfo.Revision;
             var routeConfig = new RouteModel(proxyRoute, clusterInfo, HttpTransformer.Default);
 
             var endpoint = factory.CreateEndpoint(routeConfig, Array.Empty<Action<EndpointBuilder>>());
@@ -97,16 +97,16 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Order = 12,
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteEntity("route1");
+            var routeState = new RouteState("route1");
 
-            var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeInfo, route, cluster);
+            var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeState, route, cluster);
 
             Assert.Same(cluster, routeConfig.Cluster);
             Assert.Equal("route1", routeEndpoint.DisplayName);
             Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteModel>());
             Assert.Equal("/{**catchall}", routeEndpoint.RoutePattern.RawText);
             Assert.Equal(12, routeEndpoint.Order);
-            Assert.False(routeConfig.HasConfigChanged(route, cluster, routeInfo.ClusterRevision));
+            Assert.False(routeConfig.HasConfigChanged(route, cluster, routeState.ClusterRevision));
 
             var hostMetadata = routeEndpoint.Metadata.GetMetadata<HostAttribute>();
             Assert.NotNull(hostMetadata);
@@ -131,16 +131,16 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Order = 12,
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteEntity("route1");
+            var routeState = new RouteState("route1");
 
-            var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeInfo, route, cluster);
+            var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeState, route, cluster);
 
             Assert.Same(cluster, routeConfig.Cluster);
             Assert.Equal("route1", routeEndpoint.DisplayName);
             Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteModel>());
             Assert.Equal("/{**catchall}", routeEndpoint.RoutePattern.RawText);
             Assert.Equal(12, routeEndpoint.Order);
-            Assert.False(routeConfig.HasConfigChanged(route, cluster, routeInfo.ClusterRevision));
+            Assert.False(routeConfig.HasConfigChanged(route, cluster, routeState.ClusterRevision));
 
             var hostMetadata = routeEndpoint.Metadata.GetMetadata<HostAttribute>();
             Assert.NotNull(hostMetadata);
@@ -165,16 +165,16 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Order = 12,
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteEntity("route1");
+            var routeState = new RouteState("route1");
 
-            var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeInfo, route, cluster);
+            var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeState, route, cluster);
 
             Assert.Same(cluster, routeConfig.Cluster);
             Assert.Equal("route1", routeEndpoint.DisplayName);
             Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteModel>());
             Assert.Equal("/a", routeEndpoint.RoutePattern.RawText);
             Assert.Equal(12, routeEndpoint.Order);
-            Assert.False(routeConfig.HasConfigChanged(route, cluster, routeInfo.ClusterRevision));
+            Assert.False(routeConfig.HasConfigChanged(route, cluster, routeState.ClusterRevision));
 
             var hostMetadata = routeEndpoint.Metadata.GetMetadata<HostAttribute>();
             Assert.Null(hostMetadata);
@@ -194,16 +194,16 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Match = new RouteMatch()
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteEntity("route1");
+            var routeState = new RouteState("route1");
 
-            var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeInfo, route, cluster);
+            var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeState, route, cluster);
 
             Assert.Same(cluster, routeConfig.Cluster);
             Assert.Equal("route1", routeEndpoint.DisplayName);
             Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteModel>());
             Assert.Equal("/{**catchall}", routeEndpoint.RoutePattern.RawText);
             Assert.Equal(12, routeEndpoint.Order);
-            Assert.False(routeConfig.HasConfigChanged(route, cluster, routeInfo.ClusterRevision));
+            Assert.False(routeConfig.HasConfigChanged(route, cluster, routeState.ClusterRevision));
 
             var hostMetadata = routeEndpoint.Metadata.GetMetadata<HostAttribute>();
             Assert.Null(hostMetadata);
@@ -226,9 +226,9 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Order = 12,
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteEntity("route1");
+            var routeState = new RouteState("route1");
 
-            Action action = () => CreateEndpoint(factory, routeInfo, route, cluster);
+            Action action = () => CreateEndpoint(factory, routeState, route, cluster);
 
             Assert.Throws<RoutePatternException>(action);
         }
@@ -248,9 +248,9 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Match = new RouteMatch(),
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteEntity("route1");
+            var routeState = new RouteState("route1");
 
-            var (routeEndpoint, _) = CreateEndpoint(factory, routeInfo, route, cluster);
+            var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
 
             var attribute = Assert.IsType<AuthorizeAttribute>(routeEndpoint.Metadata.GetMetadata<IAuthorizeData>());
             Assert.Null(attribute.Policy);
@@ -271,9 +271,9 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Match = new RouteMatch(),
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteEntity("route1");
+            var routeState = new RouteState("route1");
 
-            var (routeEndpoint, _) = CreateEndpoint(factory, routeInfo, route, cluster);
+            var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
 
             Assert.IsType<AllowAnonymousAttribute>(routeEndpoint.Metadata.GetMetadata<IAllowAnonymous>());
         }
@@ -293,9 +293,9 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Match = new RouteMatch(),
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteEntity("route1");
+            var routeState = new RouteState("route1");
 
-            var (routeEndpoint, _) = CreateEndpoint(factory, routeInfo, route, cluster);
+            var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
 
             var attribute = Assert.IsType<AuthorizeAttribute>(routeEndpoint.Metadata.GetMetadata<IAuthorizeData>());
             Assert.Equal("custom", attribute.Policy);
@@ -315,9 +315,9 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Match = new RouteMatch(),
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteEntity("route1");
+            var routeState = new RouteState("route1");
 
-            var (routeEndpoint, _) = CreateEndpoint(factory, routeInfo, route, cluster);
+            var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
 
             Assert.Null(routeEndpoint.Metadata.GetMetadata<IAuthorizeData>());
             Assert.Null(routeEndpoint.Metadata.GetMetadata<IAllowAnonymous>());
@@ -338,9 +338,9 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Match = new RouteMatch(),
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteEntity("route1");
+            var routeState = new RouteState("route1");
 
-            var (routeEndpoint, _) = CreateEndpoint(factory, routeInfo, route, cluster);
+            var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
 
             var attribute = Assert.IsType<EnableCorsAttribute>(routeEndpoint.Metadata.GetMetadata<IEnableCorsAttribute>());
             Assert.Null(attribute.PolicyName);
@@ -362,9 +362,9 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Match = new RouteMatch(),
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteEntity("route1");
+            var routeState = new RouteState("route1");
 
-            var (routeEndpoint, _) = CreateEndpoint(factory, routeInfo, route, cluster);
+            var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
 
             var attribute = Assert.IsType<EnableCorsAttribute>(routeEndpoint.Metadata.GetMetadata<IEnableCorsAttribute>());
             Assert.Equal("custom", attribute.PolicyName);
@@ -386,9 +386,9 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Match = new RouteMatch(),
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteEntity("route1");
+            var routeState = new RouteState("route1");
 
-            var (routeEndpoint, _) = CreateEndpoint(factory, routeInfo, route, cluster);
+            var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
 
             Assert.IsType<DisableCorsAttribute>(routeEndpoint.Metadata.GetMetadata<IDisableCorsAttribute>());
             Assert.Null(routeEndpoint.Metadata.GetMetadata<IEnableCorsAttribute>());
@@ -408,9 +408,9 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Match = new RouteMatch(),
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteEntity("route1");
+            var routeState = new RouteState("route1");
 
-            var (routeEndpoint, _) = CreateEndpoint(factory, routeInfo, route, cluster);
+            var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
 
             Assert.Null(routeEndpoint.Metadata.GetMetadata<IEnableCorsAttribute>());
             Assert.Null(routeEndpoint.Metadata.GetMetadata<IDisableCorsAttribute>());
@@ -442,9 +442,9 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 },
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteEntity("route1");
+            var routeState = new RouteState("route1");
 
-            var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeInfo, route, cluster);
+            var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeState, route, cluster);
 
             Assert.Same(cluster, routeConfig.Cluster);
             Assert.Equal("route1", routeEndpoint.DisplayName);
@@ -458,7 +458,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             Assert.Equal(HeaderMatchMode.HeaderPrefix, matcher.Mode);
             Assert.True(matcher.IsCaseSensitive);
 
-            Assert.False(routeConfig.HasConfigChanged(route, cluster, routeInfo.ClusterRevision));
+            Assert.False(routeConfig.HasConfigChanged(route, cluster, routeState.ClusterRevision));
         }
 
         [Fact]
@@ -492,9 +492,9 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 },
             };
             var cluster = new ClusterInfo("cluster1");
-            var routeInfo = new RouteEntity("route1");
+            var routeState = new RouteState("route1");
 
-            var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeInfo, route, cluster);
+            var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeState, route, cluster);
 
             Assert.Same(cluster, routeConfig.Cluster);
             Assert.Equal("route1", routeEndpoint.DisplayName);
@@ -515,7 +515,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             Assert.Equal(HeaderMatchMode.Exists, secondMetadata.Mode);
             Assert.False(secondMetadata.IsCaseSensitive);
 
-            Assert.False(routeConfig.HasConfigChanged(route, cluster, routeInfo.ClusterRevision));
+            Assert.False(routeConfig.HasConfigChanged(route, cluster, routeState.ClusterRevision));
         }
     }
 }

--- a/test/ReverseProxy.Tests/Service/DynamicEndpoint/ProxyEndpointFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Service/DynamicEndpoint/ProxyEndpointFactoryTests.cs
@@ -40,7 +40,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             var factory = services.GetRequiredService<ProxyEndpointFactory>();
             factory.SetProxyPipeline(context => Task.CompletedTask);
 
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 Match = new RouteMatch
@@ -68,7 +68,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             Assert.Equal("example.com", hostMetadata.Hosts[0]);
         }
 
-        private (RouteEndpoint routeEndpoint, RouteState routeConfig) CreateEndpoint(ProxyEndpointFactory factory, RouteEntity routeInfo, ProxyRoute proxyRoute, ClusterInfo clusterInfo)
+        private (RouteEndpoint routeEndpoint, RouteState routeConfig) CreateEndpoint(ProxyEndpointFactory factory, RouteEntity routeInfo, RouteConfig proxyRoute, ClusterInfo clusterInfo)
         {
             routeInfo.ClusterRevision = clusterInfo.Revision;
             var routeConfig = new RouteState(proxyRoute, clusterInfo, HttpTransformer.Default);
@@ -87,7 +87,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             var factory = services.GetRequiredService<ProxyEndpointFactory>();
             factory.SetProxyPipeline(context => Task.CompletedTask);
 
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 Match = new RouteMatch
@@ -121,7 +121,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             var factory = services.GetRequiredService<ProxyEndpointFactory>();
             factory.SetProxyPipeline(context => Task.CompletedTask);
 
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 Match = new RouteMatch
@@ -155,7 +155,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             var factory = services.GetRequiredService<ProxyEndpointFactory>();
             factory.SetProxyPipeline(context => Task.CompletedTask);
 
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 Match = new RouteMatch
@@ -187,7 +187,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             var factory = services.GetRequiredService<ProxyEndpointFactory>();
             factory.SetProxyPipeline(context => Task.CompletedTask);
 
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 Order = 12,
@@ -216,7 +216,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             var factory = services.GetRequiredService<ProxyEndpointFactory>();
             factory.SetProxyPipeline(context => Task.CompletedTask);
 
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 Match = new RouteMatch
@@ -240,7 +240,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             var factory = services.GetRequiredService<ProxyEndpointFactory>();
             factory.SetProxyPipeline(context => Task.CompletedTask);
 
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 AuthorizationPolicy = "defaulT",
@@ -263,7 +263,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             var factory = services.GetRequiredService<ProxyEndpointFactory>();
             factory.SetProxyPipeline(context => Task.CompletedTask);
 
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 AuthorizationPolicy = "AnonymouS",
@@ -285,7 +285,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             var factory = services.GetRequiredService<ProxyEndpointFactory>();
             factory.SetProxyPipeline(context => Task.CompletedTask);
 
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 AuthorizationPolicy = "custom",
@@ -308,7 +308,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             var factory = services.GetRequiredService<ProxyEndpointFactory>();
             factory.SetProxyPipeline(context => Task.CompletedTask);
 
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 Order = 12,
@@ -330,7 +330,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             var factory = services.GetRequiredService<ProxyEndpointFactory>();
             factory.SetProxyPipeline(context => Task.CompletedTask);
 
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 CorsPolicy = "defaulT",
@@ -354,7 +354,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             var factory = services.GetRequiredService<ProxyEndpointFactory>();
             factory.SetProxyPipeline(context => Task.CompletedTask);
 
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 CorsPolicy = "custom",
@@ -378,7 +378,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             var factory = services.GetRequiredService<ProxyEndpointFactory>();
             factory.SetProxyPipeline(context => Task.CompletedTask);
 
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 CorsPolicy = "disAble",
@@ -401,7 +401,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             var factory = services.GetRequiredService<ProxyEndpointFactory>();
             factory.SetProxyPipeline(context => Task.CompletedTask);
 
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 Order = 12,
@@ -423,7 +423,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             var factory = services.GetRequiredService<ProxyEndpointFactory>();
             factory.SetProxyPipeline(context => Task.CompletedTask);
 
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 Match = new RouteMatch
@@ -468,7 +468,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             var factory = services.GetRequiredService<ProxyEndpointFactory>();
             factory.SetProxyPipeline(context => Task.CompletedTask);
 
-            var route = new ProxyRoute
+            var route = new RouteConfig
             {
                 RouteId = "route1",
                 Match = new RouteMatch

--- a/test/ReverseProxy.Tests/Service/DynamicEndpoint/ProxyEndpointFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Service/DynamicEndpoint/ProxyEndpointFactoryTests.cs
@@ -68,16 +68,16 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             Assert.Equal("example.com", hostMetadata.Hosts[0]);
         }
 
-        private (RouteEndpoint routeEndpoint, RouteModel routeConfig) CreateEndpoint(ProxyEndpointFactory factory, RouteState routeState, RouteConfig proxyRoute, ClusterInfo clusterInfo)
+        private (RouteEndpoint routeEndpoint, RouteModel routeConfig) CreateEndpoint(ProxyEndpointFactory factory, RouteState routeState, RouteConfig routeConfig, ClusterInfo clusterInfo)
         {
             routeState.ClusterRevision = clusterInfo.Revision;
-            var routeConfig = new RouteModel(proxyRoute, clusterInfo, HttpTransformer.Default);
+            var routeModel = new RouteModel(routeConfig, clusterInfo, HttpTransformer.Default);
 
-            var endpoint = factory.CreateEndpoint(routeConfig, Array.Empty<Action<EndpointBuilder>>());
+            var endpoint = factory.CreateEndpoint(routeModel, Array.Empty<Action<EndpointBuilder>>());
 
             var routeEndpoint = Assert.IsType<RouteEndpoint>(endpoint);
 
-            return (routeEndpoint, routeConfig);
+            return (routeEndpoint, routeModel);
         }
 
         [Fact]

--- a/test/ReverseProxy.Tests/Service/DynamicEndpoint/ProxyEndpointFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Service/DynamicEndpoint/ProxyEndpointFactoryTests.cs
@@ -57,7 +57,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
 
             Assert.Same(cluster, routeConfig.Cluster);
             Assert.Equal("route1", routeEndpoint.DisplayName);
-            Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteConfig>());
+            Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteState>());
             Assert.Equal("/a", routeEndpoint.RoutePattern.RawText);
             Assert.Equal(12, routeEndpoint.Order);
             Assert.False(routeConfig.HasConfigChanged(route, cluster, routeInfo.ClusterRevision));
@@ -68,10 +68,10 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             Assert.Equal("example.com", hostMetadata.Hosts[0]);
         }
 
-        private (RouteEndpoint routeEndpoint, RouteConfig routeConfig) CreateEndpoint(ProxyEndpointFactory factory, RouteEntity routeInfo, ProxyRoute proxyRoute, ClusterInfo clusterInfo)
+        private (RouteEndpoint routeEndpoint, RouteState routeConfig) CreateEndpoint(ProxyEndpointFactory factory, RouteEntity routeInfo, ProxyRoute proxyRoute, ClusterInfo clusterInfo)
         {
             routeInfo.ClusterRevision = clusterInfo.Revision;
-            var routeConfig = new RouteConfig(proxyRoute, clusterInfo, HttpTransformer.Default);
+            var routeConfig = new RouteState(proxyRoute, clusterInfo, HttpTransformer.Default);
 
             var endpoint = factory.CreateEndpoint(routeConfig, Array.Empty<Action<EndpointBuilder>>());
 
@@ -103,7 +103,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
 
             Assert.Same(cluster, routeConfig.Cluster);
             Assert.Equal("route1", routeEndpoint.DisplayName);
-            Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteConfig>());
+            Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteState>());
             Assert.Equal("/{**catchall}", routeEndpoint.RoutePattern.RawText);
             Assert.Equal(12, routeEndpoint.Order);
             Assert.False(routeConfig.HasConfigChanged(route, cluster, routeInfo.ClusterRevision));
@@ -137,7 +137,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
 
             Assert.Same(cluster, routeConfig.Cluster);
             Assert.Equal("route1", routeEndpoint.DisplayName);
-            Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteConfig>());
+            Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteState>());
             Assert.Equal("/{**catchall}", routeEndpoint.RoutePattern.RawText);
             Assert.Equal(12, routeEndpoint.Order);
             Assert.False(routeConfig.HasConfigChanged(route, cluster, routeInfo.ClusterRevision));
@@ -171,7 +171,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
 
             Assert.Same(cluster, routeConfig.Cluster);
             Assert.Equal("route1", routeEndpoint.DisplayName);
-            Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteConfig>());
+            Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteState>());
             Assert.Equal("/a", routeEndpoint.RoutePattern.RawText);
             Assert.Equal(12, routeEndpoint.Order);
             Assert.False(routeConfig.HasConfigChanged(route, cluster, routeInfo.ClusterRevision));
@@ -200,7 +200,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
 
             Assert.Same(cluster, routeConfig.Cluster);
             Assert.Equal("route1", routeEndpoint.DisplayName);
-            Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteConfig>());
+            Assert.Same(routeConfig, routeEndpoint.Metadata.GetMetadata<RouteState>());
             Assert.Equal("/{**catchall}", routeEndpoint.RoutePattern.RawText);
             Assert.Equal(12, routeEndpoint.Order);
             Assert.False(routeConfig.HasConfigChanged(route, cluster, routeInfo.ClusterRevision));

--- a/test/ReverseProxy.Tests/Service/Management/ProxyConfigManagerTests.cs
+++ b/test/ReverseProxy.Tests/Service/Management/ProxyConfigManagerTests.cs
@@ -125,9 +125,9 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
             Assert.NotNull(dataSource);
             var endpoints = dataSource.Endpoints;
             var endpoint = Assert.Single(endpoints);
-            var routeConfig = endpoint.Metadata.GetMetadata<RouteState>();
+            var routeConfig = endpoint.Metadata.GetMetadata<RouteModel>();
             Assert.NotNull(routeConfig);
-            Assert.Equal("route1", routeConfig.ProxyRoute.RouteId);
+            Assert.Equal("route1", routeConfig.Config.RouteId);
 
             var clusterInfo = routeConfig.Cluster;
             Assert.NotNull(clusterInfo);
@@ -182,7 +182,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
 
             Assert.NotNull(dataSource);
             var endpoint = Assert.Single(dataSource.Endpoints);
-            var routeConfig = endpoint.Metadata.GetMetadata<RouteState>();
+            var routeConfig = endpoint.Metadata.GetMetadata<RouteModel>();
             var clusterInfo = routeConfig.Cluster;
             Assert.Equal("cluster1", clusterInfo.ClusterId);
             var clusterConfig = clusterInfo.Config;
@@ -374,7 +374,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
 
             Assert.NotNull(dataSource);
             var endpoint = Assert.Single(dataSource.Endpoints);
-            var routeConfig = endpoint.Metadata.GetMetadata<RouteState>();
+            var routeConfig = endpoint.Metadata.GetMetadata<RouteModel>();
             var clusterInfo = routeConfig.Cluster;
             Assert.NotNull(clusterInfo);
             Assert.True(clusterInfo.Config.Options.HealthCheck.Enabled);

--- a/test/ReverseProxy.Tests/Service/Management/ProxyConfigManagerTests.cs
+++ b/test/ReverseProxy.Tests/Service/Management/ProxyConfigManagerTests.cs
@@ -125,7 +125,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
             Assert.NotNull(dataSource);
             var endpoints = dataSource.Endpoints;
             var endpoint = Assert.Single(endpoints);
-            var routeConfig = endpoint.Metadata.GetMetadata<RouteConfig>();
+            var routeConfig = endpoint.Metadata.GetMetadata<RouteState>();
             Assert.NotNull(routeConfig);
             Assert.Equal("route1", routeConfig.ProxyRoute.RouteId);
 
@@ -182,7 +182,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
 
             Assert.NotNull(dataSource);
             var endpoint = Assert.Single(dataSource.Endpoints);
-            var routeConfig = endpoint.Metadata.GetMetadata<RouteConfig>();
+            var routeConfig = endpoint.Metadata.GetMetadata<RouteState>();
             var clusterInfo = routeConfig.Cluster;
             Assert.Equal("cluster1", clusterInfo.ClusterId);
             var clusterConfig = clusterInfo.Config;
@@ -374,7 +374,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
 
             Assert.NotNull(dataSource);
             var endpoint = Assert.Single(dataSource.Endpoints);
-            var routeConfig = endpoint.Metadata.GetMetadata<RouteConfig>();
+            var routeConfig = endpoint.Metadata.GetMetadata<RouteState>();
             var clusterInfo = routeConfig.Cluster;
             Assert.NotNull(clusterInfo);
             Assert.True(clusterInfo.Config.Options.HealthCheck.Enabled);

--- a/test/ReverseProxy.Tests/Service/Proxy/LoadBalancingPoliciesTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/LoadBalancingPoliciesTests.cs
@@ -137,10 +137,10 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
 
             var context = new DefaultHttpContext();
 
-            var routeConfig = new RouteConfig(new ProxyRoute(), new ClusterInfo("cluster1"), transformer: null);
+            var routeConfig = new RouteState(new ProxyRoute(), new ClusterInfo("cluster1"), transformer: null);
             var feature = new ReverseProxyFeature()
             {
-                RouteSnapshot = routeConfig,
+                RouteState = routeConfig,
             };
             context.Features.Set<IReverseProxyFeature>(feature);
 

--- a/test/ReverseProxy.Tests/Service/Proxy/LoadBalancingPoliciesTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/LoadBalancingPoliciesTests.cs
@@ -137,7 +137,7 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
 
             var context = new DefaultHttpContext();
 
-            var routeConfig = new RouteState(new ProxyRoute(), new ClusterInfo("cluster1"), transformer: null);
+            var routeConfig = new RouteState(new RouteConfig(), new ClusterInfo("cluster1"), transformer: null);
             var feature = new ReverseProxyFeature()
             {
                 RouteState = routeConfig,

--- a/test/ReverseProxy.Tests/Service/Proxy/LoadBalancingPoliciesTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/LoadBalancingPoliciesTests.cs
@@ -137,10 +137,10 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
 
             var context = new DefaultHttpContext();
 
-            var routeConfig = new RouteState(new RouteConfig(), new ClusterInfo("cluster1"), transformer: null);
+            var routeConfig = new RouteModel(new RouteConfig(), new ClusterInfo("cluster1"), transformer: null);
             var feature = new ReverseProxyFeature()
             {
-                RouteState = routeConfig,
+                Route = routeConfig,
             };
             context.Features.Set<IReverseProxyFeature>(feature);
 

--- a/testassets/ReverseProxy.Code/InMemoryConfigProvider.cs
+++ b/testassets/ReverseProxy.Code/InMemoryConfigProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class InMemoryConfigProviderExtensions
     {
-        public static IReverseProxyBuilder LoadFromMemory(this IReverseProxyBuilder builder, IReadOnlyList<ProxyRoute> routes, IReadOnlyList<Cluster> clusters)
+        public static IReverseProxyBuilder LoadFromMemory(this IReverseProxyBuilder builder, IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
         {
             builder.Services.AddSingleton<IProxyConfigProvider>(new InMemoryConfigProvider(routes, clusters));
             return builder;
@@ -26,14 +26,14 @@ namespace Yarp.ReverseProxy.Configuration
     {
         private volatile InMemoryConfig _config;
 
-        public InMemoryConfigProvider(IReadOnlyList<ProxyRoute> routes, IReadOnlyList<Cluster> clusters)
+        public InMemoryConfigProvider(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
         {
             _config = new InMemoryConfig(routes, clusters);
         }
 
         public IProxyConfig GetConfig() => _config;
 
-        public void Update(IReadOnlyList<ProxyRoute> routes, IReadOnlyList<Cluster> clusters)
+        public void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
         {
             var oldConfig = _config;
             _config = new InMemoryConfig(routes, clusters);
@@ -44,14 +44,14 @@ namespace Yarp.ReverseProxy.Configuration
         {
             private readonly CancellationTokenSource _cts = new CancellationTokenSource();
 
-            public InMemoryConfig(IReadOnlyList<ProxyRoute> routes, IReadOnlyList<Cluster> clusters)
+            public InMemoryConfig(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
             {
                 Routes = routes;
                 Clusters = clusters;
                 ChangeToken = new CancellationChangeToken(_cts.Token);
             }
 
-            public IReadOnlyList<ProxyRoute> Routes { get; }
+            public IReadOnlyList<RouteConfig> Routes { get; }
 
             public IReadOnlyList<Cluster> Clusters { get; }
 

--- a/testassets/ReverseProxy.Code/Startup.cs
+++ b/testassets/ReverseProxy.Code/Startup.cs
@@ -27,7 +27,7 @@ namespace Yarp.ReverseProxy.Sample
             services.AddControllers();
             var routes = new[]
             {
-                new ProxyRoute()
+                new RouteConfig()
                 {
                     RouteId = "route1",
                     ClusterId = "cluster1",

--- a/testassets/ReverseProxy.Config/CustomConfigFilter.cs
+++ b/testassets/ReverseProxy.Config/CustomConfigFilter.cs
@@ -53,16 +53,16 @@ namespace Yarp.ReverseProxy.Sample
             return new ValueTask<Cluster>(cluster);
         }
 
-        public ValueTask<ProxyRoute> ConfigureRouteAsync(ProxyRoute route, CancellationToken cancel)
+        public ValueTask<RouteConfig> ConfigureRouteAsync(RouteConfig route, CancellationToken cancel)
         {
             // Do not let config based routes take priority over code based routes.
             // Lower numbers are higher priority. Code routes default to 0.
             if (route.Order.HasValue && route.Order.Value < 1)
             {
-                return new ValueTask<ProxyRoute>(route with { Order = 1 });
+                return new ValueTask<RouteConfig>(route with { Order = 1 });
             }
 
-            return new ValueTask<ProxyRoute>(route);
+            return new ValueTask<RouteConfig>(route);
         }
     }
 }


### PR DESCRIPTION
From API review: For the main concepts in YARP (route, cluster, destination) we use three levels of object model. 
- ProxyRoute, Cluster, Destination - the raw config input, immutable records
- RouteConfig, ClusterConfig, DestinationConfig - A set of objects derived from the raw config like the HttpClient to use, structured transforms,  etc.. This is rebuilt each time config changes and swapped out atomically so that new requests get a new, coherent model.
- RouteInfo, ClusterInfo, DestinationInfo - The long lived objects that identify an route/cluster/destination across config reloads. These track ongoing state like counters and health.

The naming is inconsistent and not very descriptive. We came up with the following new names:
- Route/Cluster/DestinationConfig for the lowest level config input
- Route/Cluster/DestinationState for the derived configuration
- Route/Cluster/DestinationEntity for the long lived objects

In this PR I've only updated the route types to see if the new names work well.
- *Config seems to work well for the lowest level.
- *State seems like a misnomer for the middle level since a lot of the state is actually tracked by the upper level. We also have DestinationHealthState and ClusterDynamicState types that represent real state. The middle level objects actually represent derived configuration. RouteModel, RouteConstruct?
- *Entity is ok, but still vague. RouteInstance? RouteState?

Update:
- Route/Cluster/DestinationConfig for the lowest level config input
- Route/Cluster/DestinationModel for the derived configuration
- Route/Cluster/DestinationState for the long lived objects

I've still only done the Route renames for this PR. I'll do a follow-up PR for clusters and destinations so it's easier to review.