### PR TITLE
API renames: Clusters

### DIFF
--- a/src/ReverseProxy.Kubernetes.Controller/Converters/YarpIngressContext.cs
+++ b/src/ReverseProxy.Kubernetes.Controller/Converters/YarpIngressContext.cs
@@ -18,7 +18,7 @@ namespace Yarp.ReverseProxy.Kubernetes.Controller.Services
         public YarpIngressOptions Options { get; set; } = new YarpIngressOptions();
         public Dictionary<string, ClusterTrasfer> ClusterTransfers { get; set; } = new Dictionary<string, ClusterTrasfer>();
         public List<RouteConfig> Routes { get; set; } = new List<RouteConfig>();
-        public List<Cluster> Clusters { get; set; } = new List<Cluster>();
+        public List<ClusterConfig> Clusters { get; set; } = new List<ClusterConfig>();
         public IngressData Ingress { get; }
         public List<Endpoints> Endpoints { get; }
     }

--- a/src/ReverseProxy.Kubernetes.Controller/Converters/YarpParser.cs
+++ b/src/ReverseProxy.Kubernetes.Controller/Converters/YarpParser.cs
@@ -38,10 +38,10 @@ namespace Yarp.ReverseProxy.Kubernetes.Controller.Converters
         {
             foreach (var cluster in context.ClusterTransfers)
             {
-                context.Clusters.Add(new Cluster()
+                context.Clusters.Add(new ClusterConfig()
                 {
                     Destinations = cluster.Value.Destinations,
-                    Id = cluster.Value.ClusterId
+                    ClusterId = cluster.Value.ClusterId
                 });
             }
         }

--- a/src/ReverseProxy.Kubernetes.Protocol/IUpdateConfig.cs
+++ b/src/ReverseProxy.Kubernetes.Protocol/IUpdateConfig.cs
@@ -8,6 +8,6 @@ namespace Yarp.ReverseProxy.Kubernetes.Protocol
 {
     public interface IUpdateConfig
     {
-        void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters);
+        void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters);
     }
 }

--- a/src/ReverseProxy.Kubernetes.Protocol/Message.cs
+++ b/src/ReverseProxy.Kubernetes.Protocol/Message.cs
@@ -26,7 +26,7 @@ namespace Yarp.ReverseProxy.Kubernetes.Protocol
 #pragma warning disable CA2227 // Collection properties should be read only
         public List<RouteConfig> Routes { get; set; }
 
-        public List<Cluster> Cluster { get; set; }
+        public List<ClusterConfig> Cluster { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
     }
 }

--- a/src/ReverseProxy.Kubernetes.Protocol/MessageConfigProvider.cs
+++ b/src/ReverseProxy.Kubernetes.Protocol/MessageConfigProvider.cs
@@ -20,7 +20,7 @@ namespace Yarp.ReverseProxy.Kubernetes.Protocol
 
         public IProxyConfig GetConfig() => _config;
 
-        public void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
+        public void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
         {
             var oldConfig = _config;
             _config = new MessageConfig(routes, clusters);
@@ -33,7 +33,7 @@ namespace Yarp.ReverseProxy.Kubernetes.Protocol
         {
             private readonly CancellationTokenSource _cts = new CancellationTokenSource();
 
-            public MessageConfig(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
+            public MessageConfig(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
             {
                 Routes = routes;
                 Clusters = clusters;
@@ -42,7 +42,7 @@ namespace Yarp.ReverseProxy.Kubernetes.Protocol
 
             public IReadOnlyList<RouteConfig> Routes { get; }
 
-            public IReadOnlyList<Cluster> Clusters { get; }
+            public IReadOnlyList<ClusterConfig> Clusters { get; }
 
             public IChangeToken ChangeToken { get; }
 

--- a/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Discoverer.cs
+++ b/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Discoverer.cs
@@ -48,14 +48,14 @@ namespace Yarp.ReverseProxy.ServiceFabric
         }
 
         /// <inheritdoc/>
-        public async Task<(IReadOnlyList<RouteConfig> Routes, IReadOnlyList<Cluster> Clusters)> DiscoverAsync(CancellationToken cancellation)
+        public async Task<(IReadOnlyList<RouteConfig> Routes, IReadOnlyList<ClusterConfig> Clusters)> DiscoverAsync(CancellationToken cancellation)
         {
             // Take a snapshot of current options and use that consistently for this execution.
             var options = _optionsMonitor.CurrentValue;
 
             _serviceFabricCaller.CleanUpExpired();
 
-            var discoveredBackends = new Dictionary<string, Cluster>(StringComparer.Ordinal);
+            var discoveredBackends = new Dictionary<string, ClusterConfig>(StringComparer.Ordinal);
             var discoveredRoutes = new List<RouteConfig>();
             IEnumerable<ApplicationWrapper> applications;
 
@@ -110,12 +110,12 @@ namespace Yarp.ReverseProxy.ServiceFabric
                         var clusterValidationErrors = await _configValidator.ValidateClusterAsync(cluster);
                         if (clusterValidationErrors.Count > 0)
                         {
-                            throw new ConfigException($"Skipping cluster id '{cluster.Id} due to validation errors.", new AggregateException(clusterValidationErrors));
+                            throw new ConfigException($"Skipping cluster id '{cluster.ClusterId} due to validation errors.", new AggregateException(clusterValidationErrors));
                         }
 
-                        if (!discoveredBackends.TryAdd(cluster.Id, cluster))
+                        if (!discoveredBackends.TryAdd(cluster.ClusterId, cluster))
                         {
-                            throw new ConfigException($"Duplicated cluster id '{cluster.Id}'. Skipping repeated definition, service '{service.ServiceName}'");
+                            throw new ConfigException($"Duplicated cluster id '{cluster.ClusterId}'. Skipping repeated definition, service '{service.ServiceName}'");
                         }
 
                         var routes = LabelsParser.BuildRoutes(service.ServiceName, serviceExtensionLabels);
@@ -130,12 +130,12 @@ namespace Yarp.ReverseProxy.ServiceFabric
                             // Don't add ANY routes if even a single one is bad. Trying to add partial routes
                             // could lead to unexpected results (e.g. a typo in the configuration of higher-priority route
                             // could lead to a lower-priority route being selected for requests it should not be handling).
-                            throw new ConfigException($"Skipping ALL routes for cluster id '{cluster.Id} due to validation errors.", new AggregateException(routeValidationErrors));
+                            throw new ConfigException($"Skipping ALL routes for cluster id '{cluster.ClusterId} due to validation errors.", new AggregateException(routeValidationErrors));
                         }
 
                         discoveredRoutes.AddRange(routes);
 
-                        ReportServiceHealth(options, service.ServiceName, HealthState.Ok, $"Successfully built cluster '{cluster.Id}' with {routes.Count} routes.");
+                        ReportServiceHealth(options, service.ServiceName, HealthState.Ok, $"Successfully built cluster '{cluster.ClusterId}' with {routes.Count} routes.");
                     }
                     catch (ConfigException ex)
                     {
@@ -239,7 +239,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
 
         /// <summary>
         /// Finds all eligible destinations (replica endpoints) for the <paramref name="service"/> specified,
-        /// and populates the specified <paramref name="cluster"/>'s <see cref="Cluster.Destinations"/> accordingly.
+        /// and populates the specified <paramref name="cluster"/>'s <see cref="ClusterConfig.Destinations"/> accordingly.
         /// </summary>
         /// <remarks>All non-fatal exceptions are caught and logged.</remarks>
         private async Task<IReadOnlyDictionary<string, Destination>> DiscoverDestinationsAsync(

--- a/src/ReverseProxy.ServiceFabric/ServiceDiscovery/IDiscoverer.cs
+++ b/src/ReverseProxy.ServiceFabric/ServiceDiscovery/IDiscoverer.cs
@@ -10,13 +10,13 @@ namespace Yarp.ReverseProxy.ServiceFabric
 {
     /// <summary>
     /// Discovers Service Fabric services and builds the corresponding
-    /// <see cref="RouteConfig"/> and <see cref="Cluster"/> instances that represent them.
+    /// <see cref="RouteConfig"/> and <see cref="ClusterConfig"/> instances that represent them.
     /// </summary>
     internal interface IDiscoverer
     {
         /// <summary>
         /// Execute the discovery and update entities.
         /// </summary>
-        Task<(IReadOnlyList<RouteConfig> Routes, IReadOnlyList<Cluster> Clusters)> DiscoverAsync(CancellationToken cancellation);
+        Task<(IReadOnlyList<RouteConfig> Routes, IReadOnlyList<ClusterConfig> Clusters)> DiscoverAsync(CancellationToken cancellation);
     }
 }

--- a/src/ReverseProxy.ServiceFabric/ServiceDiscovery/ServiceFabricConfigProvider.cs
+++ b/src/ReverseProxy.ServiceFabric/ServiceDiscovery/ServiceFabricConfigProvider.cs
@@ -70,7 +70,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
                         if (_snapshot == null)
                         {
                             Log.StartWithoutInitialServiceFabricDiscovery(_logger);
-                            UpdateSnapshot(new List<RouteConfig>(), new List<Cluster>());
+                            UpdateSnapshot(new List<RouteConfig>(), new List<ClusterConfig>());
                         }
                     }
                 }
@@ -132,7 +132,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
             }
         }
 
-        private void UpdateSnapshot(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
+        private void UpdateSnapshot(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
         {
             // Prevent overlapping updates
             lock (_lockObject)
@@ -164,7 +164,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
         {
             public IReadOnlyList<RouteConfig> Routes { get; internal set; }
 
-            public IReadOnlyList<Cluster> Clusters { get; internal set; }
+            public IReadOnlyList<ClusterConfig> Clusters { get; internal set; }
 
             public IChangeToken ChangeToken { get; internal set; }
         }

--- a/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Util/LabelsParser.cs
+++ b/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Util/LabelsParser.cs
@@ -236,7 +236,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
             return routes;
         }
 
-        internal static Cluster BuildCluster(Uri serviceName, Dictionary<string, string> labels, IReadOnlyDictionary<string, Destination> destinations)
+        internal static ClusterConfig BuildCluster(Uri serviceName, Dictionary<string, string> labels, IReadOnlyDictionary<string, Destination> destinations)
         {
             var clusterMetadata = new Dictionary<string, string>();
             Dictionary<string, string> sessionAffinitySettings = null;
@@ -271,9 +271,9 @@ namespace Yarp.ReverseProxy.ServiceFabric
             var requestHeaderEncodingLabel = GetLabel<string>(labels, "YARP.Backend.HttpClient.RequestHeaderEncoding", null);
 #endif
 
-            var cluster = new Cluster
+            var cluster = new ClusterConfig
             {
-                Id = clusterId,
+                ClusterId = clusterId,
                 LoadBalancingPolicy = GetLabel<string>(labels, "YARP.Backend.LoadBalancingPolicy", null),
                 SessionAffinity = new SessionAffinityOptions
                 {

--- a/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/ClusterConfig.cs
+++ b/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/ClusterConfig.cs
@@ -10,16 +10,13 @@ namespace Yarp.ReverseProxy.Abstractions
 {
     /// <summary>
     /// A cluster is a group of equivalent endpoints and associated policies.
-    /// A route maps requests to a cluster, and Reverse Proxy handles that request
-    /// by proxying to any endpoint within the matching cluster,
-    /// honoring load balancing and partitioning policies when applicable.
     /// </summary>
-    public sealed record Cluster
+    public sealed record ClusterConfig
     {
         /// <summary>
         /// The Id for this cluster. This needs to be globally unique.
         /// </summary>
-        public string Id { get; init; }
+        public string ClusterId { get; init; }
 
         /// <summary>
         /// Load balancing policy.
@@ -57,7 +54,7 @@ namespace Yarp.ReverseProxy.Abstractions
         public IReadOnlyDictionary<string, string> Metadata { get; init; }
 
         /// <inheritdoc />
-        public bool Equals(Cluster other)
+        public bool Equals(ClusterConfig other)
         {
             if (other == null)
             {
@@ -68,14 +65,14 @@ namespace Yarp.ReverseProxy.Abstractions
                 && CaseInsensitiveEqualHelper.Equals(Destinations, other.Destinations, (a, b) => a == b);
         }
 
-        internal bool EqualsExcludingDestinations(Cluster other)
+        internal bool EqualsExcludingDestinations(ClusterConfig other)
         {
             if (other == null)
             {
                 return false;
             }
 
-            return string.Equals(Id, other.Id, StringComparison.OrdinalIgnoreCase)
+            return string.Equals(ClusterId, other.ClusterId, StringComparison.OrdinalIgnoreCase)
                 && string.Equals(LoadBalancingPolicy, other.LoadBalancingPolicy, StringComparison.OrdinalIgnoreCase)
                 // CS0252 warning only shows up in VS https://github.com/dotnet/roslyn/issues/49302
                 && SessionAffinity == other.SessionAffinity
@@ -89,7 +86,7 @@ namespace Yarp.ReverseProxy.Abstractions
         public override int GetHashCode()
         {
             return HashCode.Combine(
-                Id?.GetHashCode(StringComparison.OrdinalIgnoreCase),
+                ClusterId?.GetHashCode(StringComparison.OrdinalIgnoreCase),
                 LoadBalancingPolicy?.GetHashCode(StringComparison.OrdinalIgnoreCase),
                 SessionAffinity,
                 HealthCheck,

--- a/src/ReverseProxy/Abstractions/Config/IConfigValidator.cs
+++ b/src/ReverseProxy/Abstractions/Config/IConfigValidator.cs
@@ -21,6 +21,6 @@ namespace Yarp.ReverseProxy.Service
         /// <summary>
         /// Validates a cluster and returns all errors.
         /// </summary>
-        ValueTask<IList<Exception>> ValidateClusterAsync(Cluster cluster);
+        ValueTask<IList<Exception>> ValidateClusterAsync(ClusterConfig cluster);
     }
 }

--- a/src/ReverseProxy/Abstractions/Config/IProxyConfig.cs
+++ b/src/ReverseProxy/Abstractions/Config/IProxyConfig.cs
@@ -20,7 +20,7 @@ namespace Yarp.ReverseProxy.Service
         /// <summary>
         /// Cluster information for where to proxy requests to.
         /// </summary>
-        IReadOnlyList<Cluster> Clusters { get; }
+        IReadOnlyList<ClusterConfig> Clusters { get; }
 
         /// <summary>
         /// A notification that triggers when this snapshot expires.

--- a/src/ReverseProxy/Abstractions/Config/IProxyConfigFilter.cs
+++ b/src/ReverseProxy/Abstractions/Config/IProxyConfigFilter.cs
@@ -15,9 +15,8 @@ namespace Yarp.ReverseProxy.Service
         /// <summary>
         /// Allows modification of a cluster configuration.
         /// </summary>
-        /// <param name="id">The id for the cluster.</param>
-        /// <param name="cluster">The <see cref="Cluster"/> instance to configure.</param>
-        ValueTask<Cluster> ConfigureClusterAsync(Cluster cluster, CancellationToken cancel);
+        /// <param name="cluster">The <see cref="ClusterConfig"/> instance to configure.</param>
+        ValueTask<ClusterConfig> ConfigureClusterAsync(ClusterConfig cluster, CancellationToken cancel);
 
         /// <summary>
         /// Allows modification of a route configuration.

--- a/src/ReverseProxy/Abstractions/Config/ITransformBuilder.cs
+++ b/src/ReverseProxy/Abstractions/Config/ITransformBuilder.cs
@@ -23,12 +23,12 @@ namespace Yarp.ReverseProxy.Service
         /// <summary>
         /// Validates that any cluster data needed for transforms is valid.
         /// </summary>
-        IReadOnlyList<Exception> ValidateCluster(Cluster cluster);
+        IReadOnlyList<Exception> ValidateCluster(ClusterConfig cluster);
 
         /// <summary>
         /// Builds the transforms for the given route into executable rules.
         /// </summary>
-        HttpTransformer Build(RouteConfig route, Cluster cluster);
+        HttpTransformer Build(RouteConfig route, ClusterConfig cluster);
 
         HttpTransformer Create(Action<TransformBuilderContext> action);
     }

--- a/src/ReverseProxy/Abstractions/Config/TransformBuilderContext.cs
+++ b/src/ReverseProxy/Abstractions/Config/TransformBuilderContext.cs
@@ -25,7 +25,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// The cluster config the route is associated with.
         /// </summary>
-        public Cluster Cluster { get; init; }
+        public ClusterConfig Cluster { get; init; }
 
         /// <summary>
         /// Indicates if request headers should all be copied to the proxy request before transforms are applied.

--- a/src/ReverseProxy/Abstractions/Config/TransformBuilderContext.cs
+++ b/src/ReverseProxy/Abstractions/Config/TransformBuilderContext.cs
@@ -23,7 +23,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         public RouteConfig Route { get; init; }
 
         /// <summary>
-        /// The cluster config the route is associated with.
+        /// The cluster config used by the route.
         /// </summary>
         public ClusterConfig Cluster { get; init; }
 

--- a/src/ReverseProxy/Abstractions/Config/TransformClusterValidationContext.cs
+++ b/src/ReverseProxy/Abstractions/Config/TransformClusterValidationContext.cs
@@ -19,7 +19,7 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         /// <summary>
         /// The cluster configuration that may be used when creating transforms.
         /// </summary>
-        public Cluster Cluster { get; init; }
+        public ClusterConfig Cluster { get; init; }
 
         /// <summary>
         /// The accumulated list of validation errors for this cluster.

--- a/src/ReverseProxy/Configuration/ConfigurationConfigProvider.cs
+++ b/src/ReverseProxy/Configuration/ConfigurationConfigProvider.cs
@@ -144,23 +144,23 @@ namespace Yarp.ReverseProxy.Configuration
             }
         }
 
-        private Cluster CreateCluster(IConfigurationSection section)
+        private ClusterConfig CreateCluster(IConfigurationSection section)
         {
             var destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase);
-            foreach (var destination in section.GetSection(nameof(Cluster.Destinations)).GetChildren())
+            foreach (var destination in section.GetSection(nameof(ClusterConfig.Destinations)).GetChildren())
             {
                 destinations.Add(destination.Key, CreateDestination(destination));
             }
 
-            return new Cluster
+            return new ClusterConfig
             {
-                Id = section.Key,
-                LoadBalancingPolicy = section[nameof(Cluster.LoadBalancingPolicy)],
-                SessionAffinity = CreateSessionAffinityOptions(section.GetSection(nameof(Cluster.SessionAffinity))),
-                HealthCheck = CreateHealthCheckOptions(section.GetSection(nameof(Cluster.HealthCheck))),
-                HttpClient = CreateProxyHttpClientOptions(section.GetSection(nameof(Cluster.HttpClient))),
-                HttpRequest = CreateProxyRequestOptions(section.GetSection(nameof(Cluster.HttpRequest))),
-                Metadata = section.GetSection(nameof(Cluster.Metadata)).ReadStringDictionary(),
+                ClusterId = section.Key,
+                LoadBalancingPolicy = section[nameof(ClusterConfig.LoadBalancingPolicy)],
+                SessionAffinity = CreateSessionAffinityOptions(section.GetSection(nameof(ClusterConfig.SessionAffinity))),
+                HealthCheck = CreateHealthCheckOptions(section.GetSection(nameof(ClusterConfig.HealthCheck))),
+                HttpClient = CreateProxyHttpClientOptions(section.GetSection(nameof(ClusterConfig.HttpClient))),
+                HttpRequest = CreateProxyRequestOptions(section.GetSection(nameof(ClusterConfig.HttpRequest))),
+                Metadata = section.GetSection(nameof(ClusterConfig.Metadata)).ReadStringDictionary(),
                 Destinations = destinations,
             };
         }

--- a/src/ReverseProxy/Configuration/ConfigurationSnapshot.cs
+++ b/src/ReverseProxy/Configuration/ConfigurationSnapshot.cs
@@ -12,11 +12,11 @@ namespace Yarp.ReverseProxy.Configuration
     {
         public List<RouteConfig> Routes { get; internal set; } = new List<RouteConfig>();
 
-        public List<Cluster> Clusters { get; internal set; } = new List<Cluster>();
+        public List<ClusterConfig> Clusters { get; internal set; } = new List<ClusterConfig>();
 
         IReadOnlyList<RouteConfig> IProxyConfig.Routes => Routes;
 
-        IReadOnlyList<Cluster> IProxyConfig.Clusters => Clusters;
+        IReadOnlyList<ClusterConfig> IProxyConfig.Clusters => Clusters;
 
         public IChangeToken ChangeToken { get; internal set; }
     }

--- a/src/ReverseProxy/Middleware/HttpContextFeaturesExtensions.cs
+++ b/src/ReverseProxy/Middleware/HttpContextFeaturesExtensions.cs
@@ -16,12 +16,12 @@ namespace Microsoft.AspNetCore.Http
     public static class HttpContextFeaturesExtensions
     {
         /// <summary>
-        /// Retrieves the <see cref="ClusterInfo"/> instance associated with the current request.
+        /// Retrieves the <see cref="ClusterState"/> instance associated with the current request.
         /// </summary>
-        public static ClusterInfo GetClusterInfo(this HttpContext context)
+        public static ClusterState GetClusterState(this HttpContext context)
         {
             var route = context.GetRouteModel();
-            var cluster = route.Cluster ?? throw new InvalidOperationException($"The {typeof(RouteModel).FullName} is missing the {typeof(ClusterInfo).FullName}.");
+            var cluster = route.Cluster ?? throw new InvalidOperationException($"The {typeof(RouteModel).FullName} is missing the {typeof(ClusterState).FullName}.");
             return cluster;
         }
 

--- a/src/ReverseProxy/Middleware/IReverseProxyFeature.cs
+++ b/src/ReverseProxy/Middleware/IReverseProxyFeature.cs
@@ -17,9 +17,9 @@ namespace Yarp.ReverseProxy.Middleware
         RouteModel Route { get; }
 
         /// <summary>
-        /// Cluster config for the current request.
+        /// The cluster model for the current request.
         /// </summary>
-        ClusterConfig ClusterSnapshot { get; }
+        ClusterModel Cluster { get; }
 
         /// <summary>
         /// All destinations for the current cluster.

--- a/src/ReverseProxy/Middleware/LoadBalancingMiddleware.cs
+++ b/src/ReverseProxy/Middleware/LoadBalancingMiddleware.cs
@@ -51,14 +51,14 @@ namespace Yarp.ReverseProxy.Middleware
             }
             else
             {
-                var currentPolicy = _loadBalancingPolicies.GetRequiredServiceById(proxyFeature.ClusterSnapshot.Options.LoadBalancingPolicy, LoadBalancingPolicies.PowerOfTwoChoices);
+                var currentPolicy = _loadBalancingPolicies.GetRequiredServiceById(proxyFeature.Cluster.Options.LoadBalancingPolicy, LoadBalancingPolicies.PowerOfTwoChoices);
                 destination = currentPolicy.PickDestination(context, destinations);
             }
 
             if (destination == null)
             {
                 // We intentionally do not short circuit here, we allow for later middleware to decide how to handle this case.
-                Log.NoAvailableDestinations(_logger, proxyFeature.ClusterSnapshot.Options.Id);
+                Log.NoAvailableDestinations(_logger, proxyFeature.Cluster.Options.Id);
                 proxyFeature.AvailableDestinations = Array.Empty<DestinationInfo>();
             }
             else

--- a/src/ReverseProxy/Middleware/LoadBalancingMiddleware.cs
+++ b/src/ReverseProxy/Middleware/LoadBalancingMiddleware.cs
@@ -51,14 +51,14 @@ namespace Yarp.ReverseProxy.Middleware
             }
             else
             {
-                var currentPolicy = _loadBalancingPolicies.GetRequiredServiceById(proxyFeature.Cluster.Options.LoadBalancingPolicy, LoadBalancingPolicies.PowerOfTwoChoices);
+                var currentPolicy = _loadBalancingPolicies.GetRequiredServiceById(proxyFeature.Cluster.Config.LoadBalancingPolicy, LoadBalancingPolicies.PowerOfTwoChoices);
                 destination = currentPolicy.PickDestination(context, destinations);
             }
 
             if (destination == null)
             {
                 // We intentionally do not short circuit here, we allow for later middleware to decide how to handle this case.
-                Log.NoAvailableDestinations(_logger, proxyFeature.Cluster.Options.Id);
+                Log.NoAvailableDestinations(_logger, proxyFeature.Cluster.Config.ClusterId);
                 proxyFeature.AvailableDestinations = Array.Empty<DestinationInfo>();
             }
             else

--- a/src/ReverseProxy/Middleware/PassiveHealthCheckMiddleware.cs
+++ b/src/ReverseProxy/Middleware/PassiveHealthCheckMiddleware.cs
@@ -27,7 +27,7 @@ namespace Yarp.ReverseProxy.Middleware
             await _next(context);
 
             var proxyFeature = context.GetReverseProxyFeature();
-            var options = proxyFeature.Cluster.Options.HealthCheck?.Passive;
+            var options = proxyFeature.Cluster.Config.HealthCheck?.Passive;
 
             // Do nothing if no target destination has been chosen for the request.
             if (!(options?.Enabled).GetValueOrDefault() || proxyFeature.ProxiedDestination == null)

--- a/src/ReverseProxy/Middleware/PassiveHealthCheckMiddleware.cs
+++ b/src/ReverseProxy/Middleware/PassiveHealthCheckMiddleware.cs
@@ -27,7 +27,7 @@ namespace Yarp.ReverseProxy.Middleware
             await _next(context);
 
             var proxyFeature = context.GetReverseProxyFeature();
-            var options = proxyFeature.ClusterSnapshot.Options.HealthCheck?.Passive;
+            var options = proxyFeature.Cluster.Options.HealthCheck?.Passive;
 
             // Do nothing if no target destination has been chosen for the request.
             if (!(options?.Enabled).GetValueOrDefault() || proxyFeature.ProxiedDestination == null)

--- a/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
+++ b/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
@@ -78,7 +78,7 @@ namespace Yarp.ReverseProxy.Middleware
                 ProxyTelemetry.Log.ProxyInvoke(cluster.ClusterId, route.Config.RouteId, destination.DestinationId);
 
                 var clusterConfig = reverseProxyFeature.Cluster;
-                await _httpProxy.ProxyAsync(context, destinationConfig.Options.Address, clusterConfig.HttpClient, clusterConfig.Options.HttpRequest, route.Transformer);
+                await _httpProxy.ProxyAsync(context, destinationConfig.Options.Address, clusterConfig.HttpClient, clusterConfig.Config.HttpRequest, route.Transformer);
             }
             finally
             {

--- a/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
+++ b/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
@@ -77,7 +77,7 @@ namespace Yarp.ReverseProxy.Middleware
 
                 ProxyTelemetry.Log.ProxyInvoke(cluster.ClusterId, route.Config.RouteId, destination.DestinationId);
 
-                var clusterConfig = reverseProxyFeature.ClusterSnapshot;
+                var clusterConfig = reverseProxyFeature.Cluster;
                 await _httpProxy.ProxyAsync(context, destinationConfig.Options.Address, clusterConfig.HttpClient, clusterConfig.Options.HttpRequest, route.Transformer);
             }
             finally

--- a/src/ReverseProxy/Middleware/ProxyPipelineInitializerMiddleware.cs
+++ b/src/ReverseProxy/Middleware/ProxyPipelineInitializerMiddleware.cs
@@ -45,7 +45,7 @@ namespace Yarp.ReverseProxy.Middleware
             context.Features.Set<IReverseProxyFeature>(new ReverseProxyFeature
             {
                 Route = route,
-                ClusterSnapshot = cluster.Config,
+                Cluster = cluster.Model,
                 AllDestinations = dynamicState.AllDestinations,
                 AvailableDestinations = dynamicState.HealthyDestinations
             });

--- a/src/ReverseProxy/Middleware/ReverseProxyFeature.cs
+++ b/src/ReverseProxy/Middleware/ReverseProxyFeature.cs
@@ -15,7 +15,7 @@ namespace Yarp.ReverseProxy.Middleware
         public RouteModel Route { get; init; }
 
         /// <inheritdoc/>
-        public ClusterConfig ClusterSnapshot { get; set; }
+        public ClusterModel Cluster { get; set; }
 
         /// <inheritdoc/>
         public IReadOnlyList<DestinationInfo> AllDestinations { get; init; }

--- a/src/ReverseProxy/Middleware/SessionAffinityMiddleware.cs
+++ b/src/ReverseProxy/Middleware/SessionAffinityMiddleware.cs
@@ -40,7 +40,7 @@ namespace Yarp.ReverseProxy.Middleware
         {
             var proxyFeature = context.GetReverseProxyFeature();
 
-            var cluster = proxyFeature.ClusterSnapshot.Options;
+            var cluster = proxyFeature.Cluster.Options;
             var options = cluster.SessionAffinity;
 
             if (!(options?.Enabled).GetValueOrDefault())

--- a/src/ReverseProxy/Middleware/SessionAffinityMiddleware.cs
+++ b/src/ReverseProxy/Middleware/SessionAffinityMiddleware.cs
@@ -40,7 +40,7 @@ namespace Yarp.ReverseProxy.Middleware
         {
             var proxyFeature = context.GetReverseProxyFeature();
 
-            var cluster = proxyFeature.Cluster.Options;
+            var cluster = proxyFeature.Cluster.Config;
             var options = cluster.SessionAffinity;
 
             if (!(options?.Enabled).GetValueOrDefault())
@@ -48,7 +48,7 @@ namespace Yarp.ReverseProxy.Middleware
                 return _next(context);
             }
 
-            return InvokeInternal(context, proxyFeature, options, cluster.Id);
+            return InvokeInternal(context, proxyFeature, options, cluster.ClusterId);
         }
 
         private async Task InvokeInternal(HttpContext context, IReverseProxyFeature proxyFeature, SessionAffinityOptions options, string clusterId)

--- a/src/ReverseProxy/Service/Config/ConfigValidator.cs
+++ b/src/ReverseProxy/Service/Config/ConfigValidator.cs
@@ -90,12 +90,12 @@ namespace Yarp.ReverseProxy.Service
         }
 
         // Note this performs all validation steps without short circuiting in order to report all possible errors.
-        public ValueTask<IList<Exception>> ValidateClusterAsync(Cluster cluster)
+        public ValueTask<IList<Exception>> ValidateClusterAsync(ClusterConfig cluster)
         {
             _ = cluster ?? throw new ArgumentNullException(nameof(cluster));
             var errors = new List<Exception>();
 
-            if (string.IsNullOrEmpty(cluster.Id))
+            if (string.IsNullOrEmpty(cluster.ClusterId))
             {
                 errors.Add(new ArgumentException("Missing Cluster Id."));
             }
@@ -293,7 +293,7 @@ namespace Yarp.ReverseProxy.Service
             }
         }
 
-        private void ValidateLoadBalancing(IList<Exception> errors, Cluster cluster)
+        private void ValidateLoadBalancing(IList<Exception> errors, ClusterConfig cluster)
         {
             var loadBalancingPolicy = cluster.LoadBalancingPolicy;
             if (string.IsNullOrEmpty(loadBalancingPolicy))
@@ -304,11 +304,11 @@ namespace Yarp.ReverseProxy.Service
 
             if (!_loadBalancingPolicies.ContainsKey(loadBalancingPolicy))
             {
-                errors.Add(new ArgumentException($"No matching {nameof(ILoadBalancingPolicy)} found for the load balancing policy '{loadBalancingPolicy}' set on the cluster '{cluster.Id}'."));
+                errors.Add(new ArgumentException($"No matching {nameof(ILoadBalancingPolicy)} found for the load balancing policy '{loadBalancingPolicy}' set on the cluster '{cluster.ClusterId}'."));
             }
         }
 
-        private void ValidateSessionAffinity(IList<Exception> errors, Cluster cluster)
+        private void ValidateSessionAffinity(IList<Exception> errors, ClusterConfig cluster)
         {
             if (!(cluster.SessionAffinity?.Enabled ?? false))
             {
@@ -327,11 +327,11 @@ namespace Yarp.ReverseProxy.Service
 
             if (!_affinityFailurePolicies.ContainsKey(affinityFailurePolicy))
             {
-                errors.Add(new ArgumentException($"No matching IAffinityFailurePolicy found for the affinity failure policy name '{affinityFailurePolicy}' set on the cluster '{cluster.Id}'."));
+                errors.Add(new ArgumentException($"No matching IAffinityFailurePolicy found for the affinity failure policy name '{affinityFailurePolicy}' set on the cluster '{cluster.ClusterId}'."));
             }
         }
 
-        private static void ValidateProxyHttpClient(IList<Exception> errors, Cluster cluster)
+        private static void ValidateProxyHttpClient(IList<Exception> errors, ClusterConfig cluster)
         {
             if (cluster.HttpClient == null)
             {
@@ -341,11 +341,11 @@ namespace Yarp.ReverseProxy.Service
 
             if (cluster.HttpClient.MaxConnectionsPerServer != null && cluster.HttpClient.MaxConnectionsPerServer <= 0)
             {
-                errors.Add(new ArgumentException($"Max connections per server limit set on the cluster '{cluster.Id}' must be positive."));
+                errors.Add(new ArgumentException($"Max connections per server limit set on the cluster '{cluster.ClusterId}' must be positive."));
             }
         }
 
-        private static void ValidateProxyHttpRequest(IList<Exception> errors, Cluster cluster)
+        private static void ValidateProxyHttpRequest(IList<Exception> errors, ClusterConfig cluster)
         {
             if (cluster.HttpRequest == null)
             {
@@ -362,7 +362,7 @@ namespace Yarp.ReverseProxy.Service
             }
         }
 
-        private void ValidateActiveHealthCheck(IList<Exception> errors, Cluster cluster)
+        private void ValidateActiveHealthCheck(IList<Exception> errors, ClusterConfig cluster)
         {
             if (!(cluster.HealthCheck?.Active?.Enabled ?? false))
             {
@@ -379,21 +379,21 @@ namespace Yarp.ReverseProxy.Service
             }
             if (!_activeHealthCheckPolicies.ContainsKey(policy))
             {
-                errors.Add(new ArgumentException($"No matching {nameof(IActiveHealthCheckPolicy)} found for the active health check policy name '{policy}' set on the cluster '{cluster.Id}'."));
+                errors.Add(new ArgumentException($"No matching {nameof(IActiveHealthCheckPolicy)} found for the active health check policy name '{policy}' set on the cluster '{cluster.ClusterId}'."));
             }
 
             if (activeOptions.Interval != null && activeOptions.Interval <= TimeSpan.Zero)
             {
-                errors.Add(new ArgumentException($"Destination probing interval set on the cluster '{cluster.Id}' must be positive."));
+                errors.Add(new ArgumentException($"Destination probing interval set on the cluster '{cluster.ClusterId}' must be positive."));
             }
 
             if (activeOptions.Timeout != null && activeOptions.Timeout <= TimeSpan.Zero)
             {
-                errors.Add(new ArgumentException($"Destination probing timeout set on the cluster '{cluster.Id}' must be positive."));
+                errors.Add(new ArgumentException($"Destination probing timeout set on the cluster '{cluster.ClusterId}' must be positive."));
             }
         }
 
-        private void ValidatePassiveHealthCheck(IList<Exception> errors, Cluster cluster)
+        private void ValidatePassiveHealthCheck(IList<Exception> errors, ClusterConfig cluster)
         {
             if (!(cluster.HealthCheck?.Passive?.Enabled ?? false))
             {
@@ -410,12 +410,12 @@ namespace Yarp.ReverseProxy.Service
             }
             if (!_passiveHealthCheckPolicies.ContainsKey(policy))
             {
-                errors.Add(new ArgumentException($"No matching {nameof(IPassiveHealthCheckPolicy)} found for the passive health check policy name '{policy}' set on the cluster '{cluster.Id}'."));
+                errors.Add(new ArgumentException($"No matching {nameof(IPassiveHealthCheckPolicy)} found for the passive health check policy name '{policy}' set on the cluster '{cluster.ClusterId}'."));
             }
 
             if (passiveOptions.ReactivationPeriod != null && passiveOptions.ReactivationPeriod <= TimeSpan.Zero)
             {
-                errors.Add(new ArgumentException($"Unhealthy destination reactivation period set on the cluster '{cluster.Id}' must be positive."));
+                errors.Add(new ArgumentException($"Unhealthy destination reactivation period set on the cluster '{cluster.ClusterId}' must be positive."));
             }
         }
     }

--- a/src/ReverseProxy/Service/Config/TransformBuilder.cs
+++ b/src/ReverseProxy/Service/Config/TransformBuilder.cs
@@ -73,7 +73,7 @@ namespace Yarp.ReverseProxy.Service.Config
         }
 
         /// <inheritdoc/>
-        public IReadOnlyList<Exception> ValidateCluster(Cluster cluster)
+        public IReadOnlyList<Exception> ValidateCluster(ClusterConfig cluster)
         {
             var context = new TransformClusterValidationContext()
             {
@@ -92,13 +92,13 @@ namespace Yarp.ReverseProxy.Service.Config
         }
 
         /// <inheritdoc/>
-        public HttpTransformer Build(RouteConfig route, Cluster cluster)
+        public HttpTransformer Build(RouteConfig route, ClusterConfig cluster)
         {
             return BuildInternal(route, cluster);
         }
 
         // This is separate from Build for testing purposes.
-        internal StructuredTransformer BuildInternal(RouteConfig route, Cluster cluster)
+        internal StructuredTransformer BuildInternal(RouteConfig route, ClusterConfig cluster)
         {
             var rawTransforms = route.Transforms;
 

--- a/src/ReverseProxy/Service/DynamicEndpoint/ReverseProxyConventionBuilder.cs
+++ b/src/ReverseProxy/Service/DynamicEndpoint/ReverseProxyConventionBuilder.cs
@@ -84,7 +84,7 @@ namespace Yarp.ReverseProxy
             {
                 var routeModel = endpointBuilder.Metadata.OfType<RouteModel>().Single();
 
-                var clusterConfig = routeModel.Cluster?.Config.Options;
+                var clusterConfig = routeModel.Cluster?.Model.Options;
                 var routeConfig = routeModel.Config;
                 var conventionBuilder = new EndpointBuilderConventionBuilder(endpointBuilder);
                 convention(conventionBuilder, routeConfig, clusterConfig);

--- a/src/ReverseProxy/Service/DynamicEndpoint/ReverseProxyConventionBuilder.cs
+++ b/src/ReverseProxy/Service/DynamicEndpoint/ReverseProxyConventionBuilder.cs
@@ -76,7 +76,7 @@ namespace Yarp.ReverseProxy
         /// </summary>
         /// <param name="convention">The convention to add to the builder.</param>
         /// <returns></returns>
-        public ReverseProxyConventionBuilder ConfigureEndpoints(Action<IEndpointConventionBuilder, RouteConfig, Cluster> convention)
+        public ReverseProxyConventionBuilder ConfigureEndpoints(Action<IEndpointConventionBuilder, RouteConfig, ClusterConfig> convention)
         {
             _ = convention ?? throw new ArgumentNullException(nameof(convention));
 
@@ -84,7 +84,7 @@ namespace Yarp.ReverseProxy
             {
                 var routeModel = endpointBuilder.Metadata.OfType<RouteModel>().Single();
 
-                var clusterConfig = routeModel.Cluster?.Model.Options;
+                var clusterConfig = routeModel.Cluster?.Model.Config;
                 var routeConfig = routeModel.Config;
                 var conventionBuilder = new EndpointBuilderConventionBuilder(endpointBuilder);
                 convention(conventionBuilder, routeConfig, clusterConfig);

--- a/src/ReverseProxy/Service/HealthChecks/ActiveHealthCheckMonitor.cs
+++ b/src/ReverseProxy/Service/HealthChecks/ActiveHealthCheckMonitor.cs
@@ -49,7 +49,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                     var probeClusterTasks = new List<Task>();
                     foreach (var cluster in clusters)
                     {
-                        if ((cluster.Config.Options.HealthCheck?.Active?.Enabled).GetValueOrDefault())
+                        if ((cluster.Model.Options.HealthCheck?.Active?.Enabled).GetValueOrDefault())
                         {
                             probeClusterTasks.Add(ProbeCluster(cluster));
                         }
@@ -72,7 +72,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 
         public void OnClusterAdded(ClusterState cluster)
         {
-            var activeHealthCheckOptions = cluster.Config.Options.HealthCheck?.Active;
+            var activeHealthCheckOptions = cluster.Model.Options.HealthCheck?.Active;
             if ((activeHealthCheckOptions?.Enabled).GetValueOrDefault())
             {
                 _scheduler.ScheduleEntity(cluster, activeHealthCheckOptions.Interval ?? _monitorOptions.DefaultInterval);
@@ -81,7 +81,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 
         public void OnClusterChanged(ClusterState cluster)
         {
-            var activeHealthCheckOptions = cluster.Config.Options.HealthCheck?.Active;
+            var activeHealthCheckOptions = cluster.Model.Options.HealthCheck?.Active;
             if ((activeHealthCheckOptions?.Enabled).GetValueOrDefault())
             {
                 _scheduler.ChangePeriod(cluster, activeHealthCheckOptions.Interval ?? _monitorOptions.DefaultInterval);
@@ -104,8 +104,8 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 
         private async Task ProbeCluster(ClusterState cluster)
         {
-            var clusterConfig = cluster.Config;
-            var activeHealthOptions = clusterConfig.Options.HealthCheck?.Active;
+            var clusterModel = cluster.Model;
+            var activeHealthOptions = clusterModel.Options.HealthCheck?.Active;
             if (!(activeHealthOptions?.Enabled).GetValueOrDefault())
             {
                 return;
@@ -124,11 +124,11 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                     var cts = new CancellationTokenSource(timeout);
                     try
                     {
-                        var request = _probingRequestFactory.CreateRequest(clusterConfig, destination.Config);
+                        var request = _probingRequestFactory.CreateRequest(clusterModel, destination.Config);
 
                         Log.SendingHealthProbeToEndpointOfDestination(_logger, request.RequestUri, destination.DestinationId, cluster.ClusterId);
 
-                        probeTasks.Add((clusterConfig.HttpClient.SendAsync(request, cts.Token), cts));
+                        probeTasks.Add((clusterModel.HttpClient.SendAsync(request, cts.Token), cts));
                     }
                     catch (Exception ex)
                     {

--- a/src/ReverseProxy/Service/HealthChecks/ActiveHealthCheckMonitor.cs
+++ b/src/ReverseProxy/Service/HealthChecks/ActiveHealthCheckMonitor.cs
@@ -49,7 +49,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                     var probeClusterTasks = new List<Task>();
                     foreach (var cluster in clusters)
                     {
-                        if ((cluster.Model.Options.HealthCheck?.Active?.Enabled).GetValueOrDefault())
+                        if ((cluster.Model.Config.HealthCheck?.Active?.Enabled).GetValueOrDefault())
                         {
                             probeClusterTasks.Add(ProbeCluster(cluster));
                         }
@@ -72,7 +72,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 
         public void OnClusterAdded(ClusterState cluster)
         {
-            var activeHealthCheckOptions = cluster.Model.Options.HealthCheck?.Active;
+            var activeHealthCheckOptions = cluster.Model.Config.HealthCheck?.Active;
             if ((activeHealthCheckOptions?.Enabled).GetValueOrDefault())
             {
                 _scheduler.ScheduleEntity(cluster, activeHealthCheckOptions.Interval ?? _monitorOptions.DefaultInterval);
@@ -81,7 +81,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 
         public void OnClusterChanged(ClusterState cluster)
         {
-            var activeHealthCheckOptions = cluster.Model.Options.HealthCheck?.Active;
+            var activeHealthCheckOptions = cluster.Model.Config.HealthCheck?.Active;
             if ((activeHealthCheckOptions?.Enabled).GetValueOrDefault())
             {
                 _scheduler.ChangePeriod(cluster, activeHealthCheckOptions.Interval ?? _monitorOptions.DefaultInterval);
@@ -105,7 +105,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         private async Task ProbeCluster(ClusterState cluster)
         {
             var clusterModel = cluster.Model;
-            var activeHealthOptions = clusterModel.Options.HealthCheck?.Active;
+            var activeHealthOptions = clusterModel.Config.HealthCheck?.Active;
             if (!(activeHealthOptions?.Enabled).GetValueOrDefault())
             {
                 return;

--- a/src/ReverseProxy/Service/HealthChecks/ActiveHealthCheckMonitor.cs
+++ b/src/ReverseProxy/Service/HealthChecks/ActiveHealthCheckMonitor.cs
@@ -21,7 +21,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         private readonly ActiveHealthCheckMonitorOptions _monitorOptions;
         private readonly IDictionary<string, IActiveHealthCheckPolicy> _policies;
         private readonly IProbingRequestFactory _probingRequestFactory;
-        private readonly EntityActionScheduler<ClusterInfo> _scheduler;
+        private readonly EntityActionScheduler<ClusterState> _scheduler;
         private readonly ILogger<ActiveHealthCheckMonitor> _logger;
 
         public ActiveHealthCheckMonitor(
@@ -35,12 +35,12 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             _policies = policies?.ToDictionaryByUniqueId(p => p.Name) ?? throw new ArgumentNullException(nameof(policies));
             _probingRequestFactory = probingRequestFactory ?? throw new ArgumentNullException(nameof(probingRequestFactory));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _scheduler = new EntityActionScheduler<ClusterInfo>(cluster => ProbeCluster(cluster), autoStart: false, runOnce: false, timerFactory);
+            _scheduler = new EntityActionScheduler<ClusterState>(cluster => ProbeCluster(cluster), autoStart: false, runOnce: false, timerFactory);
         }
 
         public bool InitialDestinationsProbed { get; private set; }
 
-        public Task CheckHealthAsync(IEnumerable<ClusterInfo> clusters)
+        public Task CheckHealthAsync(IEnumerable<ClusterState> clusters)
         {
             return Task.Run(async () =>
             {
@@ -70,7 +70,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             });
         }
 
-        public void OnClusterAdded(ClusterInfo cluster)
+        public void OnClusterAdded(ClusterState cluster)
         {
             var activeHealthCheckOptions = cluster.Config.Options.HealthCheck?.Active;
             if ((activeHealthCheckOptions?.Enabled).GetValueOrDefault())
@@ -79,7 +79,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             }
         }
 
-        public void OnClusterChanged(ClusterInfo cluster)
+        public void OnClusterChanged(ClusterState cluster)
         {
             var activeHealthCheckOptions = cluster.Config.Options.HealthCheck?.Active;
             if ((activeHealthCheckOptions?.Enabled).GetValueOrDefault())
@@ -92,7 +92,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             }
         }
 
-        public void OnClusterRemoved(ClusterInfo cluster)
+        public void OnClusterRemoved(ClusterState cluster)
         {
             _scheduler.UnscheduleEntity(cluster);
         }
@@ -102,7 +102,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             _scheduler.Dispose();
         }
 
-        private async Task ProbeCluster(ClusterInfo cluster)
+        private async Task ProbeCluster(ClusterState cluster)
         {
             var clusterConfig = cluster.Config;
             var activeHealthOptions = clusterConfig.Options.HealthCheck?.Active;

--- a/src/ReverseProxy/Service/HealthChecks/ConsecutiveFailuresHealthPolicy.cs
+++ b/src/ReverseProxy/Service/HealthChecks/ConsecutiveFailuresHealthPolicy.cs
@@ -16,7 +16,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
     internal sealed class ConsecutiveFailuresHealthPolicy : IActiveHealthCheckPolicy
     {
         private readonly ConsecutiveFailuresHealthPolicyOptions _options;
-        private readonly ConditionalWeakTable<ClusterInfo, ParsedMetadataEntry<double>> _clusterThresholds = new ConditionalWeakTable<ClusterInfo, ParsedMetadataEntry<double>>();
+        private readonly ConditionalWeakTable<ClusterState, ParsedMetadataEntry<double>> _clusterThresholds = new ConditionalWeakTable<ClusterState, ParsedMetadataEntry<double>>();
         private readonly ConditionalWeakTable<DestinationInfo, AtomicCounter> _failureCounters = new ConditionalWeakTable<DestinationInfo, AtomicCounter>();
         private readonly IDestinationHealthUpdater _healthUpdater;
 
@@ -28,7 +28,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             _healthUpdater = healthUpdater ?? throw new ArgumentNullException(nameof(healthUpdater));
         }
 
-        public void ProbingCompleted(ClusterInfo cluster, IReadOnlyList<DestinationProbingResult> probingResults)
+        public void ProbingCompleted(ClusterState cluster, IReadOnlyList<DestinationProbingResult> probingResults)
         {
             if (probingResults.Count == 0)
             {
@@ -50,7 +50,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             _healthUpdater.SetActive(cluster, newHealthStates);
         }
 
-        private double GetFailureThreshold(ClusterInfo cluster)
+        private double GetFailureThreshold(ClusterState cluster)
         {
             var thresholdEntry = _clusterThresholds.GetValue(cluster, c => new ParsedMetadataEntry<double>(TryParse, c, ConsecutiveFailuresHealthPolicyOptions.ThresholdMetadataName));
             return thresholdEntry.GetParsedOrDefault(_options.DefaultThreshold);

--- a/src/ReverseProxy/Service/HealthChecks/DefaultProbingRequestFactory.cs
+++ b/src/ReverseProxy/Service/HealthChecks/DefaultProbingRequestFactory.cs
@@ -13,14 +13,14 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         public HttpRequestMessage CreateRequest(ClusterModel cluster, DestinationConfig destination)
         {
             var probeAddress = !string.IsNullOrEmpty(destination.Options.Health) ? destination.Options.Health : destination.Options.Address;
-            var probePath = cluster.Options.HealthCheck.Active.Path;
+            var probePath = cluster.Config.HealthCheck.Active.Path;
             UriHelper.FromAbsolute(probeAddress, out var destinationScheme, out var destinationHost, out var destinationPathBase, out _, out _);
             var probeUri = UriHelper.BuildAbsolute(destinationScheme, destinationHost, destinationPathBase, probePath, default);
             return new HttpRequestMessage(HttpMethod.Get, probeUri)
             {
-                Version = cluster.Options.HttpRequest?.Version ?? HttpVersion.Version20,
+                Version = cluster.Config.HttpRequest?.Version ?? HttpVersion.Version20,
 #if NET
-                VersionPolicy = cluster.Options.HttpRequest?.VersionPolicy ?? HttpVersionPolicy.RequestVersionOrLower
+                VersionPolicy = cluster.Config.HttpRequest?.VersionPolicy ?? HttpVersionPolicy.RequestVersionOrLower
 #endif
             };
         }

--- a/src/ReverseProxy/Service/HealthChecks/DefaultProbingRequestFactory.cs
+++ b/src/ReverseProxy/Service/HealthChecks/DefaultProbingRequestFactory.cs
@@ -10,17 +10,17 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 {
     internal sealed class DefaultProbingRequestFactory : IProbingRequestFactory
     {
-        public HttpRequestMessage CreateRequest(ClusterConfig clusterConfig, DestinationConfig destinationConfig)
+        public HttpRequestMessage CreateRequest(ClusterModel cluster, DestinationConfig destination)
         {
-            var probeAddress = !string.IsNullOrEmpty(destinationConfig.Options.Health) ? destinationConfig.Options.Health : destinationConfig.Options.Address;
-            var probePath = clusterConfig.Options.HealthCheck.Active.Path;
+            var probeAddress = !string.IsNullOrEmpty(destination.Options.Health) ? destination.Options.Health : destination.Options.Address;
+            var probePath = cluster.Options.HealthCheck.Active.Path;
             UriHelper.FromAbsolute(probeAddress, out var destinationScheme, out var destinationHost, out var destinationPathBase, out _, out _);
             var probeUri = UriHelper.BuildAbsolute(destinationScheme, destinationHost, destinationPathBase, probePath, default);
             return new HttpRequestMessage(HttpMethod.Get, probeUri)
             {
-                Version = clusterConfig.Options.HttpRequest?.Version ?? HttpVersion.Version20,
+                Version = cluster.Options.HttpRequest?.Version ?? HttpVersion.Version20,
 #if NET
-                VersionPolicy = clusterConfig.Options.HttpRequest?.VersionPolicy ?? HttpVersionPolicy.RequestVersionOrLower
+                VersionPolicy = cluster.Options.HttpRequest?.VersionPolicy ?? HttpVersionPolicy.RequestVersionOrLower
 #endif
             };
         }

--- a/src/ReverseProxy/Service/HealthChecks/DestinationHealthUpdater.cs
+++ b/src/ReverseProxy/Service/HealthChecks/DestinationHealthUpdater.cs
@@ -13,16 +13,16 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 {
     internal sealed class DestinationHealthUpdater : IDestinationHealthUpdater, IDisposable
     {
-        private readonly EntityActionScheduler<(ClusterInfo Cluster, DestinationInfo Destination)> _scheduler;
+        private readonly EntityActionScheduler<(ClusterState Cluster, DestinationInfo Destination)> _scheduler;
         private readonly ILogger<DestinationHealthUpdater> _logger;
 
         public DestinationHealthUpdater(ITimerFactory timerFactory, ILogger<DestinationHealthUpdater> logger)
         {
-            _scheduler = new EntityActionScheduler<(ClusterInfo Cluster, DestinationInfo Destination)>(d => Reactivate(d.Cluster, d.Destination), autoStart: true, runOnce: true, timerFactory);
+            _scheduler = new EntityActionScheduler<(ClusterState Cluster, DestinationInfo Destination)>(d => Reactivate(d.Cluster, d.Destination), autoStart: true, runOnce: true, timerFactory);
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public void SetActive(ClusterInfo cluster, IEnumerable<NewActiveDestinationHealth> newHealthPairs)
+        public void SetActive(ClusterState cluster, IEnumerable<NewActiveDestinationHealth> newHealthPairs)
         {
             var changed = false;
             foreach (var newHealthPair in newHealthPairs)
@@ -52,24 +52,24 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             }
         }
 
-        public void SetPassive(ClusterInfo cluster, DestinationInfo destination, DestinationHealth newHealth, TimeSpan reactivationPeriod)
+        public void SetPassive(ClusterState cluster, DestinationInfo destination, DestinationHealth newHealth, TimeSpan reactivationPeriod)
         {
             _ = SetPassiveAsync(cluster, destination, newHealth, reactivationPeriod);
         }
 
-        internal Task SetPassiveAsync(ClusterInfo cluster, DestinationInfo destination, DestinationHealth newHealth, TimeSpan reactivationPeriod)
+        internal Task SetPassiveAsync(ClusterState cluster, DestinationInfo destination, DestinationHealth newHealth, TimeSpan reactivationPeriod)
         {
             var healthState = destination.Health;
             if (newHealth != healthState.Passive)
             {
                 healthState.Passive = newHealth;
                 ScheduleReactivation(cluster, destination, newHealth, reactivationPeriod);
-                return Task.Factory.StartNew(c => ((ClusterInfo)c).UpdateDynamicState(), cluster, TaskCreationOptions.RunContinuationsAsynchronously);
+                return Task.Factory.StartNew(c => ((ClusterState)c).UpdateDynamicState(), cluster, TaskCreationOptions.RunContinuationsAsynchronously);
             }
             return Task.CompletedTask;
         }
 
-        private void ScheduleReactivation(ClusterInfo cluster, DestinationInfo destination, DestinationHealth newHealth, TimeSpan reactivationPeriod)
+        private void ScheduleReactivation(ClusterState cluster, DestinationInfo destination, DestinationHealth newHealth, TimeSpan reactivationPeriod)
         {
             if (newHealth == DestinationHealth.Unhealthy)
             {
@@ -83,7 +83,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             _scheduler.Dispose();
         }
 
-        private Task Reactivate(ClusterInfo cluster, DestinationInfo destination)
+        private Task Reactivate(ClusterState cluster, DestinationInfo destination)
         {
             var healthState = destination.Health;
             if (healthState.Passive == DestinationHealth.Unhealthy)

--- a/src/ReverseProxy/Service/HealthChecks/IActiveHealthCheckMonitor.cs
+++ b/src/ReverseProxy/Service/HealthChecks/IActiveHealthCheckMonitor.cs
@@ -27,6 +27,6 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         /// </summary>
         /// <param name="clusters">Clusters to check the health of their destinations.</param>
         /// <returns><see cref="Task"/> representing the health check process.</returns>
-        Task CheckHealthAsync(IEnumerable<ClusterInfo> clusters);
+        Task CheckHealthAsync(IEnumerable<ClusterState> clusters);
     }
 }

--- a/src/ReverseProxy/Service/HealthChecks/IActiveHealthCheckPolicy.cs
+++ b/src/ReverseProxy/Service/HealthChecks/IActiveHealthCheckPolicy.cs
@@ -23,6 +23,6 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         /// </summary>
         /// <param name="cluster">Cluster.</param>
         /// <param name="probingResults">Destination probing results.</param>
-        void ProbingCompleted(ClusterInfo cluster, IReadOnlyList<DestinationProbingResult> probingResults);
+        void ProbingCompleted(ClusterState cluster, IReadOnlyList<DestinationProbingResult> probingResults);
     }
 }

--- a/src/ReverseProxy/Service/HealthChecks/IDestinationHealthUpdater.cs
+++ b/src/ReverseProxy/Service/HealthChecks/IDestinationHealthUpdater.cs
@@ -22,13 +22,13 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         /// <param name="reactivationPeriod">If <paramref name="newHealth"/> is <see cref="DestinationHealth.Unhealthy"/>,
         /// this parameter specifies a reactivation period after which the destination's <see cref="DestinationHealthState.Passive"/> value
         /// will be reset to <see cref="DestinationHealth.Unknown"/>. Otherwise, it's not used.</param>
-        void SetPassive(ClusterInfo cluster, DestinationInfo destination, DestinationHealth newHealth, TimeSpan reactivationPeriod);
+        void SetPassive(ClusterState cluster, DestinationInfo destination, DestinationHealth newHealth, TimeSpan reactivationPeriod);
 
         /// <summary>
         /// Sets the active health values on the given destinations.
         /// </summary>
         /// <param name="cluster">Cluster.</param>
         /// <param name="newHealthStates">New active health states.</param>
-        void SetActive(ClusterInfo cluster, IEnumerable<NewActiveDestinationHealth> newHealthStates);
+        void SetActive(ClusterState cluster, IEnumerable<NewActiveDestinationHealth> newHealthStates);
     }
 }

--- a/src/ReverseProxy/Service/HealthChecks/IPassiveHealthCheckPolicy.cs
+++ b/src/ReverseProxy/Service/HealthChecks/IPassiveHealthCheckPolicy.cs
@@ -23,6 +23,6 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         /// <param name="cluster">Request's cluster.</param>
         /// <param name="destination">Request's destination.</param>
         /// <param name="context">Context.</param>
-        void RequestProxied(ClusterInfo cluster, DestinationInfo destination, HttpContext context);
+        void RequestProxied(ClusterState cluster, DestinationInfo destination, HttpContext context);
     }
 }

--- a/src/ReverseProxy/Service/HealthChecks/IProbingRequestFactory.cs
+++ b/src/ReverseProxy/Service/HealthChecks/IProbingRequestFactory.cs
@@ -14,9 +14,9 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         /// <summary>
         /// Creates a probing request.
         /// </summary>
-        /// <param name="clusterConfig">Cluster's config.</param>
-        /// <param name="destinationConfig">Destination being probed.</param>
+        /// <param name="cluster">The cluster being probed.</param>
+        /// <param name="destination">The destination being probed.</param>
         /// <returns>Probing <see cref="HttpRequestMessage"/>.</returns>
-        HttpRequestMessage CreateRequest(ClusterConfig clusterConfig, DestinationConfig destinationConfig);
+        HttpRequestMessage CreateRequest(ClusterModel cluster, DestinationConfig destination);
     }
 }

--- a/src/ReverseProxy/Service/HealthChecks/TransportFailureRateHealthPolicy.cs
+++ b/src/ReverseProxy/Service/HealthChecks/TransportFailureRateHealthPolicy.cs
@@ -49,7 +49,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         {
             var error = context.Features.Get<IProxyErrorFeature>();
             var newHealth = EvaluateProxiedRequest(cluster, destination, error != null);
-            var reactivationPeriod = cluster.Model.Options.HealthCheck.Passive.ReactivationPeriod ?? _defaultReactivationPeriod;
+            var reactivationPeriod = cluster.Model.Config.HealthCheck.Passive.ReactivationPeriod ?? _defaultReactivationPeriod;
             _healthUpdater.SetPassive(cluster, destination, newHealth, reactivationPeriod);
         }
 

--- a/src/ReverseProxy/Service/HealthChecks/TransportFailureRateHealthPolicy.cs
+++ b/src/ReverseProxy/Service/HealthChecks/TransportFailureRateHealthPolicy.cs
@@ -49,7 +49,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         {
             var error = context.Features.Get<IProxyErrorFeature>();
             var newHealth = EvaluateProxiedRequest(cluster, destination, error != null);
-            var reactivationPeriod = cluster.Config.Options.HealthCheck.Passive.ReactivationPeriod ?? _defaultReactivationPeriod;
+            var reactivationPeriod = cluster.Model.Options.HealthCheck.Passive.ReactivationPeriod ?? _defaultReactivationPeriod;
             _healthUpdater.SetPassive(cluster, destination, newHealth, reactivationPeriod);
         }
 

--- a/src/ReverseProxy/Service/HealthChecks/TransportFailureRateHealthPolicy.cs
+++ b/src/ReverseProxy/Service/HealthChecks/TransportFailureRateHealthPolicy.cs
@@ -30,7 +30,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         private readonly IDestinationHealthUpdater _healthUpdater;
         private readonly TransportFailureRateHealthPolicyOptions _policyOptions;
         private readonly IClock _clock;
-        private readonly ConditionalWeakTable<ClusterInfo, ParsedMetadataEntry<double>> _clusterFailureRateLimits = new ConditionalWeakTable<ClusterInfo, ParsedMetadataEntry<double>>();
+        private readonly ConditionalWeakTable<ClusterState, ParsedMetadataEntry<double>> _clusterFailureRateLimits = new ConditionalWeakTable<ClusterState, ParsedMetadataEntry<double>>();
         private readonly ConditionalWeakTable<DestinationInfo, ProxiedRequestHistory> _requestHistories = new ConditionalWeakTable<DestinationInfo, ProxiedRequestHistory>();
 
         public string Name => HealthCheckConstants.PassivePolicy.TransportFailureRate;
@@ -45,7 +45,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             _healthUpdater = healthUpdater ?? throw new ArgumentNullException(nameof(healthUpdater));
         }
 
-        public void RequestProxied(ClusterInfo cluster, DestinationInfo destination, HttpContext context)
+        public void RequestProxied(ClusterState cluster, DestinationInfo destination, HttpContext context)
         {
             var error = context.Features.Get<IProxyErrorFeature>();
             var newHealth = EvaluateProxiedRequest(cluster, destination, error != null);
@@ -53,7 +53,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             _healthUpdater.SetPassive(cluster, destination, newHealth, reactivationPeriod);
         }
 
-        private DestinationHealth EvaluateProxiedRequest(ClusterInfo cluster, DestinationInfo destination, bool failed)
+        private DestinationHealth EvaluateProxiedRequest(ClusterState cluster, DestinationInfo destination, bool failed)
         {
             var history = _requestHistories.GetOrCreateValue(destination);
             var rateLimitEntry = _clusterFailureRateLimits.GetValue(cluster, c => new ParsedMetadataEntry<double>(TryParse, c, TransportFailureRateHealthPolicyOptions.FailureRateLimitMetadataName));

--- a/src/ReverseProxy/Service/LoadBalancing/RoundRobinLoadBalancingPolicy.cs
+++ b/src/ReverseProxy/Service/LoadBalancing/RoundRobinLoadBalancingPolicy.cs
@@ -13,7 +13,7 @@ namespace Yarp.ReverseProxy.Service.LoadBalancing
 {
     internal sealed class RoundRobinLoadBalancingPolicy : ILoadBalancingPolicy
     {
-        private readonly ConditionalWeakTable<ClusterInfo, AtomicCounter> _counters = new ();
+        private readonly ConditionalWeakTable<ClusterState, AtomicCounter> _counters = new ();
 
         public string Name => LoadBalancingPolicies.RoundRobin;
 
@@ -24,7 +24,7 @@ namespace Yarp.ReverseProxy.Service.LoadBalancing
                 return null;
             }
 
-            var counter = _counters.GetOrCreateValue(context.GetClusterInfo());
+            var counter = _counters.GetOrCreateValue(context.GetClusterState());
 
             // Increment returns the new value and we want the first return value to be 0.
             var offset = counter.Increment() - 1;

--- a/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
@@ -376,29 +376,29 @@ namespace Yarp.ReverseProxy.Service.Management
                 }
                 else
                 {
-                    var newCluster = new ClusterState(incomingCluster.ClusterId);
+                    var newClusterState = new ClusterState(incomingCluster.ClusterId);
 
-                    UpdateRuntimeDestinations(incomingCluster.Destinations, newCluster.Destinations);
+                    UpdateRuntimeDestinations(incomingCluster.Destinations, newClusterState.Destinations);
 
                     var httpClient = _httpClientFactory.CreateClient(new ProxyHttpClientContext
                     {
-                        ClusterId = newCluster.ClusterId,
+                        ClusterId = newClusterState.ClusterId,
                         NewOptions = incomingCluster.HttpClient ?? ProxyHttpClientOptions.Empty,
                         NewMetadata = incomingCluster.Metadata
                     });
 
-                    newCluster.Model = new ClusterModel(incomingCluster, httpClient);
-                    newCluster.Revision++;
+                    newClusterState.Model = new ClusterModel(incomingCluster, httpClient);
+                    newClusterState.Revision++;
                     Log.ClusterAdded(_logger, incomingCluster.ClusterId);
 
-                    newCluster.ProcessDestinationChanges();
+                    newClusterState.ProcessDestinationChanges();
 
-                    var added = _clusters.TryAdd(newCluster.ClusterId, newCluster);
+                    var added = _clusters.TryAdd(newClusterState.ClusterId, newClusterState);
                     Debug.Assert(added);
 
                     foreach (var listener in _clusterChangeListeners)
                     {
-                        listener.OnClusterAdded(newCluster);
+                        listener.OnClusterAdded(newClusterState);
                     }
                 }
             }

--- a/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
@@ -35,7 +35,7 @@ namespace Yarp.ReverseProxy.Service.Management
         private readonly ILogger<ProxyConfigManager> _logger;
         private readonly IProxyConfigProvider _provider;
         private readonly IClusterChangeListener[] _clusterChangeListeners;
-        private readonly ConcurrentDictionary<string, ClusterInfo> _clusters = new(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, ClusterState> _clusters = new(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<string, RouteState> _routes = new(StringComparer.OrdinalIgnoreCase);
         private readonly IProxyConfigFilter[] _filters;
         private readonly IConfigValidator _configValidator;
@@ -376,7 +376,7 @@ namespace Yarp.ReverseProxy.Service.Management
                 }
                 else
                 {
-                    var newCluster = new ClusterInfo(incomingCluster.Id);
+                    var newCluster = new ClusterState(incomingCluster.Id);
 
                     UpdateRuntimeDestinations(incomingCluster.Destinations, newCluster.Destinations);
 
@@ -570,7 +570,7 @@ namespace Yarp.ReverseProxy.Service.Management
             }
         }
 
-        private RouteModel BuildRouteModel(RouteConfig source, ClusterInfo cluster)
+        private RouteModel BuildRouteModel(RouteConfig source, ClusterState cluster)
         {
             var transforms = _transformBuilder.Build(source, cluster?.Config?.Options);
 

--- a/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
@@ -339,29 +339,29 @@ namespace Yarp.ReverseProxy.Service.Management
                 {
                     var destinationsChanged = UpdateRuntimeDestinations(incomingCluster.Destinations, currentCluster.Destinations);
 
-                    var currentClusterConfig = currentCluster.Config;
+                    var currentClusterModel = currentCluster.Model;
 
                     var httpClient = _httpClientFactory.CreateClient(new ProxyHttpClientContext
                     {
                         ClusterId = currentCluster.ClusterId,
-                        OldOptions = currentClusterConfig.Options.HttpClient ?? ProxyHttpClientOptions.Empty,
-                        OldMetadata = currentClusterConfig.Options.Metadata,
-                        OldClient = currentClusterConfig.HttpClient,
+                        OldOptions = currentClusterModel.Options.HttpClient ?? ProxyHttpClientOptions.Empty,
+                        OldMetadata = currentClusterModel.Options.Metadata,
+                        OldClient = currentClusterModel.HttpClient,
                         NewOptions = incomingCluster.HttpClient ?? ProxyHttpClientOptions.Empty,
                         NewMetadata = incomingCluster.Metadata
                     });
 
-                    var newClusterConfig = new ClusterConfig(incomingCluster, httpClient);
+                    var newClusterModel = new ClusterModel(incomingCluster, httpClient);
 
                     // Excludes destination changes, they're tracked separately.
-                    var configChanged = currentClusterConfig.HasConfigChanged(newClusterConfig);
+                    var configChanged = currentClusterModel.HasConfigChanged(newClusterModel);
                     if (configChanged)
                     {
                         currentCluster.Revision++;
                         Log.ClusterChanged(_logger, incomingCluster.Id);
 
                         // Config changed, so update runtime cluster
-                        currentCluster.Config = newClusterConfig;
+                        currentCluster.Model = newClusterModel;
                     }
 
                     if (destinationsChanged || configChanged)
@@ -387,7 +387,7 @@ namespace Yarp.ReverseProxy.Service.Management
                         NewMetadata = incomingCluster.Metadata
                     });
 
-                    newCluster.Config = new ClusterConfig(incomingCluster, httpClient);
+                    newCluster.Model = new ClusterModel(incomingCluster, httpClient);
                     newCluster.Revision++;
                     Log.ClusterAdded(_logger, incomingCluster.Id);
 
@@ -572,7 +572,7 @@ namespace Yarp.ReverseProxy.Service.Management
 
         private RouteModel BuildRouteModel(RouteConfig source, ClusterState cluster)
         {
-            var transforms = _transformBuilder.Build(source, cluster?.Config?.Options);
+            var transforms = _transformBuilder.Build(source, cluster?.Model?.Options);
 
             return new RouteModel(source, cluster, transforms);
         }

--- a/src/ReverseProxy/Service/Proxy/Infrastructure/ProxyHttpClientContext.cs
+++ b/src/ReverseProxy/Service/Proxy/Infrastructure/ProxyHttpClientContext.cs
@@ -14,7 +14,7 @@ namespace Yarp.ReverseProxy.Service.Proxy.Infrastructure
     public class ProxyHttpClientContext
     {
         /// <summary>
-        /// Id of a <see cref="ClusterConfig"/> HTTP client belongs to.
+        /// Id of a <see cref="ClusterModel"/> HTTP client belongs to.
         /// </summary>
         public string ClusterId { get; set; }
 

--- a/src/ReverseProxy/Service/RuntimeModel/ClusterModel.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/ClusterModel.cs
@@ -20,14 +20,14 @@ namespace Yarp.ReverseProxy.RuntimeModel
     public sealed class ClusterModel
     {
         public ClusterModel(
-            Cluster cluster,
+            ClusterConfig config,
             HttpMessageInvoker httpClient)
         {
-            Options = cluster ?? throw new ArgumentNullException(nameof(cluster));
+            Config = config ?? throw new ArgumentNullException(nameof(config));
             HttpClient = httpClient;
         }
 
-        public Cluster Options { get; }
+        public ClusterConfig Config { get; }
 
         /// <summary>
         /// An <see cref="HttpMessageInvoker"/> that used for proxying requests to an upstream server.
@@ -39,7 +39,7 @@ namespace Yarp.ReverseProxy.RuntimeModel
         // and destinations are the most likely to change.
         internal bool HasConfigChanged(ClusterModel newModel)
         {
-            return !Options.EqualsExcludingDestinations(newModel.Options) || newModel.HttpClient != HttpClient;
+            return !Config.EqualsExcludingDestinations(newModel.Config) || newModel.HttpClient != HttpClient;
         }
     }
 }

--- a/src/ReverseProxy/Service/RuntimeModel/ClusterModel.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/ClusterModel.cs
@@ -10,16 +10,16 @@ namespace Yarp.ReverseProxy.RuntimeModel
     /// <summary>
     /// Immutable representation of the portions of a cluster
     /// that only change in reaction to configuration changes
-    /// (e.g. health check options).
+    /// (e.g. http client options).
     /// </summary>
     /// <remarks>
     /// All members must remain immutable to avoid thread safety issues.
-    /// Instead, instances of <see cref="ClusterConfig"/> are replaced
+    /// Instead, instances of <see cref="ClusterModel"/> are replaced
     /// in their entirety when values need to change.
     /// </remarks>
-    public sealed class ClusterConfig
+    public sealed class ClusterModel
     {
-        public ClusterConfig(
+        public ClusterModel(
             Cluster cluster,
             HttpMessageInvoker httpClient)
         {
@@ -37,9 +37,9 @@ namespace Yarp.ReverseProxy.RuntimeModel
         // We intentionally do not consider destination changes when updating the cluster Revision.
         // Revision is used to rebuild routing endpoints which should be unrelated to destinations,
         // and destinations are the most likely to change.
-        internal bool HasConfigChanged(ClusterConfig newClusterConfig)
+        internal bool HasConfigChanged(ClusterModel newModel)
         {
-            return !Options.EqualsExcludingDestinations(newClusterConfig.Options) || newClusterConfig.HttpClient != HttpClient;
+            return !Options.EqualsExcludingDestinations(newModel.Options) || newModel.HttpClient != HttpClient;
         }
     }
 }

--- a/src/ReverseProxy/Service/RuntimeModel/ClusterState.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/ClusterState.cs
@@ -119,7 +119,7 @@ namespace Yarp.ReverseProxy.RuntimeModel
             {
                 try
                 {
-                    var healthChecks = _model?.Options.HealthCheck;
+                    var healthChecks = _model?.Config.HealthCheck;
                     var allDestinations = _destinationsSnapshot;
                     var availableDestinations = allDestinations;
                     if (allDestinations == null)

--- a/src/ReverseProxy/Service/RuntimeModel/ClusterState.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/ClusterState.cs
@@ -18,7 +18,7 @@ namespace Yarp.ReverseProxy.RuntimeModel
         private readonly object _stateLock = new object();
         private volatile ClusterDynamicState _dynamicState = new ClusterDynamicState(Array.Empty<DestinationInfo>(), Array.Empty<DestinationInfo>());
         private volatile IReadOnlyList<DestinationInfo> _destinationsSnapshot;
-        private volatile ClusterConfig _config;
+        private volatile ClusterModel _model;
         private readonly SemaphoreSlim _updateRequests = new SemaphoreSlim(2);
 
         /// <summary>
@@ -38,10 +38,10 @@ namespace Yarp.ReverseProxy.RuntimeModel
         /// <summary>
         /// Encapsulates parts of a cluster that can change atomically in reaction to config changes.
         /// </summary>
-        public ClusterConfig Config
+        public ClusterModel Model
         {
-            get => _config;
-            internal set => _config = value ?? throw new ArgumentNullException(nameof(value));
+            get => _model;
+            internal set => _model = value ?? throw new ArgumentNullException(nameof(value));
         }
 
         /// <summary>
@@ -119,7 +119,7 @@ namespace Yarp.ReverseProxy.RuntimeModel
             {
                 try
                 {
-                    var healthChecks = _config?.Options.HealthCheck;
+                    var healthChecks = _model?.Options.HealthCheck;
                     var allDestinations = _destinationsSnapshot;
                     var availableDestinations = allDestinations;
                     if (allDestinations == null)

--- a/src/ReverseProxy/Service/RuntimeModel/ClusterState.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/ClusterState.cs
@@ -13,14 +13,7 @@ namespace Yarp.ReverseProxy.RuntimeModel
     /// <summary>
     /// Representation of a cluster for use at runtime.
     /// </summary>
-    /// <remarks>
-    /// Note that while this class is immutable, specific members such as
-    /// <see cref="Config"/> and <see cref="DynamicState"/> hold mutable references
-    /// that can be updated atomically and which will always have latest information
-    /// relevant to this cluster.
-    /// All members are thread safe.
-    /// </remarks>
-    public sealed class ClusterInfo
+    public sealed class ClusterState
     {
         private readonly object _stateLock = new object();
         private volatile ClusterDynamicState _dynamicState = new ClusterDynamicState(Array.Empty<DestinationInfo>(), Array.Empty<DestinationInfo>());
@@ -29,10 +22,10 @@ namespace Yarp.ReverseProxy.RuntimeModel
         private readonly SemaphoreSlim _updateRequests = new SemaphoreSlim(2);
 
         /// <summary>
-        /// Creates a new ClusterInfo. This constructor is for tests and infrastructure, ClusterInfo is normally constructed by the configuration
+        /// Creates a new instance. This constructor is for tests and infrastructure, this type is normally constructed by the configuration
         /// loading infrastructure.
         /// </summary>
-        public ClusterInfo(string clusterId)
+        public ClusterState(string clusterId)
         {
             ClusterId = clusterId ?? throw new ArgumentNullException(nameof(clusterId));
         }
@@ -43,8 +36,7 @@ namespace Yarp.ReverseProxy.RuntimeModel
         public string ClusterId { get; }
 
         /// <summary>
-        /// Encapsulates parts of a cluster that can change atomically
-        /// in reaction to config changes.
+        /// Encapsulates parts of a cluster that can change atomically in reaction to config changes.
         /// </summary>
         public ClusterConfig Config
         {

--- a/src/ReverseProxy/Service/RuntimeModel/IClusterChangeListener.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/IClusterChangeListener.cs
@@ -9,21 +9,21 @@ namespace Yarp.ReverseProxy.RuntimeModel
     public interface IClusterChangeListener
     {
         /// <summary>
-        /// Gets called after a new <see cref="ClusterInfo"/> has been added.
+        /// Gets called after a new <see cref="ClusterState"/> has been added.
         /// </summary>
-        /// <param name="cluster">Added <see cref="ClusterInfo"/> instance.</param>
-        void OnClusterAdded(ClusterInfo cluster);
+        /// <param name="cluster">Added <see cref="ClusterState"/> instance.</param>
+        void OnClusterAdded(ClusterState cluster);
 
         /// <summary>
-        /// Gets called after an existing <see cref="ClusterInfo"/> has been changed.
+        /// Gets called after an existing <see cref="ClusterState"/> has been changed.
         /// </summary>
-        /// <param name="cluster">Changed <see cref="ClusterInfo"/> instance.</param>
-        void OnClusterChanged(ClusterInfo cluster);
+        /// <param name="cluster">Changed <see cref="ClusterState"/> instance.</param>
+        void OnClusterChanged(ClusterState cluster);
 
         /// <summary>
-        /// Gets called after an existing <see cref="ClusterInfo"/> has been removed.
+        /// Gets called after an existing <see cref="ClusterState"/> has been removed.
         /// </summary>
-        /// <param name="cluster">Removed <see cref="ClusterInfo"/> instance.</param>
-        void OnClusterRemoved(ClusterInfo cluster);
+        /// <param name="cluster">Removed <see cref="ClusterState"/> instance.</param>
+        void OnClusterRemoved(ClusterState cluster);
     }
 }

--- a/src/ReverseProxy/Service/RuntimeModel/RouteModel.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/RouteModel.cs
@@ -23,7 +23,7 @@ namespace Yarp.ReverseProxy.RuntimeModel
         /// </summary>
         public RouteModel(
             RouteConfig config,
-            ClusterInfo cluster,
+            ClusterState cluster,
             HttpTransformer transformer)
         {
             Config = config ?? throw new ArgumentNullException(nameof(config));
@@ -35,7 +35,7 @@ namespace Yarp.ReverseProxy.RuntimeModel
         /// <summary>
         /// The ClusterInfo instance associated with this route.
         /// </summary>
-        public ClusterInfo Cluster { get; }
+        public ClusterState Cluster { get; }
 
         /// <summary>
         /// Transforms to apply for this route.
@@ -47,7 +47,7 @@ namespace Yarp.ReverseProxy.RuntimeModel
         /// </summary>
         public RouteConfig Config { get; }
 
-        internal bool HasConfigChanged(RouteConfig newConfig, ClusterInfo cluster, int? routeRevision)
+        internal bool HasConfigChanged(RouteConfig newConfig, ClusterState cluster, int? routeRevision)
         {
             return Cluster != cluster || routeRevision != cluster?.Revision || !Config.Equals(newConfig);
         }

--- a/src/ReverseProxy/Service/SessionAffinity/AffinitizeTransform.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/AffinitizeTransform.cs
@@ -25,7 +25,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
         public override ValueTask ApplyAsync(ResponseTransformContext context)
         {
             var proxyFeature = context.HttpContext.GetReverseProxyFeature();
-            var options = proxyFeature.Cluster.Options.SessionAffinity;
+            var options = proxyFeature.Cluster.Config.SessionAffinity;
             // The transform should only be added to routes that have affinity enabled.
             Debug.Assert(options?.Enabled ?? true, "Session affinity is not enabled");
             var selectedDestination = proxyFeature.ProxiedDestination;

--- a/src/ReverseProxy/Service/SessionAffinity/AffinitizeTransform.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/AffinitizeTransform.cs
@@ -25,7 +25,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
         public override ValueTask ApplyAsync(ResponseTransformContext context)
         {
             var proxyFeature = context.HttpContext.GetReverseProxyFeature();
-            var options = proxyFeature.ClusterSnapshot.Options.SessionAffinity;
+            var options = proxyFeature.Cluster.Options.SessionAffinity;
             // The transform should only be added to routes that have affinity enabled.
             Debug.Assert(options?.Enabled ?? true, "Session affinity is not enabled");
             var selectedDestination = proxyFeature.ProxiedDestination;

--- a/src/ReverseProxy/Service/SessionAffinity/AffinitizeTransformProvider.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/AffinitizeTransformProvider.cs
@@ -40,7 +40,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
 
             if (!_sessionAffinityProviders.ContainsKey(affinityMode))
             {
-                context.Errors.Add(new ArgumentException($"No matching {nameof(ISessionAffinityProvider)} found for the session affinity mode '{affinityMode}' set on the cluster '{context.Cluster.Id}'."));
+                context.Errors.Add(new ArgumentException($"No matching {nameof(ISessionAffinityProvider)} found for the session affinity mode '{affinityMode}' set on the cluster '{context.Cluster.ClusterId}'."));
             }
         }
 

--- a/src/ReverseProxy/Utilities/ParsedMetadataEntry.cs
+++ b/src/ReverseProxy/Utilities/ParsedMetadataEntry.cs
@@ -26,7 +26,7 @@ namespace Yarp.ReverseProxy.Utilities
         public T GetParsedOrDefault(T defaultValue)
         {
             var currentValue = _value;
-            if (_cluster.Config.Options.Metadata != null && _cluster.Config.Options.Metadata.TryGetValue(_metadataName, out var stringValue))
+            if (_cluster.Model.Options.Metadata != null && _cluster.Model.Options.Metadata.TryGetValue(_metadataName, out var stringValue))
             {
                 if (currentValue == null || currentValue.Item1 != stringValue)
                 {

--- a/src/ReverseProxy/Utilities/ParsedMetadataEntry.cs
+++ b/src/ReverseProxy/Utilities/ParsedMetadataEntry.cs
@@ -26,7 +26,7 @@ namespace Yarp.ReverseProxy.Utilities
         public T GetParsedOrDefault(T defaultValue)
         {
             var currentValue = _value;
-            if (_cluster.Model.Options.Metadata != null && _cluster.Model.Options.Metadata.TryGetValue(_metadataName, out var stringValue))
+            if (_cluster.Model.Config.Metadata != null && _cluster.Model.Config.Metadata.TryGetValue(_metadataName, out var stringValue))
             {
                 if (currentValue == null || currentValue.Item1 != stringValue)
                 {

--- a/src/ReverseProxy/Utilities/ParsedMetadataEntry.cs
+++ b/src/ReverseProxy/Utilities/ParsedMetadataEntry.cs
@@ -10,13 +10,13 @@ namespace Yarp.ReverseProxy.Utilities
     {
         private readonly Parser _parser;
         private readonly string _metadataName;
-        private readonly ClusterInfo _cluster;
+        private readonly ClusterState _cluster;
         // Use a volatile field of a reference Tuple<T1, T2> type to ensure atomicity during concurrent access.
         private volatile Tuple<string, T> _value;
 
         public delegate bool Parser(string stringValue, out T parsedValue);
 
-        public ParsedMetadataEntry(Parser parser, ClusterInfo cluster, string metadataName)
+        public ParsedMetadataEntry(Parser parser, ClusterState cluster, string metadataName)
         {
             _parser = parser ?? throw new ArgumentNullException(nameof(parser));
             _cluster = cluster ?? throw new ArgumentNullException(nameof(cluster));

--- a/test/ReverseProxy.FunctionalTests/Common/InMemoryConfigProvider.cs
+++ b/test/ReverseProxy.FunctionalTests/Common/InMemoryConfigProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class InMemoryConfigProviderExtensions
     {
-        public static IReverseProxyBuilder LoadFromMemory(this IReverseProxyBuilder builder, IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
+        public static IReverseProxyBuilder LoadFromMemory(this IReverseProxyBuilder builder, IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
         {
             builder.Services.AddSingleton<IProxyConfigProvider>(new InMemoryConfigProvider(routes, clusters));
             return builder;
@@ -26,14 +26,14 @@ namespace Yarp.ReverseProxy.Configuration
     {
         private volatile InMemoryConfig _config;
 
-        public InMemoryConfigProvider(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
+        public InMemoryConfigProvider(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
         {
             _config = new InMemoryConfig(routes, clusters);
         }
 
         public IProxyConfig GetConfig() => _config;
 
-        public void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
+        public void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
         {
             var oldConfig = _config;
             _config = new InMemoryConfig(routes, clusters);
@@ -44,7 +44,7 @@ namespace Yarp.ReverseProxy.Configuration
         {
             private readonly CancellationTokenSource _cts = new CancellationTokenSource();
 
-            public InMemoryConfig(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
+            public InMemoryConfig(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
             {
                 Routes = routes;
                 Clusters = clusters;
@@ -53,7 +53,7 @@ namespace Yarp.ReverseProxy.Configuration
 
             public IReadOnlyList<RouteConfig> Routes { get; }
 
-            public IReadOnlyList<Cluster> Clusters { get; }
+            public IReadOnlyList<ClusterConfig> Clusters { get; }
 
             public IChangeToken ChangeToken { get; }
 

--- a/test/ReverseProxy.FunctionalTests/Common/TestEnvironment.cs
+++ b/test/ReverseProxy.FunctionalTests/Common/TestEnvironment.cs
@@ -93,9 +93,9 @@ namespace Yarp.ReverseProxy.Common
                         Match = new RouteMatch { Path = "/{**catchall}" }
                     };
 
-                    var cluster = new Cluster
+                    var cluster = new ClusterConfig
                     {
-                        Id = clusterId,
+                        ClusterId = clusterId,
                         Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
                         {
                             { "destination1",  new Destination() { Address = destinationAddress } }

--- a/test/ReverseProxy.Kubernetes.Tests/testassets/basic-ingress/clusters.json
+++ b/test/ReverseProxy.Kubernetes.Tests/testassets/basic-ingress/clusters.json
@@ -1,6 +1,6 @@
 [
   {
-    "Id": "frontend:80",
+    "ClusterId": "frontend:80",
     "LoadBalancingPolicy": null,
     "SessionAffinity": null,
     "HealthCheck": null,

--- a/test/ReverseProxy.Kubernetes.Tests/testassets/exact-match/clusters.json
+++ b/test/ReverseProxy.Kubernetes.Tests/testassets/exact-match/clusters.json
@@ -1,6 +1,6 @@
 [
   {
-    "Id": "frontend:80",
+    "ClusterId": "frontend:80",
     "LoadBalancingPolicy": null,
     "SessionAffinity": null,
     "HealthCheck": null,

--- a/test/ReverseProxy.Kubernetes.Tests/testassets/https/clusters.json
+++ b/test/ReverseProxy.Kubernetes.Tests/testassets/https/clusters.json
@@ -1,6 +1,6 @@
 [
   {
-    "Id": "frontend:443",
+    "ClusterId": "frontend:443",
     "LoadBalancingPolicy": null,
     "SessionAffinity": null,
     "HealthCheck": null,

--- a/test/ReverseProxy.Kubernetes.Tests/testassets/multiple-endpoints-ports/clusters.json
+++ b/test/ReverseProxy.Kubernetes.Tests/testassets/multiple-endpoints-ports/clusters.json
@@ -1,6 +1,6 @@
 [
   {
-    "Id": "frontend:80",
+    "ClusterId": "frontend:80",
     "LoadBalancingPolicy": null,
     "SessionAffinity": null,
     "HealthCheck": null,
@@ -16,7 +16,7 @@
     "Metadata": null
   },
   {
-    "Id": "frontend:443",
+    "ClusterId": "frontend:443",
     "LoadBalancingPolicy": null,
     "SessionAffinity": null,
     "HealthCheck": null,

--- a/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/DiscovererTests.cs
+++ b/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/DiscovererTests.cs
@@ -49,7 +49,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
                 .Returns(() => _scenarioOptions);
 
             Mock<IConfigValidator>()
-                .Setup(v => v.ValidateClusterAsync(It.IsAny<Cluster>()))
+                .Setup(v => v.ValidateClusterAsync(It.IsAny<ClusterConfig>()))
                 .ReturnsAsync(() => new List<Exception>());
             Mock<IConfigValidator>()
                 .Setup(v => v.ValidateRouteAsync(It.IsAny<RouteConfig>()))
@@ -575,7 +575,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
             _healthReports.Should().HaveCount(1);
         }
 
-        private static Cluster ClusterWithDestinations(Uri serviceName, Dictionary<string, string> labels,
+        private static ClusterConfig ClusterWithDestinations(Uri serviceName, Dictionary<string, string> labels,
             params KeyValuePair<string, Destination>[] destinations)
         {
             var newDestinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase);
@@ -587,7 +587,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
             return LabelsParser.BuildCluster(serviceName, labels, newDestinations);
         }
 
-        private async Task<(IReadOnlyList<RouteConfig> Routes, IReadOnlyList<Cluster> Clusters)> RunScenarioAsync()
+        private async Task<(IReadOnlyList<RouteConfig> Routes, IReadOnlyList<ClusterConfig> Clusters)> RunScenarioAsync()
         {
             if (_scenarioOptions == null)
             {

--- a/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/Util/LabelsParserTests.cs
+++ b/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/Util/LabelsParserTests.cs
@@ -60,9 +60,9 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
 
             var cluster = LabelsParser.BuildCluster(_testServiceName, labels, null);
 
-            var expectedCluster = new Cluster
+            var expectedCluster = new ClusterConfig
             {
-                Id = "MyCoolClusterId",
+                ClusterId = "MyCoolClusterId",
                 LoadBalancingPolicy = LoadBalancingPolicies.LeastRequests,
                 SessionAffinity = new SessionAffinityOptions
                 {
@@ -135,9 +135,9 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
 
             var cluster = LabelsParser.BuildCluster(_testServiceName, labels, null);
 
-            var expectedCluster = new Cluster
+            var expectedCluster = new ClusterConfig
             {
-                Id = "MyCoolClusterId",
+                ClusterId = "MyCoolClusterId",
                 SessionAffinity = new SessionAffinityOptions
                 {
                     Enabled = false,
@@ -215,7 +215,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
 
             var cluster = LabelsParser.BuildCluster(_testServiceName, labels, null);
 
-            cluster.Id.Should().Be(_testServiceName.ToString());
+            cluster.ClusterId.Should().Be(_testServiceName.ToString());
         }
 
         [Theory]
@@ -244,7 +244,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
                 { key, invalidValue },
             };
 
-            Func<Cluster> func = () => LabelsParser.BuildCluster(_testServiceName, labels, null);
+            Func<ClusterConfig> func = () => LabelsParser.BuildCluster(_testServiceName, labels, null);
 
             func.Should().Throw<ConfigException>().WithMessage($"Could not convert label {key}='{invalidValue}' *");
         }

--- a/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/ClusterTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/ClusterTests.cs
@@ -17,9 +17,9 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
         [Fact]
         public void Equals_Same_Value_Returns_True()
         {
-            var options1 = new Cluster
+            var options1 = new ClusterConfig
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
                 {
                     {
@@ -87,9 +87,9 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
                 Metadata = new Dictionary<string, string> { { "cluster1-K1", "cluster1-V1" }, { "cluster1-K2", "cluster1-V2" } }
             };
 
-            var options2 = new Cluster
+            var options2 = new ClusterConfig
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
                 {
                     {
@@ -167,9 +167,9 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
         [Fact]
         public void Equals_Different_Value_Returns_False()
         {
-            var options1 = new Cluster
+            var options1 = new ClusterConfig
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
                 {
                     {
@@ -234,7 +234,7 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
                 Metadata = new Dictionary<string, string> { { "cluster1-K1", "cluster1-V1" }, { "cluster1-K2", "cluster1-V2" } }
             };
 
-            Assert.False(options1.Equals(options1 with { Id = "different" }));
+            Assert.False(options1.Equals(options1 with { ClusterId = "different" }));
             Assert.False(options1.Equals(options1 with { Destinations = new Dictionary<string, Destination>() }));
             Assert.False(options1.Equals(options1 with { HealthCheck = new HealthCheckOptions() }));
             Assert.False(options1.Equals(options1 with { LoadBalancingPolicy = "different" }));
@@ -265,7 +265,7 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
         [Fact]
         public void Equals_Second_Null_Returns_False()
         {
-            var options1 = new Cluster();
+            var options1 = new ClusterConfig();
 
             var equals = options1.Equals(null);
 

--- a/test/ReverseProxy.Tests/Common/InMemoryConfigProvider.cs
+++ b/test/ReverseProxy.Tests/Common/InMemoryConfigProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class InMemoryConfigProviderExtensions
     {
-        public static IReverseProxyBuilder LoadFromMemory(this IReverseProxyBuilder builder, IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
+        public static IReverseProxyBuilder LoadFromMemory(this IReverseProxyBuilder builder, IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
         {
             builder.Services.AddSingleton<IProxyConfigProvider>(new InMemoryConfigProvider(routes, clusters));
             return builder;
@@ -26,14 +26,14 @@ namespace Yarp.ReverseProxy.Configuration
     {
         private volatile InMemoryConfig _config;
 
-        public InMemoryConfigProvider(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
+        public InMemoryConfigProvider(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
         {
             _config = new InMemoryConfig(routes, clusters);
         }
 
         public IProxyConfig GetConfig() => _config;
 
-        public void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
+        public void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
         {
             var oldConfig = _config;
             _config = new InMemoryConfig(routes, clusters);
@@ -44,7 +44,7 @@ namespace Yarp.ReverseProxy.Configuration
         {
             private readonly CancellationTokenSource _cts = new CancellationTokenSource();
 
-            public InMemoryConfig(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
+            public InMemoryConfig(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
             {
                 Routes = routes;
                 Clusters = clusters;
@@ -53,7 +53,7 @@ namespace Yarp.ReverseProxy.Configuration
 
             public IReadOnlyList<RouteConfig> Routes { get; }
 
-            public IReadOnlyList<Cluster> Clusters { get; }
+            public IReadOnlyList<ClusterConfig> Clusters { get; }
 
             public IChangeToken ChangeToken { get; }
 

--- a/test/ReverseProxy.Tests/Configuration/ConfigurationConfigProviderTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigurationConfigProviderTests.cs
@@ -33,9 +33,9 @@ namespace Yarp.ReverseProxy.Configuration
             Clusters =
             {
                 {
-                    new Cluster
+                    new ClusterConfig
                     {
-                        Id = "cluster1",
+                        ClusterId = "cluster1",
                         Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
                         {
                             {
@@ -104,9 +104,9 @@ namespace Yarp.ReverseProxy.Configuration
                     }
                 },
                 {
-                    new Cluster
+                    new ClusterConfig
                     {
-                        Id = "cluster2",
+                        ClusterId = "cluster2",
                         Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
                         {
                             { "destinationC", new Destination { Address = "https://localhost:10001/destC" } },
@@ -374,9 +374,9 @@ namespace Yarp.ReverseProxy.Configuration
             var provider = new ConfigurationConfigProvider(logger.Object, proxyConfig, certLoader.Object);
             var abstractConfig = (ConfigurationSnapshot)provider.GetConfig();
 
-            var abstractionsNamespace = typeof(Cluster).Namespace;
+            var abstractionsNamespace = typeof(ClusterConfig).Namespace;
             // Removed incompletely filled out instances.
-            abstractConfig.Clusters = abstractConfig.Clusters.Where(c => c.Id == "cluster1").ToList();
+            abstractConfig.Clusters = abstractConfig.Clusters.Where(c => c.ClusterId == "cluster1").ToList();
             abstractConfig.Routes = abstractConfig.Routes.Where(r => r.RouteId == "routeA").ToList();
 
             VerifyAllPropertiesAreSet(abstractConfig);
@@ -579,9 +579,9 @@ namespace Yarp.ReverseProxy.Configuration
             Assert.NotNull(abstractConfig);
             Assert.Equal(2, abstractConfig.Clusters.Count);
 
-            var cluster1 = validConfig.Clusters.First(c => c.Id == "cluster1");
-            Assert.Single(abstractConfig.Clusters.Where(c => c.Id == "cluster1"));
-            var abstractCluster1 = abstractConfig.Clusters.Single(c => c.Id == "cluster1");
+            var cluster1 = validConfig.Clusters.First(c => c.ClusterId == "cluster1");
+            Assert.Single(abstractConfig.Clusters.Where(c => c.ClusterId == "cluster1"));
+            var abstractCluster1 = abstractConfig.Clusters.Single(c => c.ClusterId == "cluster1");
             Assert.Equal(cluster1.Destinations["destinationA"].Address, abstractCluster1.Destinations["destinationA"].Address);
             Assert.Equal(cluster1.Destinations["destinationA"].Health, abstractCluster1.Destinations["destinationA"].Health);
             Assert.Equal(cluster1.Destinations["destinationA"].Metadata, abstractCluster1.Destinations["destinationA"].Metadata);
@@ -617,9 +617,9 @@ namespace Yarp.ReverseProxy.Configuration
             Assert.Equal(cluster1.HttpClient.DangerousAcceptAnyServerCertificate, abstractCluster1.HttpClient.DangerousAcceptAnyServerCertificate);
             Assert.Equal(cluster1.Metadata, abstractCluster1.Metadata);
 
-            var cluster2 = validConfig.Clusters.First(c => c.Id == "cluster2");
-            Assert.Single(abstractConfig.Clusters.Where(c => c.Id == "cluster2"));
-            var abstractCluster2 = abstractConfig.Clusters.Single(c => c.Id == "cluster2");
+            var cluster2 = validConfig.Clusters.First(c => c.ClusterId == "cluster2");
+            Assert.Single(abstractConfig.Clusters.Where(c => c.ClusterId == "cluster2"));
+            var abstractCluster2 = abstractConfig.Clusters.Single(c => c.ClusterId == "cluster2");
             Assert.Equal(cluster2.Destinations["destinationC"].Address, abstractCluster2.Destinations["destinationC"].Address);
             Assert.Equal(cluster2.Destinations["destinationC"].Metadata, abstractCluster2.Destinations["destinationC"].Metadata);
             Assert.Equal(cluster2.Destinations["destinationD"].Address, abstractCluster2.Destinations["destinationD"].Address);

--- a/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
+++ b/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
@@ -28,7 +28,7 @@ namespace Yarp.ReverseProxy.DynamicEndpoint
             });
 
             var routeConfig = new RouteConfig();
-            var cluster = new Cluster();
+            var cluster = new ClusterConfig();
             var endpointBuilder = CreateEndpointBuilder(routeConfig, cluster);
 
             var action = Assert.Single(conventions);
@@ -51,7 +51,7 @@ namespace Yarp.ReverseProxy.DynamicEndpoint
             });
 
             var routeConfig = new RouteConfig();
-            var cluster = new Cluster();
+            var cluster = new ClusterConfig();
             var endpointBuilder = CreateEndpointBuilder(routeConfig, cluster);
 
             var action = Assert.Single(conventions);
@@ -74,7 +74,7 @@ namespace Yarp.ReverseProxy.DynamicEndpoint
             });
 
             var routeConfig = new RouteConfig();
-            var cluster = new Cluster();
+            var cluster = new ClusterConfig();
             var endpointBuilder = CreateEndpointBuilder(routeConfig, cluster);
 
             var action = Assert.Single(conventions);
@@ -83,7 +83,7 @@ namespace Yarp.ReverseProxy.DynamicEndpoint
             Assert.True(configured);
         }
 
-        private static RouteEndpointBuilder CreateEndpointBuilder(RouteConfig routeConfig, Cluster cluster)
+        private static RouteEndpointBuilder CreateEndpointBuilder(RouteConfig routeConfig, ClusterConfig cluster)
         {
             var endpointBuilder = new RouteEndpointBuilder(context => Task.CompletedTask, RoutePatternFactory.Parse(""), 0);
             var routeModel = new RouteModel(

--- a/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
+++ b/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
@@ -90,7 +90,7 @@ namespace Yarp.ReverseProxy.DynamicEndpoint
                 routeConfig,
                 new ClusterState("cluster-1")
                 {
-                    Config = new ClusterConfig(cluster, default)
+                    Model = new ClusterModel(cluster, default)
                 },
                 HttpTransformer.Default);
 

--- a/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
+++ b/test/ReverseProxy.Tests/DynamicEndpoint/ReverseProxyConventionBuilderTests.cs
@@ -88,7 +88,7 @@ namespace Yarp.ReverseProxy.DynamicEndpoint
             var endpointBuilder = new RouteEndpointBuilder(context => Task.CompletedTask, RoutePatternFactory.Parse(""), 0);
             var routeModel = new RouteModel(
                 routeConfig,
-                new ClusterInfo("cluster-1")
+                new ClusterState("cluster-1")
                 {
                     Config = new ClusterConfig(cluster, default)
                 },

--- a/test/ReverseProxy.Tests/IntegrationTests/RoutingTests.cs
+++ b/test/ReverseProxy.Tests/IntegrationTests/RoutingTests.cs
@@ -324,9 +324,9 @@ namespace Yarp.ReverseProxy.IntegrationTests
         {
             var clusters = new[]
             {
-                new Cluster()
+                new ClusterConfig()
                 {
-                    Id = "cluster1",
+                    ClusterId = "cluster1",
                     Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
                     {
                         { "d1", new Destination() { Address = "http://localhost/" }  }

--- a/test/ReverseProxy.Tests/Middleware/LoadBalancerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/LoadBalancerMiddlewareTests.cs
@@ -180,7 +180,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
 
         private static HttpContext CreateContext(string loadBalancingPolicy, IReadOnlyList<DestinationInfo> destinations)
         {
-            var cluster = new ClusterInfo("cluster1")
+            var cluster = new ClusterState("cluster1")
             {
                 Config = new ClusterConfig(new Cluster { LoadBalancingPolicy = loadBalancingPolicy }, default)
             };

--- a/test/ReverseProxy.Tests/Middleware/LoadBalancerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/LoadBalancerMiddlewareTests.cs
@@ -182,7 +182,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
         {
             var cluster = new ClusterState("cluster1")
             {
-                Config = new ClusterConfig(new Cluster { LoadBalancingPolicy = loadBalancingPolicy }, default)
+                Model = new ClusterModel(new Cluster { LoadBalancingPolicy = loadBalancingPolicy }, default)
             };
 
             var context = new DefaultHttpContext();
@@ -191,7 +191,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
                 new ReverseProxyFeature()
                 {
                     AvailableDestinations = destinations,
-                    ClusterSnapshot = cluster.Config
+                    Cluster = cluster.Model
                 });
             context.Features.Set(cluster);
 

--- a/test/ReverseProxy.Tests/Middleware/LoadBalancerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/LoadBalancerMiddlewareTests.cs
@@ -182,7 +182,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
         {
             var cluster = new ClusterState("cluster1")
             {
-                Model = new ClusterModel(new Cluster { LoadBalancingPolicy = loadBalancingPolicy }, default)
+                Model = new ClusterModel(new ClusterConfig { LoadBalancingPolicy = loadBalancingPolicy }, default)
             };
 
             var context = new DefaultHttpContext();

--- a/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
@@ -94,7 +94,7 @@ namespace Yarp.ReverseProxy.Middleware
             policies[1].VerifyNoOtherCalls();
         }
 
-        private HttpContext GetContext(ClusterInfo cluster, int selectedDestination, IProxyErrorFeature error)
+        private HttpContext GetContext(ClusterState cluster, int selectedDestination, IProxyErrorFeature error)
         {
             var context = new DefaultHttpContext();
             context.Features.Set(GetProxyFeature(cluster, cluster.DynamicState.AllDestinations[selectedDestination]));
@@ -109,17 +109,17 @@ namespace Yarp.ReverseProxy.Middleware
             return policy;
         }
 
-        private IReverseProxyFeature GetProxyFeature(ClusterInfo clusterInfo, DestinationInfo destination)
+        private IReverseProxyFeature GetProxyFeature(ClusterState clusterState, DestinationInfo destination)
         {
             return new ReverseProxyFeature()
             {
                 ProxiedDestination = destination,
-                ClusterSnapshot = clusterInfo.Config,
-                Route = new RouteModel(new RouteConfig(), clusterInfo, HttpTransformer.Default),
+                ClusterSnapshot = clusterState.Config,
+                Route = new RouteModel(new RouteConfig(), clusterState, HttpTransformer.Default),
             };
         }
 
-        private ClusterInfo GetClusterInfo(string id, string policy, bool enabled = true)
+        private ClusterState GetClusterInfo(string id, string policy, bool enabled = true)
         {
             var clusterConfig = new ClusterConfig(
                 new Cluster
@@ -135,14 +135,14 @@ namespace Yarp.ReverseProxy.Middleware
                     }
                 },
                 null);
-            var clusterInfo = new ClusterInfo(id);
-            clusterInfo.Config = clusterConfig;
-            clusterInfo.Destinations.GetOrAdd("destination0", id => new DestinationInfo(id));
-            clusterInfo.Destinations.GetOrAdd("destination1", id => new DestinationInfo(id));
+            var clusterState = new ClusterState(id);
+            clusterState.Config = clusterConfig;
+            clusterState.Destinations.GetOrAdd("destination0", id => new DestinationInfo(id));
+            clusterState.Destinations.GetOrAdd("destination1", id => new DestinationInfo(id));
 
-            clusterInfo.ProcessDestinationChanges();
+            clusterState.ProcessDestinationChanges();
 
-            return clusterInfo;
+            return clusterState;
         }
     }
 }

--- a/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
@@ -114,14 +114,14 @@ namespace Yarp.ReverseProxy.Middleware
             return new ReverseProxyFeature()
             {
                 ProxiedDestination = destination,
-                ClusterSnapshot = clusterState.Config,
+                Cluster = clusterState.Model,
                 Route = new RouteModel(new RouteConfig(), clusterState, HttpTransformer.Default),
             };
         }
 
         private ClusterState GetClusterInfo(string id, string policy, bool enabled = true)
         {
-            var clusterConfig = new ClusterConfig(
+            var clusterModel = new ClusterModel(
                 new Cluster
                 {
                     Id = id,
@@ -136,7 +136,7 @@ namespace Yarp.ReverseProxy.Middleware
                 },
                 null);
             var clusterState = new ClusterState(id);
-            clusterState.Config = clusterConfig;
+            clusterState.Model = clusterModel;
             clusterState.Destinations.GetOrAdd("destination0", id => new DestinationInfo(id));
             clusterState.Destinations.GetOrAdd("destination1", id => new DestinationInfo(id));
 

--- a/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
@@ -122,9 +122,9 @@ namespace Yarp.ReverseProxy.Middleware
         private ClusterState GetClusterInfo(string id, string policy, bool enabled = true)
         {
             var clusterModel = new ClusterModel(
-                new Cluster
+                new ClusterConfig
                 {
-                    Id = id,
+                    ClusterId = id,
                     HealthCheck = new HealthCheckOptions
                     {
                         Passive = new PassiveHealthCheckOptions

--- a/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
@@ -49,7 +49,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
 #endif
             };
             var cluster1 = new ClusterState(clusterId: "cluster1");
-            var clusterConfig = new ClusterConfig(new Cluster() { HttpRequest = httpRequestOptions },
+            var clusterModel = new ClusterModel(new Cluster() { HttpRequest = httpRequestOptions },
                 httpClient);
             var destination1 = cluster1.Destinations.GetOrAdd(
                 "destination1",
@@ -66,7 +66,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
                 new ReverseProxyFeature()
             {
                     AvailableDestinations = new List<DestinationInfo>() { destination1 }.AsReadOnly(),
-                    ClusterSnapshot = clusterConfig,
+                    Cluster = clusterModel,
                     Route = routeConfig,
                 });
             httpContext.Features.Set(cluster1);
@@ -136,7 +136,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
 
             var httpClient = new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object);
             var cluster1 = new ClusterState(clusterId: "cluster1");
-            var clusterConfig = new ClusterConfig(new Cluster(), httpClient);
+            var clusterModel = new ClusterModel(new Cluster(), httpClient);
             var routeConfig = new RouteModel(
                 config: new RouteConfig(),
                 cluster: cluster1,
@@ -145,7 +145,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
                 new ReverseProxyFeature()
                 {
                     AvailableDestinations = Array.Empty<DestinationInfo>(),
-                    ClusterSnapshot = clusterConfig,
+                    Cluster = clusterModel,
                     Route = routeConfig,
                 });
 

--- a/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
@@ -49,7 +49,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
 #endif
             };
             var cluster1 = new ClusterState(clusterId: "cluster1");
-            var clusterModel = new ClusterModel(new Cluster() { HttpRequest = httpRequestOptions },
+            var clusterModel = new ClusterModel(new ClusterConfig() { HttpRequest = httpRequestOptions },
                 httpClient);
             var destination1 = cluster1.Destinations.GetOrAdd(
                 "destination1",
@@ -136,7 +136,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
 
             var httpClient = new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object);
             var cluster1 = new ClusterState(clusterId: "cluster1");
-            var clusterModel = new ClusterModel(new Cluster(), httpClient);
+            var clusterModel = new ClusterModel(new ClusterConfig(), httpClient);
             var routeConfig = new RouteModel(
                 config: new RouteConfig(),
                 cluster: cluster1,

--- a/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
@@ -48,7 +48,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
                 VersionPolicy = HttpVersionPolicy.RequestVersionExact,
 #endif
             };
-            var cluster1 = new ClusterInfo(clusterId: "cluster1");
+            var cluster1 = new ClusterState(clusterId: "cluster1");
             var clusterConfig = new ClusterConfig(new Cluster() { HttpRequest = httpRequestOptions },
                 httpClient);
             var destination1 = cluster1.Destinations.GetOrAdd(
@@ -135,7 +135,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             httpContext.Request.Host = new HostString("example.com");
 
             var httpClient = new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object);
-            var cluster1 = new ClusterInfo(clusterId: "cluster1");
+            var cluster1 = new ClusterState(clusterId: "cluster1");
             var clusterConfig = new ClusterConfig(new Cluster(), httpClient);
             var routeConfig = new RouteModel(
                 config: new RouteConfig(),

--- a/test/ReverseProxy.Tests/Middleware/ProxyPipelineInitializerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyPipelineInitializerMiddlewareTests.cs
@@ -39,7 +39,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
         {
             var httpClient = new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object);
             var cluster1 = new ClusterState(clusterId: "cluster1");
-            cluster1.Config = new ClusterConfig(new Cluster(), httpClient);
+            cluster1.Model = new ClusterModel(new Cluster(), httpClient);
             var destination1 = cluster1.Destinations.GetOrAdd(
                 "destination1",
                 id => new DestinationInfo(id) { Config = new DestinationConfig(new Destination { Address = "https://localhost:123/a/b/" }) });
@@ -64,7 +64,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             Assert.NotNull(proxyFeature.AvailableDestinations);
             Assert.Equal(1, proxyFeature.AvailableDestinations.Count);
             Assert.Same(destination1, proxyFeature.AvailableDestinations[0]);
-            Assert.Same(cluster1.Config, proxyFeature.ClusterSnapshot);
+            Assert.Same(cluster1.Model, proxyFeature.Cluster);
 
             Assert.Equal(StatusCodes.Status418ImATeapot, httpContext.Response.StatusCode);
         }
@@ -74,7 +74,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
         {
             var httpClient = new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object);
             var cluster1 = new ClusterState(clusterId: "cluster1");
-            cluster1.Config = new ClusterConfig(
+            cluster1.Model = new ClusterModel(
                 new Cluster()
                 {
                     HealthCheck = new HealthCheckOptions

--- a/test/ReverseProxy.Tests/Middleware/ProxyPipelineInitializerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyPipelineInitializerMiddlewareTests.cs
@@ -38,7 +38,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
         public async Task Invoke_SetsFeatures()
         {
             var httpClient = new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object);
-            var cluster1 = new ClusterInfo(clusterId: "cluster1");
+            var cluster1 = new ClusterState(clusterId: "cluster1");
             cluster1.Config = new ClusterConfig(new Cluster(), httpClient);
             var destination1 = cluster1.Destinations.GetOrAdd(
                 "destination1",
@@ -73,7 +73,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
         public async Task Invoke_NoHealthyEndpoints_CallsNext()
         {
             var httpClient = new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object);
-            var cluster1 = new ClusterInfo(clusterId: "cluster1");
+            var cluster1 = new ClusterState(clusterId: "cluster1");
             cluster1.Config = new ClusterConfig(
                 new Cluster()
                 {

--- a/test/ReverseProxy.Tests/Middleware/ProxyPipelineInitializerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyPipelineInitializerMiddlewareTests.cs
@@ -39,7 +39,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
         {
             var httpClient = new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object);
             var cluster1 = new ClusterState(clusterId: "cluster1");
-            cluster1.Model = new ClusterModel(new Cluster(), httpClient);
+            cluster1.Model = new ClusterModel(new ClusterConfig(), httpClient);
             var destination1 = cluster1.Destinations.GetOrAdd(
                 "destination1",
                 id => new DestinationInfo(id) { Config = new DestinationConfig(new Destination { Address = "https://localhost:123/a/b/" }) });
@@ -75,7 +75,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             var httpClient = new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object);
             var cluster1 = new ClusterState(clusterId: "cluster1");
             cluster1.Model = new ClusterModel(
-                new Cluster()
+                new ClusterConfig()
                 {
                     HealthCheck = new HealthCheckOptions
                     {

--- a/test/ReverseProxy.Tests/Middleware/SessionAffinityMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/SessionAffinityMiddlewareTests.cs
@@ -20,7 +20,7 @@ namespace Yarp.ReverseProxy.Middleware
     public class SessionAffinityMiddlewareTests
     {
         protected const string AffinitizedDestinationName = "dest-B";
-        protected readonly ClusterConfig ClusterConfig = new ClusterConfig(new Cluster
+        protected readonly ClusterModel ClusterConfig = new ClusterModel(new Cluster
         {
             Id = "cluster-1",
             SessionAffinity = new SessionAffinityOptions
@@ -61,7 +61,7 @@ namespace Yarp.ReverseProxy.Middleware
                 new Mock<ILogger<SessionAffinityMiddleware>>().Object);
             var context = new DefaultHttpContext();
             context.SetEndpoint(endpoint);
-            var destinationFeature = GetDestinationsFeature(cluster.Destinations.Values.ToList(), cluster.Config);
+            var destinationFeature = GetDestinationsFeature(cluster.Destinations.Values.ToList(), cluster.Model);
             context.Features.Set(destinationFeature);
 
             await middleware.Invoke(context);
@@ -108,7 +108,7 @@ namespace Yarp.ReverseProxy.Middleware
                 providers.Select(p => p.Object), failurePolicies.Select(p => p.Object),
                 logger.Object);
             var context = new DefaultHttpContext();
-            var destinationFeature = GetDestinationsFeature(cluster.Destinations.Values.ToList(), cluster.Config);
+            var destinationFeature = GetDestinationsFeature(cluster.Destinations.Values.ToList(), cluster.Model);
 
             context.SetEndpoint(endpoint);
             context.Features.Set(destinationFeature);
@@ -135,7 +135,7 @@ namespace Yarp.ReverseProxy.Middleware
             destinationManager.GetOrAdd("dest-A", id => new DestinationInfo(id));
             destinationManager.GetOrAdd(AffinitizedDestinationName, id => new DestinationInfo(id));
             destinationManager.GetOrAdd("dest-C", id => new DestinationInfo(id));
-            cluster.Config = ClusterConfig;
+            cluster.Model = ClusterConfig;
             cluster.ProcessDestinationChanges();
             return cluster;
         }
@@ -189,12 +189,12 @@ namespace Yarp.ReverseProxy.Middleware
             return result.AsReadOnly();
         }
 
-        internal IReverseProxyFeature GetDestinationsFeature(IReadOnlyList<DestinationInfo> destinations, ClusterConfig clusterConfig)
+        internal IReverseProxyFeature GetDestinationsFeature(IReadOnlyList<DestinationInfo> destinations, ClusterModel clusterModel)
         {
             return new ReverseProxyFeature()
             {
                 AvailableDestinations = destinations,
-                ClusterSnapshot = clusterConfig,
+                Cluster = clusterModel,
             };
         }
 

--- a/test/ReverseProxy.Tests/Middleware/SessionAffinityMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/SessionAffinityMiddlewareTests.cs
@@ -128,9 +128,9 @@ namespace Yarp.ReverseProxy.Middleware
             }
         }
 
-        internal ClusterInfo GetCluster()
+        internal ClusterState GetCluster()
         {
-            var cluster = new ClusterInfo("cluster-1");
+            var cluster = new ClusterState("cluster-1");
             var destinationManager = cluster.Destinations;
             destinationManager.GetOrAdd("dest-A", id => new DestinationInfo(id));
             destinationManager.GetOrAdd(AffinitizedDestinationName, id => new DestinationInfo(id));
@@ -198,7 +198,7 @@ namespace Yarp.ReverseProxy.Middleware
             };
         }
 
-        internal Endpoint GetEndpoint(ClusterInfo cluster)
+        internal Endpoint GetEndpoint(ClusterState cluster)
         {
             var routeConfig = new RouteConfig();
             var routeModel = new RouteModel(routeConfig, cluster, HttpTransformer.Default);

--- a/test/ReverseProxy.Tests/Middleware/SessionAffinityMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/SessionAffinityMiddlewareTests.cs
@@ -20,9 +20,9 @@ namespace Yarp.ReverseProxy.Middleware
     public class SessionAffinityMiddlewareTests
     {
         protected const string AffinitizedDestinationName = "dest-B";
-        protected readonly ClusterModel ClusterConfig = new ClusterModel(new Cluster
+        protected readonly ClusterModel ClusterConfig = new ClusterModel(new ClusterConfig
         {
-            Id = "cluster-1",
+            ClusterId = "cluster-1",
             SessionAffinity = new SessionAffinityOptions
             {
                 Enabled = true,
@@ -157,7 +157,7 @@ namespace Yarp.ReverseProxy.Middleware
                         It.IsAny<HttpContext>(),
                         expectedDestinations,
                         expectedCluster,
-                        ClusterConfig.Options.SessionAffinity))
+                        ClusterConfig.Config.SessionAffinity))
                     .Returns(new AffinityResult(destinations, status.Value))
                     .Callback(() => callback(provider.Object));
                 }
@@ -165,7 +165,7 @@ namespace Yarp.ReverseProxy.Middleware
                 {
                     provider.Setup(p => p.AffinitizeRequest(
                         It.IsAny<HttpContext>(),
-                        ClusterConfig.Options.SessionAffinity,
+                        ClusterConfig.Config.SessionAffinity,
                         expectedDestinations[0]))
                     .Callback(() => callback(provider.Object));
                 }

--- a/test/ReverseProxy.Tests/Service/Config/ConfigValidatorTests.cs
+++ b/test/ReverseProxy.Tests/Service/Config/ConfigValidatorTests.cs
@@ -569,9 +569,9 @@ namespace Yarp.ReverseProxy.Service.Tests
             var services = CreateServices();
             var validator = services.GetRequiredService<IConfigValidator>();
 
-            var cluster = new Cluster
+            var cluster = new ClusterConfig
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
             };
 
             var errors = await validator.ValidateClusterAsync(cluster);
@@ -585,9 +585,9 @@ namespace Yarp.ReverseProxy.Service.Tests
             var services = CreateServices();
             var validator = services.GetRequiredService<IConfigValidator>();
 
-            var cluster = new Cluster
+            var cluster = new ClusterConfig
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 LoadBalancingPolicy = LoadBalancingPolicies.RoundRobin
             };
 
@@ -602,9 +602,9 @@ namespace Yarp.ReverseProxy.Service.Tests
             var services = CreateServices();
             var validator = services.GetRequiredService<IConfigValidator>();
 
-            var cluster = new Cluster
+            var cluster = new ClusterConfig
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 LoadBalancingPolicy = "MyCustomPolicy"
             };
 
@@ -620,9 +620,9 @@ namespace Yarp.ReverseProxy.Service.Tests
             var services = CreateServices();
             var validator = services.GetRequiredService<IConfigValidator>();
 
-            var cluster = new Cluster
+            var cluster = new ClusterConfig
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 SessionAffinity = new SessionAffinityOptions()
                 {
                     Enabled = true
@@ -640,9 +640,9 @@ namespace Yarp.ReverseProxy.Service.Tests
             var services = CreateServices();
             var validator = services.GetRequiredService<IConfigValidator>();
 
-            var cluster = new Cluster
+            var cluster = new ClusterConfig
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 SessionAffinity = new SessionAffinityOptions()
                 {
                     Enabled = true,
@@ -662,9 +662,9 @@ namespace Yarp.ReverseProxy.Service.Tests
             var services = CreateServices();
             var validator = services.GetRequiredService<IConfigValidator>();
 
-            var cluster = new Cluster
+            var cluster = new ClusterConfig
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 HttpRequest = new RequestProxyOptions
                 {
                     Version = null,
@@ -686,9 +686,9 @@ namespace Yarp.ReverseProxy.Service.Tests
             var services = CreateServices();
             var validator = services.GetRequiredService<IConfigValidator>();
 
-            var cluster = new Cluster
+            var cluster = new ClusterConfig
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 HttpRequest = new RequestProxyOptions
                 {
                     Version = version,
@@ -710,9 +710,9 @@ namespace Yarp.ReverseProxy.Service.Tests
             var services = CreateServices();
             var validator = services.GetRequiredService<IConfigValidator>();
 
-            var cluster = new Cluster
+            var cluster = new ClusterConfig
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 HttpRequest = new RequestProxyOptions
                 {
                     Version = version,
@@ -738,9 +738,9 @@ namespace Yarp.ReverseProxy.Service.Tests
             var services = CreateServices();
             var validator = services.GetRequiredService<IConfigValidator>();
 
-            var cluster = new Cluster
+            var cluster = new ClusterConfig
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 HealthCheck = new HealthCheckOptions
                 {
                     Active = new ActiveHealthCheckOptions
@@ -768,9 +768,9 @@ namespace Yarp.ReverseProxy.Service.Tests
             var services = CreateServices();
             var validator = services.GetRequiredService<IConfigValidator>();
 
-            var cluster = new Cluster
+            var cluster = new ClusterConfig
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 HealthCheck = new HealthCheckOptions
                 {
                     Active = new ActiveHealthCheckOptions
@@ -800,9 +800,9 @@ namespace Yarp.ReverseProxy.Service.Tests
             var services = CreateServices();
             var validator = services.GetRequiredService<IConfigValidator>();
 
-            var cluster = new Cluster
+            var cluster = new ClusterConfig
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 HealthCheck = new HealthCheckOptions
                 {
                     Passive = new PassiveHealthCheckOptions
@@ -827,9 +827,9 @@ namespace Yarp.ReverseProxy.Service.Tests
             var services = CreateServices();
             var validator = services.GetRequiredService<IConfigValidator>();
 
-            var cluster = new Cluster
+            var cluster = new ClusterConfig
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 HealthCheck = new HealthCheckOptions
                 {
                     Passive = new PassiveHealthCheckOptions

--- a/test/ReverseProxy.Tests/Service/Config/TransformBuilderTests.cs
+++ b/test/ReverseProxy.Tests/Service/Config/TransformBuilderTests.cs
@@ -45,7 +45,7 @@ namespace Yarp.ReverseProxy.Service.Config
             var errors = transformBuilder.ValidateRoute(route);
             Assert.Empty(errors);
 
-            var results = transformBuilder.BuildInternal(route, new Cluster());
+            var results = transformBuilder.BuildInternal(route, new ClusterConfig());
             Assert.NotNull(results);
             Assert.Null(results.ShouldCopyRequestHeaders);
             Assert.Null(results.ShouldCopyResponseHeaders);
@@ -120,7 +120,7 @@ namespace Yarp.ReverseProxy.Service.Config
             var error = Assert.Single(errors);
             Assert.Equal("Unknown transform: ", error.Message);
 
-            var nie = Assert.Throws<ArgumentException>(() => transformBuilder.BuildInternal(route, new Cluster()));
+            var nie = Assert.Throws<ArgumentException>(() => transformBuilder.BuildInternal(route, new ClusterConfig()));
             Assert.Equal("Unknown transform: ", nie.Message);
         }
 
@@ -148,7 +148,7 @@ namespace Yarp.ReverseProxy.Service.Config
             Assert.Equal(2, errors.Count);
             Assert.Equal("Unknown transform: string1;string2", errors.First().Message);
             Assert.Equal("Unknown transform: string3;string4", errors.Skip(1).First().Message);
-            var ex = Assert.Throws<ArgumentException>(() => transformBuilder.BuildInternal(route, new Cluster()));
+            var ex = Assert.Throws<ArgumentException>(() => transformBuilder.BuildInternal(route, new ClusterConfig()));
             // First error reported
             Assert.Equal("Unknown transform: string1;string2", ex.Message);
         }
@@ -172,7 +172,7 @@ namespace Yarp.ReverseProxy.Service.Config
             Assert.Equal(1, factory2.ValidationCalls);
             Assert.Equal(0, factory3.ValidationCalls);
 
-            var transforms = builder.BuildInternal(route, new Cluster());
+            var transforms = builder.BuildInternal(route, new ClusterConfig());
             Assert.Equal(1, factory1.BuildCalls);
             Assert.Equal(1, factory2.BuildCalls);
             Assert.Equal(0, factory3.BuildCalls);
@@ -196,7 +196,7 @@ namespace Yarp.ReverseProxy.Service.Config
             Assert.Equal(1, provider2.ValidateRouteCalls);
             Assert.Equal(1, provider3.ValidateRouteCalls);
 
-            var cluster = new Cluster();
+            var cluster = new ClusterConfig();
             errors = builder.ValidateCluster(cluster);
             Assert.Empty(errors);
             Assert.Equal(1, provider1.ValidateClusterCalls);
@@ -231,7 +231,7 @@ namespace Yarp.ReverseProxy.Service.Config
             var errors = transformBuilder.ValidateRoute(route);
             Assert.Empty(errors);
 
-            var results = transformBuilder.BuildInternal(route, new Cluster());
+            var results = transformBuilder.BuildInternal(route, new ClusterConfig());
             Assert.NotNull(results);
             Assert.False(results.ShouldCopyRequestHeaders);
             Assert.Empty(results.RequestTransforms);
@@ -277,7 +277,7 @@ namespace Yarp.ReverseProxy.Service.Config
             var errors = transformBuilder.ValidateRoute(route);
             Assert.Empty(errors);
 
-            var results = transformBuilder.BuildInternal(route, new Cluster());
+            var results = transformBuilder.BuildInternal(route, new ClusterConfig());
             Assert.NotNull(results);
             Assert.Equal(copyHeaders, results.ShouldCopyRequestHeaders);
             Assert.Empty(results.ResponseTransforms);
@@ -362,7 +362,7 @@ namespace Yarp.ReverseProxy.Service.Config
             var errors = transformBuilder.ValidateRoute(route);
             Assert.Empty(errors);
 
-            var results = transformBuilder.BuildInternal(route, new Cluster());
+            var results = transformBuilder.BuildInternal(route, new ClusterConfig());
             Assert.Equal(copyHeaders, results.ShouldCopyRequestHeaders);
 
             var httpContext = new DefaultHttpContext();
@@ -395,7 +395,7 @@ namespace Yarp.ReverseProxy.Service.Config
             var errors = transformBuilder.ValidateRoute(route);
             Assert.Empty(errors);
 
-            var results = transformBuilder.BuildInternal(route, new Cluster());
+            var results = transformBuilder.BuildInternal(route, new ClusterConfig());
             var transform = Assert.Single(results.RequestTransforms);
             var forwardedTransform = Assert.IsType<RequestHeaderForwardedTransform>(transform);
             Assert.True(forwardedTransform.ProtoEnabled);

--- a/test/ReverseProxy.Tests/Service/DynamicEndpoint/ProxyEndpointFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Service/DynamicEndpoint/ProxyEndpointFactoryTests.cs
@@ -50,7 +50,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 },
                 Order = 12,
             };
-            var cluster = new ClusterInfo("cluster1");
+            var cluster = new ClusterState("cluster1");
             var routeState = new RouteState("route1");
 
             var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeState, route, cluster);
@@ -68,10 +68,10 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
             Assert.Equal("example.com", hostMetadata.Hosts[0]);
         }
 
-        private (RouteEndpoint routeEndpoint, RouteModel routeConfig) CreateEndpoint(ProxyEndpointFactory factory, RouteState routeState, RouteConfig routeConfig, ClusterInfo clusterInfo)
+        private (RouteEndpoint routeEndpoint, RouteModel routeConfig) CreateEndpoint(ProxyEndpointFactory factory, RouteState routeState, RouteConfig routeConfig, ClusterState clusterState)
         {
-            routeState.ClusterRevision = clusterInfo.Revision;
-            var routeModel = new RouteModel(routeConfig, clusterInfo, HttpTransformer.Default);
+            routeState.ClusterRevision = clusterState.Revision;
+            var routeModel = new RouteModel(routeConfig, clusterState, HttpTransformer.Default);
 
             var endpoint = factory.CreateEndpoint(routeModel, Array.Empty<Action<EndpointBuilder>>());
 
@@ -96,7 +96,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 },
                 Order = 12,
             };
-            var cluster = new ClusterInfo("cluster1");
+            var cluster = new ClusterState("cluster1");
             var routeState = new RouteState("route1");
 
             var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeState, route, cluster);
@@ -130,7 +130,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 },
                 Order = 12,
             };
-            var cluster = new ClusterInfo("cluster1");
+            var cluster = new ClusterState("cluster1");
             var routeState = new RouteState("route1");
 
             var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeState, route, cluster);
@@ -164,7 +164,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 },
                 Order = 12,
             };
-            var cluster = new ClusterInfo("cluster1");
+            var cluster = new ClusterState("cluster1");
             var routeState = new RouteState("route1");
 
             var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeState, route, cluster);
@@ -193,7 +193,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Order = 12,
                 Match = new RouteMatch()
             };
-            var cluster = new ClusterInfo("cluster1");
+            var cluster = new ClusterState("cluster1");
             var routeState = new RouteState("route1");
 
             var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeState, route, cluster);
@@ -225,7 +225,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 },
                 Order = 12,
             };
-            var cluster = new ClusterInfo("cluster1");
+            var cluster = new ClusterState("cluster1");
             var routeState = new RouteState("route1");
 
             Action action = () => CreateEndpoint(factory, routeState, route, cluster);
@@ -247,7 +247,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Order = 12,
                 Match = new RouteMatch(),
             };
-            var cluster = new ClusterInfo("cluster1");
+            var cluster = new ClusterState("cluster1");
             var routeState = new RouteState("route1");
 
             var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
@@ -270,7 +270,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Order = 12,
                 Match = new RouteMatch(),
             };
-            var cluster = new ClusterInfo("cluster1");
+            var cluster = new ClusterState("cluster1");
             var routeState = new RouteState("route1");
 
             var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
@@ -292,7 +292,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Order = 12,
                 Match = new RouteMatch(),
             };
-            var cluster = new ClusterInfo("cluster1");
+            var cluster = new ClusterState("cluster1");
             var routeState = new RouteState("route1");
 
             var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
@@ -314,7 +314,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Order = 12,
                 Match = new RouteMatch(),
             };
-            var cluster = new ClusterInfo("cluster1");
+            var cluster = new ClusterState("cluster1");
             var routeState = new RouteState("route1");
 
             var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
@@ -337,7 +337,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Order = 12,
                 Match = new RouteMatch(),
             };
-            var cluster = new ClusterInfo("cluster1");
+            var cluster = new ClusterState("cluster1");
             var routeState = new RouteState("route1");
 
             var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
@@ -361,7 +361,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Order = 12,
                 Match = new RouteMatch(),
             };
-            var cluster = new ClusterInfo("cluster1");
+            var cluster = new ClusterState("cluster1");
             var routeState = new RouteState("route1");
 
             var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
@@ -385,7 +385,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Order = 12,
                 Match = new RouteMatch(),
             };
-            var cluster = new ClusterInfo("cluster1");
+            var cluster = new ClusterState("cluster1");
             var routeState = new RouteState("route1");
 
             var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
@@ -407,7 +407,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                 Order = 12,
                 Match = new RouteMatch(),
             };
-            var cluster = new ClusterInfo("cluster1");
+            var cluster = new ClusterState("cluster1");
             var routeState = new RouteState("route1");
 
             var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
@@ -441,7 +441,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                     }
                 },
             };
-            var cluster = new ClusterInfo("cluster1");
+            var cluster = new ClusterState("cluster1");
             var routeState = new RouteState("route1");
 
             var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeState, route, cluster);
@@ -491,7 +491,7 @@ namespace Yarp.ReverseProxy.Service.DynamicEndpoint
                     }
                 },
             };
-            var cluster = new ClusterInfo("cluster1");
+            var cluster = new ClusterState("cluster1");
             var routeState = new RouteState("route1");
 
             var (routeEndpoint, routeConfig) = CreateEndpoint(factory, routeState, route, cluster);

--- a/test/ReverseProxy.Tests/Service/HealthChecks/ActiveHealthCheckMonitorTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/ActiveHealthCheckMonitorTests.cs
@@ -32,7 +32,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             var policy1 = new Mock<IActiveHealthCheckPolicy>();
             policy1.SetupGet(p => p.Name).Returns("policy1");
             var options = Options.Create(new ActiveHealthCheckMonitorOptions { DefaultInterval = TimeSpan.FromSeconds(60), DefaultTimeout = TimeSpan.FromSeconds(5) });
-            var clusters = new List<ClusterInfo>();
+            var clusters = new List<ClusterState>();
             var monitor = new ActiveHealthCheckMonitor(options, new[] { policy0.Object, policy1.Object }, new DefaultProbingRequestFactory(), new Mock<ITimerFactory>().Object, GetLogger());
 
             var httpClient0 = GetHttpClient();
@@ -78,7 +78,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 
             Assert.False(monitor.InitialDestinationsProbed);
 
-            await monitor.CheckHealthAsync(new ClusterInfo[0]);
+            await monitor.CheckHealthAsync(new ClusterState[0]);
 
             Assert.True(monitor.InitialDestinationsProbed);
 
@@ -111,7 +111,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 
             Assert.False(monitor.InitialDestinationsProbed);
 
-            await monitor.CheckHealthAsync(new ClusterInfo[0]);
+            await monitor.CheckHealthAsync(new ClusterState[0]);
 
             Assert.True(monitor.InitialDestinationsProbed);
 
@@ -150,7 +150,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 
             Assert.False(monitor.InitialDestinationsProbed);
 
-            await monitor.CheckHealthAsync(new ClusterInfo[0]);
+            await monitor.CheckHealthAsync(new ClusterState[0]);
 
             Assert.True(monitor.InitialDestinationsProbed);
 
@@ -193,7 +193,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 
             Assert.False(monitor.InitialDestinationsProbed);
 
-            await monitor.CheckHealthAsync(new ClusterInfo[0]);
+            await monitor.CheckHealthAsync(new ClusterState[0]);
 
             Assert.True(monitor.InitialDestinationsProbed);
 
@@ -242,7 +242,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 
             Assert.False(monitor.InitialDestinationsProbed);
 
-            await monitor.CheckHealthAsync(new ClusterInfo[0]);
+            await monitor.CheckHealthAsync(new ClusterState[0]);
 
             Assert.True(monitor.InitialDestinationsProbed);
 
@@ -280,7 +280,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             var policy = new Mock<IActiveHealthCheckPolicy>();
             policy.SetupGet(p => p.Name).Returns("policy0");
             var options = Options.Create(new ActiveHealthCheckMonitorOptions { DefaultInterval = TimeSpan.FromSeconds(60), DefaultTimeout = TimeSpan.FromSeconds(5) });
-            var clusters = new List<ClusterInfo>();
+            var clusters = new List<ClusterState>();
             var monitor = new ActiveHealthCheckMonitor(options, new[] { policy.Object }, new DefaultProbingRequestFactory(), new Mock<ITimerFactory>().Object, GetLogger());
 
             var httpClient = new Mock<HttpMessageInvoker>(() => new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object));
@@ -333,7 +333,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             var policy = new Mock<IActiveHealthCheckPolicy>();
             policy.SetupGet(p => p.Name).Returns("policy0");
             var options = Options.Create(new ActiveHealthCheckMonitorOptions { DefaultInterval = TimeSpan.FromSeconds(60), DefaultTimeout = TimeSpan.FromSeconds(5) });
-            var clusters = new List<ClusterInfo>();
+            var clusters = new List<ClusterState>();
             var monitor = new ActiveHealthCheckMonitor(options, new[] { policy.Object }, new DefaultProbingRequestFactory(), new Mock<ITimerFactory>().Object, GetLogger());
 
             var httpClient = new Mock<HttpMessageInvoker>(() => new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object));
@@ -371,9 +371,9 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         {
             var policy = new Mock<IActiveHealthCheckPolicy>();
             policy.SetupGet(p => p.Name).Returns("policy0");
-            policy.Setup(p => p.ProbingCompleted(It.IsAny<ClusterInfo>(), It.IsAny<IReadOnlyList<DestinationProbingResult>>())).Throws<InvalidOperationException>();
+            policy.Setup(p => p.ProbingCompleted(It.IsAny<ClusterState>(), It.IsAny<IReadOnlyList<DestinationProbingResult>>())).Throws<InvalidOperationException>();
             var options = Options.Create(new ActiveHealthCheckMonitorOptions { DefaultInterval = TimeSpan.FromSeconds(60), DefaultTimeout = TimeSpan.FromSeconds(5) });
-            var clusters = new List<ClusterInfo>();
+            var clusters = new List<ClusterState>();
             var monitor = new ActiveHealthCheckMonitor(options, new[] { policy.Object }, new DefaultProbingRequestFactory(), new Mock<ITimerFactory>().Object, GetLogger());
 
             var httpClient = GetHttpClient();
@@ -386,7 +386,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 
             Assert.True(monitor.InitialDestinationsProbed);
 
-            policy.Verify(p => p.ProbingCompleted(It.IsAny<ClusterInfo>(), It.IsAny<IReadOnlyList<DestinationProbingResult>>()), Times.Once);
+            policy.Verify(p => p.ProbingCompleted(It.IsAny<ClusterState>(), It.IsAny<IReadOnlyList<DestinationProbingResult>>()), Times.Once);
             policy.Verify(p => p.Name);
             policy.VerifyNoOtherCalls();
         }
@@ -403,7 +403,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             var policy = new Mock<IActiveHealthCheckPolicy>();
             policy.SetupGet(p => p.Name).Returns("policy0");
             var options = Options.Create(new ActiveHealthCheckMonitorOptions { DefaultInterval = TimeSpan.FromSeconds(60), DefaultTimeout = Timeout.InfiniteTimeSpan });
-            var clusters = new List<ClusterInfo>();
+            var clusters = new List<ClusterState>();
             var monitor = new ActiveHealthCheckMonitor(options, new[] { policy.Object }, new DefaultProbingRequestFactory(), new Mock<ITimerFactory>().Object, GetLogger());
 
             var tcs0 = new TaskCompletionSource<HttpResponseMessage>();
@@ -442,7 +442,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 
             Assert.True(monitor.InitialDestinationsProbed);
 
-            policy.Verify(p => p.ProbingCompleted(It.IsAny<ClusterInfo>(), It.IsAny<IReadOnlyList<DestinationProbingResult>>()), Times.Exactly(3));
+            policy.Verify(p => p.ProbingCompleted(It.IsAny<ClusterState>(), It.IsAny<IReadOnlyList<DestinationProbingResult>>()), Times.Exactly(3));
             policy.Verify(p => p.Name);
             policy.VerifyNoOtherCalls();
         }
@@ -453,7 +453,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             var policy = new Mock<IActiveHealthCheckPolicy>();
             policy.SetupGet(p => p.Name).Returns("policy0");
             var options = Options.Create(new ActiveHealthCheckMonitorOptions { DefaultInterval = TimeSpan.FromSeconds(60), DefaultTimeout = TimeSpan.FromMilliseconds(1) });
-            var clusters = new List<ClusterInfo>();
+            var clusters = new List<ClusterState>();
             var monitor = new ActiveHealthCheckMonitor(options, new[] { policy.Object }, new DefaultProbingRequestFactory(), new Mock<ITimerFactory>().Object, GetLogger());
 
             var tcs0 = new TaskCompletionSource<HttpResponseMessage>();
@@ -483,7 +483,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 
             Assert.True(monitor.InitialDestinationsProbed);
 
-            policy.Verify(p => p.ProbingCompleted(It.IsAny<ClusterInfo>(), It.IsAny<IReadOnlyList<DestinationProbingResult>>()), Times.Exactly(2));
+            policy.Verify(p => p.ProbingCompleted(It.IsAny<ClusterState>(), It.IsAny<IReadOnlyList<DestinationProbingResult>>()), Times.Exactly(2));
             policy.Verify(p => p.Name);
             policy.VerifyNoOtherCalls();
         }
@@ -494,7 +494,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             var policy = new Mock<IActiveHealthCheckPolicy>();
             policy.SetupGet(p => p.Name).Returns("policy0");
             var options = Options.Create(new ActiveHealthCheckMonitorOptions { DefaultInterval = TimeSpan.FromSeconds(60), DefaultTimeout = TimeSpan.FromMilliseconds(1) });
-            var clusters = new List<ClusterInfo>();
+            var clusters = new List<ClusterState>();
             var monitor = new ActiveHealthCheckMonitor(options, new[] { policy.Object }, new DefaultProbingRequestFactory(), new Mock<ITimerFactory>().Object, GetLogger());
 
             var tcs0 = new TaskCompletionSource<HttpResponseMessage>();
@@ -516,7 +516,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 
             Assert.True(monitor.InitialDestinationsProbed);
 
-            policy.Verify(p => p.ProbingCompleted(It.IsAny<ClusterInfo>(), It.IsAny<IReadOnlyList<DestinationProbingResult>>()), Times.Exactly(2));
+            policy.Verify(p => p.ProbingCompleted(It.IsAny<ClusterState>(), It.IsAny<IReadOnlyList<DestinationProbingResult>>()), Times.Exactly(2));
             policy.Verify(p => p.Name);
             policy.VerifyNoOtherCalls();
         }
@@ -527,7 +527,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             var policy = new Mock<IActiveHealthCheckPolicy>();
             policy.SetupGet(p => p.Name).Returns("policy0");
             var options = Options.Create(new ActiveHealthCheckMonitorOptions { DefaultInterval = TimeSpan.FromSeconds(60), DefaultTimeout = Timeout.InfiniteTimeSpan });
-            var clusters = new List<ClusterInfo>();
+            var clusters = new List<ClusterState>();
             var monitor = new ActiveHealthCheckMonitor(options, new[] { policy.Object }, new DefaultProbingRequestFactory(), new Mock<ITimerFactory>().Object, GetLogger());
 
             var tcs0 = new TaskCompletionSource<HttpResponseMessage>();
@@ -557,7 +557,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 
             Assert.True(monitor.InitialDestinationsProbed);
 
-            policy.Verify(p => p.ProbingCompleted(It.IsAny<ClusterInfo>(), It.IsAny<IReadOnlyList<DestinationProbingResult>>()), Times.Exactly(2));
+            policy.Verify(p => p.ProbingCompleted(It.IsAny<ClusterState>(), It.IsAny<IReadOnlyList<DestinationProbingResult>>()), Times.Exactly(2));
             policy.Verify(p => p.Name);
             policy.VerifyNoOtherCalls();
         }
@@ -568,7 +568,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             var policy = new Mock<IActiveHealthCheckPolicy>();
             policy.SetupGet(p => p.Name).Returns("policy0");
             var options = Options.Create(new ActiveHealthCheckMonitorOptions { DefaultInterval = TimeSpan.FromSeconds(60), DefaultTimeout = Timeout.InfiniteTimeSpan });
-            var clusters = new List<ClusterInfo>();
+            var clusters = new List<ClusterState>();
             var monitor = new ActiveHealthCheckMonitor(options, new[] { policy.Object }, new DefaultProbingRequestFactory(), new Mock<ITimerFactory>().Object, GetLogger());
 
             var tcs0 = new TaskCompletionSource<HttpResponseMessage>();
@@ -598,12 +598,12 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 
             Assert.True(monitor.InitialDestinationsProbed);
 
-            policy.Verify(p => p.ProbingCompleted(It.IsAny<ClusterInfo>(), It.IsAny<IReadOnlyList<DestinationProbingResult>>()), Times.Exactly(2));
+            policy.Verify(p => p.ProbingCompleted(It.IsAny<ClusterState>(), It.IsAny<IReadOnlyList<DestinationProbingResult>>()), Times.Exactly(2));
             policy.Verify(p => p.Name);
             policy.VerifyNoOtherCalls();
         }
 
-        private static void VerifySentProbeAndResult(ClusterInfo cluster, Mock<HttpMessageInvoker> httpClient, Mock<IActiveHealthCheckPolicy> policy, (string RequestUri, int Times)[] probes, int policyCallTimes = 1)
+        private static void VerifySentProbeAndResult(ClusterState cluster, Mock<HttpMessageInvoker> httpClient, Mock<IActiveHealthCheckPolicy> policy, (string RequestUri, int Times)[] probes, int policyCallTimes = 1)
         {
             foreach (var probe in probes)
             {
@@ -619,7 +619,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             policy.VerifyNoOtherCalls();
         }
 
-        private ClusterInfo GetClusterInfo(string id, string policy, bool activeCheckEnabled, HttpMessageInvoker httpClient, TimeSpan? interval = null, TimeSpan? timeout = null, int destinationCount = 2)
+        private ClusterState GetClusterInfo(string id, string policy, bool activeCheckEnabled, HttpMessageInvoker httpClient, TimeSpan? interval = null, TimeSpan? timeout = null, int destinationCount = 2)
         {
             var clusterConfig = new ClusterConfig(
                 new Cluster
@@ -638,20 +638,20 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                     }
                 },
                 httpClient);
-            var clusterInfo = new ClusterInfo(id);
-            clusterInfo.Config = clusterConfig;
+            var clusterState = new ClusterState(id);
+            clusterState.Config = clusterConfig;
             for (var i = 0; i < destinationCount; i++)
             {
                 var destinationConfig = new DestinationConfig(new Destination { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });
                 var destinationId = $"destination{i}";
-                clusterInfo.Destinations.GetOrAdd(destinationId, id => new DestinationInfo(id)
+                clusterState.Destinations.GetOrAdd(destinationId, id => new DestinationInfo(id)
                 {
                     Config = destinationConfig
                 });
             }
-            clusterInfo.ProcessDestinationChanges();
+            clusterState.ProcessDestinationChanges();
 
-            return clusterInfo;
+            return clusterState;
         }
 
         private Mock<HttpMessageInvoker> GetHttpClient(Task<HttpResponseMessage> task = null, Action cancellation = null)

--- a/test/ReverseProxy.Tests/Service/HealthChecks/ActiveHealthCheckMonitorTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/ActiveHealthCheckMonitorTests.cs
@@ -260,11 +260,11 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                 },
                 Active = new ActiveHealthCheckOptions
                 {
-                    Policy = cluster2.Config.Options.HealthCheck.Active.Policy,
+                    Policy = cluster2.Model.Options.HealthCheck.Active.Policy,
                 }
             };
-            cluster2.Config = new ClusterConfig(new Cluster { Id = cluster2.ClusterId, HealthCheck = healthCheckConfig },
-                cluster2.Config.HttpClient);
+            cluster2.Model = new ClusterModel(new Cluster { Id = cluster2.ClusterId, HealthCheck = healthCheckConfig },
+                cluster2.Model.HttpClient);
 
             monitor.OnClusterChanged(cluster2);
 
@@ -621,7 +621,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 
         private ClusterState GetClusterInfo(string id, string policy, bool activeCheckEnabled, HttpMessageInvoker httpClient, TimeSpan? interval = null, TimeSpan? timeout = null, int destinationCount = 2)
         {
-            var clusterConfig = new ClusterConfig(
+            var clusterModel = new ClusterModel(
                 new Cluster
                 {
                     Id = id,
@@ -639,7 +639,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                 },
                 httpClient);
             var clusterState = new ClusterState(id);
-            clusterState.Config = clusterConfig;
+            clusterState.Model = clusterModel;
             for (var i = 0; i < destinationCount; i++)
             {
                 var destinationConfig = new DestinationConfig(new Destination { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });

--- a/test/ReverseProxy.Tests/Service/HealthChecks/ActiveHealthCheckMonitorTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/ActiveHealthCheckMonitorTests.cs
@@ -260,10 +260,10 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                 },
                 Active = new ActiveHealthCheckOptions
                 {
-                    Policy = cluster2.Model.Options.HealthCheck.Active.Policy,
+                    Policy = cluster2.Model.Config.HealthCheck.Active.Policy,
                 }
             };
-            cluster2.Model = new ClusterModel(new Cluster { Id = cluster2.ClusterId, HealthCheck = healthCheckConfig },
+            cluster2.Model = new ClusterModel(new ClusterConfig { ClusterId = cluster2.ClusterId, HealthCheck = healthCheckConfig },
                 cluster2.Model.HttpClient);
 
             monitor.OnClusterChanged(cluster2);
@@ -622,9 +622,9 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         private ClusterState GetClusterInfo(string id, string policy, bool activeCheckEnabled, HttpMessageInvoker httpClient, TimeSpan? interval = null, TimeSpan? timeout = null, int destinationCount = 2)
         {
             var clusterModel = new ClusterModel(
-                new Cluster
+                new ClusterConfig
                 {
-                    Id = id,
+                    ClusterId = id,
                     HealthCheck = new HealthCheckOptions
                     {
                         Active = new ActiveHealthCheckOptions

--- a/test/ReverseProxy.Tests/Service/HealthChecks/ConsecutiveFailuresHealthPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/ConsecutiveFailuresHealthPolicyTests.cs
@@ -123,7 +123,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             var metadata = failureThreshold != null
                 ? new Dictionary<string, string> { { ConsecutiveFailuresHealthPolicyOptions.ThresholdMetadataName, failureThreshold.ToString() } }
                 : null;
-            var clusterConfig = new ClusterConfig(
+            var clusterModel = new ClusterModel(
                 new Cluster
                 {
                     Id = id,
@@ -140,7 +140,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                 },
                 null);
             var clusterState = new ClusterState(id);
-            clusterState.Config = clusterConfig;
+            clusterState.Model = clusterModel;
             for (var i = 0; i < destinationCount; i++)
             {
                 var destinationConfig = new DestinationConfig(new Destination { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });

--- a/test/ReverseProxy.Tests/Service/HealthChecks/ConsecutiveFailuresHealthPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/ConsecutiveFailuresHealthPolicyTests.cs
@@ -118,7 +118,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             Assert.Equal(DestinationHealth.Healthy, cluster.Destinations.Values.Skip(1).First().Health.Active);
         }
 
-        private ClusterInfo GetClusterInfo(string id, int destinationCount, int? failureThreshold = null)
+        private ClusterState GetClusterInfo(string id, int destinationCount, int? failureThreshold = null)
         {
             var metadata = failureThreshold != null
                 ? new Dictionary<string, string> { { ConsecutiveFailuresHealthPolicyOptions.ThresholdMetadataName, failureThreshold.ToString() } }
@@ -139,26 +139,26 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                     Metadata = metadata,
                 },
                 null);
-            var clusterInfo = new ClusterInfo(id);
-            clusterInfo.Config = clusterConfig;
+            var clusterState = new ClusterState(id);
+            clusterState.Config = clusterConfig;
             for (var i = 0; i < destinationCount; i++)
             {
                 var destinationConfig = new DestinationConfig(new Destination { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });
                 var destinationId = $"destination{i}";
-                clusterInfo.Destinations.GetOrAdd(destinationId, id => new DestinationInfo(id)
+                clusterState.Destinations.GetOrAdd(destinationId, id => new DestinationInfo(id)
                 {
                     Config = destinationConfig
                 });
             }
 
-            clusterInfo.ProcessDestinationChanges();
+            clusterState.ProcessDestinationChanges();
 
-            return clusterInfo;
+            return clusterState;
         }
 
         private class DestinationHealthUpdaterStub : IDestinationHealthUpdater
         {
-            public void SetActive(ClusterInfo cluster, IEnumerable<NewActiveDestinationHealth> newHealthStates)
+            public void SetActive(ClusterState cluster, IEnumerable<NewActiveDestinationHealth> newHealthStates)
             {
                 foreach(var newHealthState in newHealthStates)
                 {
@@ -168,7 +168,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                 cluster.UpdateDynamicState();
             }
 
-            public void SetPassive(ClusterInfo cluster, DestinationInfo destination, DestinationHealth newHealth, TimeSpan reactivationPeriod)
+            public void SetPassive(ClusterState cluster, DestinationInfo destination, DestinationHealth newHealth, TimeSpan reactivationPeriod)
             {
                 throw new NotImplementedException();
             }

--- a/test/ReverseProxy.Tests/Service/HealthChecks/ConsecutiveFailuresHealthPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/ConsecutiveFailuresHealthPolicyTests.cs
@@ -124,9 +124,9 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                 ? new Dictionary<string, string> { { ConsecutiveFailuresHealthPolicyOptions.ThresholdMetadataName, failureThreshold.ToString() } }
                 : null;
             var clusterModel = new ClusterModel(
-                new Cluster
+                new ClusterConfig
                 {
-                    Id = id,
+                    ClusterId = id,
                     HealthCheck = new HealthCheckOptions()
                     {
                         Active = new ActiveHealthCheckOptions

--- a/test/ReverseProxy.Tests/Service/HealthChecks/DefaultProbingRequestFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/DefaultProbingRequestFactoryTests.cs
@@ -72,9 +72,9 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             )
         {
             return new ClusterModel(
-                new Cluster
+                new ClusterConfig
                 {
-                    Id = id,
+                    ClusterId = id,
                     HealthCheck = new HealthCheckOptions()
                     {
                         Active = healthCheckOptions,

--- a/test/ReverseProxy.Tests/Service/HealthChecks/DefaultProbingRequestFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/DefaultProbingRequestFactoryTests.cs
@@ -22,7 +22,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         [InlineData("https://localhost:10000/", "https://localhost:20000/api", "/health/", "https://localhost:20000/api/health/")]
         public void CreateRequest_HealthEndpointIsNotDefined_UseDestinationAddress(string address, string health, string healthPath, string expectedRequestUri)
         {
-            var clusterConfig = GetClusterConfig("cluster0",
+            var clusterModel = GetClusterConfig("cluster0",
                 new ActiveHealthCheckOptions()
                 {
                     Enabled = true,
@@ -32,7 +32,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             var destinationConfig = new DestinationConfig(new Destination { Address = address, Health = health });
             var factory = new DefaultProbingRequestFactory();
 
-            var request = factory.CreateRequest(clusterConfig, destinationConfig);
+            var request = factory.CreateRequest(clusterModel, destinationConfig);
 
             Assert.Equal(expectedRequestUri, request.RequestUri.AbsoluteUri);
         }
@@ -43,7 +43,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         public void CreateRequest_RequestVersionProperties(string versionString)
         {
             var version = versionString != null ? Version.Parse(versionString) : null;
-            var clusterConfig = GetClusterConfig("cluster0",
+            var clusterModel = GetClusterConfig("cluster0",
                 new ActiveHealthCheckOptions()
                 {
                     Enabled = true,
@@ -57,7 +57,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             var destinationConfig = new DestinationConfig(new Destination { Address = "https://localhost:10000/" });
             var factory = new DefaultProbingRequestFactory();
 
-            var request = factory.CreateRequest(clusterConfig, destinationConfig);
+            var request = factory.CreateRequest(clusterModel, destinationConfig);
 
             Assert.Equal(version ?? HttpVersion.Version20, request.Version);
 #if NET
@@ -65,13 +65,13 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 #endif
         }
 
-        private ClusterConfig GetClusterConfig(string id, ActiveHealthCheckOptions healthCheckOptions, Version version
+        private ClusterModel GetClusterConfig(string id, ActiveHealthCheckOptions healthCheckOptions, Version version
 #if NET
             , HttpVersionPolicy versionPolicy = HttpVersionPolicy.RequestVersionExact
 #endif
             )
         {
-            return new ClusterConfig(
+            return new ClusterModel(
                 new Cluster
                 {
                     Id = id,

--- a/test/ReverseProxy.Tests/Service/HealthChecks/DestinationHealthUpdaterTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/DestinationHealthUpdaterTests.cs
@@ -115,9 +115,9 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             Assert.Contains(cluster.DynamicState.HealthyDestinations, d => d == destination3);
         }
 
-        private static ClusterInfo CreateCluster(bool passive, bool active, params DestinationInfo[] destinations)
+        private static ClusterState CreateCluster(bool passive, bool active, params DestinationInfo[] destinations)
         {
-            var cluster = new ClusterInfo("cluster0");
+            var cluster = new ClusterState("cluster0");
             cluster.Config = new ClusterConfig(
                 new Cluster
                 {

--- a/test/ReverseProxy.Tests/Service/HealthChecks/DestinationHealthUpdaterTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/DestinationHealthUpdaterTests.cs
@@ -118,7 +118,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         private static ClusterState CreateCluster(bool passive, bool active, params DestinationInfo[] destinations)
         {
             var cluster = new ClusterState("cluster0");
-            cluster.Config = new ClusterConfig(
+            cluster.Model = new ClusterModel(
                 new Cluster
                 {
                     Id = cluster.ClusterId,

--- a/test/ReverseProxy.Tests/Service/HealthChecks/DestinationHealthUpdaterTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/DestinationHealthUpdaterTests.cs
@@ -119,9 +119,9 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         {
             var cluster = new ClusterState("cluster0");
             cluster.Model = new ClusterModel(
-                new Cluster
+                new ClusterConfig
                 {
-                    Id = cluster.ClusterId,
+                    ClusterId = cluster.ClusterId,
                     HealthCheck = new HealthCheckOptions()
                     {
                         Passive = new PassiveHealthCheckOptions()

--- a/test/ReverseProxy.Tests/Service/HealthChecks/TransportFailureRateHealthPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/TransportFailureRateHealthPolicyTests.cs
@@ -204,7 +204,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             return context;
         }
 
-        private ClusterInfo GetClusterInfo(string id, int destinationCount, double? failureRateLimit = null, TimeSpan? reactivationPeriod = null)
+        private ClusterState GetClusterInfo(string id, int destinationCount, double? failureRateLimit = null, TimeSpan? reactivationPeriod = null)
         {
             var metadata = failureRateLimit != null
                 ? new Dictionary<string, string> { { TransportFailureRateHealthPolicyOptions.FailureRateLimitMetadataName, failureRateLimit?.ToString(CultureInfo.InvariantCulture) } }
@@ -225,19 +225,19 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                     Metadata = metadata,
                 },
                 null);
-            var clusterInfo = new ClusterInfo(id);
-            clusterInfo.Config = clusterConfig;
+            var clusterState = new ClusterState(id);
+            clusterState.Config = clusterConfig;
             for (var i = 0; i < destinationCount; i++)
             {
                 var destinationConfig = new DestinationConfig(new Destination { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });
                 var destinationId = $"destination{i}";
-                clusterInfo.Destinations.GetOrAdd(destinationId, id => new DestinationInfo(id)
+                clusterState.Destinations.GetOrAdd(destinationId, id => new DestinationInfo(id)
                 {
                     Config = destinationConfig
                 });
             }
 
-            return clusterInfo;
+            return clusterState;
         }
     }
 }

--- a/test/ReverseProxy.Tests/Service/HealthChecks/TransportFailureRateHealthPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/TransportFailureRateHealthPolicyTests.cs
@@ -209,7 +209,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             var metadata = failureRateLimit != null
                 ? new Dictionary<string, string> { { TransportFailureRateHealthPolicyOptions.FailureRateLimitMetadataName, failureRateLimit?.ToString(CultureInfo.InvariantCulture) } }
                 : null;
-            var clusterConfig = new ClusterConfig(
+            var clusterModel = new ClusterModel(
                 new Cluster
                 {
                     Id = id,
@@ -226,7 +226,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                 },
                 null);
             var clusterState = new ClusterState(id);
-            clusterState.Config = clusterConfig;
+            clusterState.Model = clusterModel;
             for (var i = 0; i < destinationCount; i++)
             {
                 var destinationConfig = new DestinationConfig(new Destination { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });

--- a/test/ReverseProxy.Tests/Service/HealthChecks/TransportFailureRateHealthPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/TransportFailureRateHealthPolicyTests.cs
@@ -210,9 +210,9 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                 ? new Dictionary<string, string> { { TransportFailureRateHealthPolicyOptions.FailureRateLimitMetadataName, failureRateLimit?.ToString(CultureInfo.InvariantCulture) } }
                 : null;
             var clusterModel = new ClusterModel(
-                new Cluster
+                new ClusterConfig
                 {
-                    Id = id,
+                    ClusterId = id,
                     HealthCheck = new HealthCheckOptions
                     {
                         Passive = new PassiveHealthCheckOptions

--- a/test/ReverseProxy.Tests/Service/Management/ProxyConfigManagerTests.cs
+++ b/test/ReverseProxy.Tests/Service/Management/ProxyConfigManagerTests.cs
@@ -134,8 +134,8 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
 
             Assert.Equal("cluster1", clusterState.ClusterId);
             Assert.NotNull(clusterState.Destinations);
-            Assert.NotNull(clusterState.Config);
-            Assert.NotNull(clusterState.Config.HttpClient);
+            Assert.NotNull(clusterState.Model);
+            Assert.NotNull(clusterState.Model.HttpClient);
             Assert.Same(clusterState, routeConfig.Cluster);
 
             var actualDestinations = clusterState.Destinations.Values;
@@ -185,16 +185,16 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
             var routeConfig = endpoint.Metadata.GetMetadata<RouteModel>();
             var clusterState = routeConfig.Cluster;
             Assert.Equal("cluster1", clusterState.ClusterId);
-            var clusterConfig = clusterState.Config;
-            Assert.NotNull(clusterConfig.HttpClient);
-            Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, clusterConfig.Options.HttpClient.SslProtocols);
-            Assert.Equal(10, clusterConfig.Options.HttpClient.MaxConnectionsPerServer);
-            Assert.Same(clientCertificate, clusterConfig.Options.HttpClient.ClientCertificate);
+            var clusterModel = clusterState.Model;
+            Assert.NotNull(clusterModel.HttpClient);
+            Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, clusterModel.Options.HttpClient.SslProtocols);
+            Assert.Equal(10, clusterModel.Options.HttpClient.MaxConnectionsPerServer);
+            Assert.Same(clientCertificate, clusterModel.Options.HttpClient.ClientCertificate);
 #if NET
-            Assert.Equal(Encoding.UTF8, clusterConfig.Options.HttpClient.RequestHeaderEncoding);
+            Assert.Equal(Encoding.UTF8, clusterModel.Options.HttpClient.RequestHeaderEncoding);
 #endif
 
-            var handler = Proxy.Tests.ProxyHttpClientFactoryTests.GetHandler(clusterConfig.HttpClient);
+            var handler = Proxy.Tests.ProxyHttpClientFactoryTests.GetHandler(clusterModel.HttpClient);
             Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, handler.SslOptions.EnabledSslProtocols);
             Assert.Equal(10, handler.MaxConnectionsPerServer);
             Assert.Single(handler.SslOptions.ClientCertificates, clientCertificate);
@@ -377,8 +377,8 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
             var routeConfig = endpoint.Metadata.GetMetadata<RouteModel>();
             var clusterState = routeConfig.Cluster;
             Assert.NotNull(clusterState);
-            Assert.True(clusterState.Config.Options.HealthCheck.Enabled);
-            Assert.Equal(TimeSpan.FromSeconds(12), clusterState.Config.Options.HealthCheck.Active.Interval);
+            Assert.True(clusterState.Model.Options.HealthCheck.Enabled);
+            Assert.Equal(TimeSpan.FromSeconds(12), clusterState.Model.Options.HealthCheck.Active.Interval);
             var destination = Assert.Single(clusterState.DynamicState.AllDestinations);
             Assert.Equal("http://localhost", destination.Config.Options.Address);
         }

--- a/test/ReverseProxy.Tests/Service/Management/ProxyConfigManagerTests.cs
+++ b/test/ReverseProxy.Tests/Service/Management/ProxyConfigManagerTests.cs
@@ -129,16 +129,16 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
             Assert.NotNull(routeConfig);
             Assert.Equal("route1", routeConfig.Config.RouteId);
 
-            var clusterInfo = routeConfig.Cluster;
-            Assert.NotNull(clusterInfo);
+            var clusterState = routeConfig.Cluster;
+            Assert.NotNull(clusterState);
 
-            Assert.Equal("cluster1", clusterInfo.ClusterId);
-            Assert.NotNull(clusterInfo.Destinations);
-            Assert.NotNull(clusterInfo.Config);
-            Assert.NotNull(clusterInfo.Config.HttpClient);
-            Assert.Same(clusterInfo, routeConfig.Cluster);
+            Assert.Equal("cluster1", clusterState.ClusterId);
+            Assert.NotNull(clusterState.Destinations);
+            Assert.NotNull(clusterState.Config);
+            Assert.NotNull(clusterState.Config.HttpClient);
+            Assert.Same(clusterState, routeConfig.Cluster);
 
-            var actualDestinations = clusterInfo.Destinations.Values;
+            var actualDestinations = clusterState.Destinations.Values;
             var destination = Assert.Single(actualDestinations);
             Assert.Equal("d1", destination.DestinationId);
             Assert.NotNull(destination.Config);
@@ -183,9 +183,9 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
             Assert.NotNull(dataSource);
             var endpoint = Assert.Single(dataSource.Endpoints);
             var routeConfig = endpoint.Metadata.GetMetadata<RouteModel>();
-            var clusterInfo = routeConfig.Cluster;
-            Assert.Equal("cluster1", clusterInfo.ClusterId);
-            var clusterConfig = clusterInfo.Config;
+            var clusterState = routeConfig.Cluster;
+            Assert.Equal("cluster1", clusterState.ClusterId);
+            var clusterConfig = clusterState.Config;
             Assert.NotNull(clusterConfig.HttpClient);
             Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, clusterConfig.Options.HttpClient.SslProtocols);
             Assert.Equal(10, clusterConfig.Options.HttpClient.MaxConnectionsPerServer);
@@ -375,11 +375,11 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
             Assert.NotNull(dataSource);
             var endpoint = Assert.Single(dataSource.Endpoints);
             var routeConfig = endpoint.Metadata.GetMetadata<RouteModel>();
-            var clusterInfo = routeConfig.Cluster;
-            Assert.NotNull(clusterInfo);
-            Assert.True(clusterInfo.Config.Options.HealthCheck.Enabled);
-            Assert.Equal(TimeSpan.FromSeconds(12), clusterInfo.Config.Options.HealthCheck.Active.Interval);
-            var destination = Assert.Single(clusterInfo.DynamicState.AllDestinations);
+            var clusterState = routeConfig.Cluster;
+            Assert.NotNull(clusterState);
+            Assert.True(clusterState.Config.Options.HealthCheck.Enabled);
+            Assert.Equal(TimeSpan.FromSeconds(12), clusterState.Config.Options.HealthCheck.Active.Interval);
+            var destination = Assert.Single(clusterState.DynamicState.AllDestinations);
             Assert.Equal("http://localhost", destination.Config.Options.Address);
         }
 

--- a/test/ReverseProxy.Tests/Service/Management/ProxyConfigManagerTests.cs
+++ b/test/ReverseProxy.Tests/Service/Management/ProxyConfigManagerTests.cs
@@ -27,7 +27,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
 {
     public class ProxyConfigManagerTests
     {
-        private IServiceProvider CreateServices(List<RouteConfig> routes, List<Cluster> clusters, Action<IReverseProxyBuilder> configureProxy = null)
+        private IServiceProvider CreateServices(List<RouteConfig> routes, List<ClusterConfig> clusters, Action<IReverseProxyBuilder> configureProxy = null)
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddLogging();
@@ -47,14 +47,14 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
         [Fact]
         public void Constructor_Works()
         {
-            var services = CreateServices(new List<RouteConfig>(), new List<Cluster>());
+            var services = CreateServices(new List<RouteConfig>(), new List<ClusterConfig>());
             _ = services.GetRequiredService<ProxyConfigManager>();
         }
 
         [Fact]
         public async Task NullRoutes_StartsEmpty()
         {
-            var services = CreateServices(null, new List<Cluster>());
+            var services = CreateServices(null, new List<ClusterConfig>());
             var manager = services.GetRequiredService<ProxyConfigManager>();
             var dataSource = await manager.InitialLoadAsync();
             Assert.NotNull(dataSource);
@@ -76,7 +76,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
         [Fact]
         public async Task Endpoints_StartsEmpty()
         {
-            var services = CreateServices(new List<RouteConfig>(), new List<Cluster>());
+            var services = CreateServices(new List<RouteConfig>(), new List<ClusterConfig>());
             var manager = services.GetRequiredService<ProxyConfigManager>();
             var dataSource = await manager.InitialLoadAsync();
             Assert.NotNull(dataSource);
@@ -87,7 +87,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
         [Fact]
         public async Task GetChangeToken_InitialValue()
         {
-            var services = CreateServices(new List<RouteConfig>(), new List<Cluster>());
+            var services = CreateServices(new List<RouteConfig>(), new List<ClusterConfig>());
             var manager = services.GetRequiredService<ProxyConfigManager>();
             var dataSource = await manager.InitialLoadAsync();
             Assert.NotNull(dataSource);
@@ -102,9 +102,9 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
         {
             const string TestAddress = "https://localhost:123/";
 
-            var cluster = new Cluster
+            var cluster = new ClusterConfig
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "d1", new Destination { Address = TestAddress } }
@@ -117,7 +117,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
                 Match = new RouteMatch { Path = "/" }
             };
 
-            var services = CreateServices(new List<RouteConfig>() { route }, new List<Cluster>() { cluster });
+            var services = CreateServices(new List<RouteConfig>() { route }, new List<ClusterConfig>() { cluster });
 
             var manager = services.GetRequiredService<ProxyConfigManager>();
             var dataSource = await manager.InitialLoadAsync();
@@ -151,9 +151,9 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
             const string TestAddress = "https://localhost:123/";
 
             var clientCertificate = TestResources.GetTestCertificate();
-            var cluster = new Cluster
+            var cluster = new ClusterConfig
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "d1", new Destination { Address = TestAddress } }
@@ -175,7 +175,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
                 Match = new RouteMatch { Path = "/" }
             };
 
-            var services = CreateServices(new List<RouteConfig>() { route }, new List<Cluster>() { cluster });
+            var services = CreateServices(new List<RouteConfig>() { route }, new List<ClusterConfig>() { cluster });
 
             var manager = services.GetRequiredService<ProxyConfigManager>();
             var dataSource = await manager.InitialLoadAsync();
@@ -187,11 +187,11 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
             Assert.Equal("cluster1", clusterState.ClusterId);
             var clusterModel = clusterState.Model;
             Assert.NotNull(clusterModel.HttpClient);
-            Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, clusterModel.Options.HttpClient.SslProtocols);
-            Assert.Equal(10, clusterModel.Options.HttpClient.MaxConnectionsPerServer);
-            Assert.Same(clientCertificate, clusterModel.Options.HttpClient.ClientCertificate);
+            Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, clusterModel.Config.HttpClient.SslProtocols);
+            Assert.Equal(10, clusterModel.Config.HttpClient.MaxConnectionsPerServer);
+            Assert.Same(clientCertificate, clusterModel.Config.HttpClient.ClientCertificate);
 #if NET
-            Assert.Equal(Encoding.UTF8, clusterModel.Options.HttpClient.RequestHeaderEncoding);
+            Assert.Equal(Encoding.UTF8, clusterModel.Config.HttpClient.RequestHeaderEncoding);
 #endif
 
             var handler = Proxy.Tests.ProxyHttpClientFactoryTests.GetHandler(clusterModel.HttpClient);
@@ -206,7 +206,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
         [Fact]
         public async Task GetChangeToken_SignalsChange()
         {
-            var services = CreateServices(new List<RouteConfig>(), new List<Cluster>());
+            var services = CreateServices(new List<RouteConfig>(), new List<ClusterConfig>());
             var inMemoryConfig = (InMemoryConfigProvider)services.GetRequiredService<IProxyConfigProvider>();
             var configManager = services.GetRequiredService<ProxyConfigManager>();
             var dataSource = await configManager.InitialLoadAsync();
@@ -227,7 +227,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
 
             // updating should signal the current change token
             Assert.False(signaled1.Task.IsCompleted);
-            inMemoryConfig.Update(new List<RouteConfig>() { new RouteConfig() { RouteId = "r1", Match = new RouteMatch { Path = "/" } } }, new List<Cluster>());
+            inMemoryConfig.Update(new List<RouteConfig>() { new RouteConfig() { RouteId = "r1", Match = new RouteMatch { Path = "/" } } }, new List<ClusterConfig>());
             await signaled1.Task.DefaultTimeout();
 
             var changeToken2 = dataSource.GetChangeToken();
@@ -240,7 +240,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
 
             // updating again should only signal the new change token
             Assert.False(signaled2.Task.IsCompleted);
-            inMemoryConfig.Update(new List<RouteConfig>() { new RouteConfig() { RouteId = "r2", Match = new RouteMatch { Path = "/" } } }, new List<Cluster>());
+            inMemoryConfig.Update(new List<RouteConfig>() { new RouteConfig() { RouteId = "r2", Match = new RouteMatch { Path = "/" } } }, new List<ClusterConfig>());
             await signaled2.Task.DefaultTimeout();
 
             Assert.NotNull(readEndpoints1);
@@ -252,9 +252,9 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
         {
             const string TestAddress = "https://localhost:123/";
 
-            var cluster = new Cluster
+            var cluster = new ClusterConfig
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "d1", new Destination { Address = TestAddress } }
@@ -262,7 +262,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
                 HttpRequest = new RequestProxyOptions() { Version = new Version(1, 2) }
             };
 
-            var services = CreateServices(new List<RouteConfig>(), new List<Cluster>() { cluster });
+            var services = CreateServices(new List<RouteConfig>(), new List<ClusterConfig>() { cluster });
             var configManager = services.GetRequiredService<ProxyConfigManager>();
 
             var ioEx = await Assert.ThrowsAsync<InvalidOperationException>(() => configManager.InitialLoadAsync());
@@ -279,7 +279,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
         {
             var routeName = "route1";
             var route1 = new RouteConfig { RouteId = routeName, Match = new RouteMatch { Hosts = null }, ClusterId = "cluster1" };
-            var services = CreateServices(new List<RouteConfig>() { route1 }, new List<Cluster>());
+            var services = CreateServices(new List<RouteConfig>() { route1 }, new List<ClusterConfig>());
             var configManager = services.GetRequiredService<ProxyConfigManager>();
 
             var ioEx = await Assert.ThrowsAsync<InvalidOperationException>(() => configManager.InitialLoadAsync());
@@ -295,7 +295,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
         public async Task LoadAsync_ConfigFilterRouteActions_CanFixBrokenRoute()
         {
             var route1 = new RouteConfig { RouteId = "route1", Match = new RouteMatch { Hosts = null }, Order = 1, ClusterId = "cluster1" };
-            var services = CreateServices(new List<RouteConfig>() { route1 }, new List<Cluster>(), proxyBuilder =>
+            var services = CreateServices(new List<RouteConfig>() { route1 }, new List<ClusterConfig>(), proxyBuilder =>
             {
                 proxyBuilder.AddConfigFilter<FixRouteHostFilter>();
             });
@@ -315,9 +315,9 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
 
         private class FixRouteHostFilter : IProxyConfigFilter
         {
-            public ValueTask<Cluster> ConfigureClusterAsync(Cluster cluster, CancellationToken cancel)
+            public ValueTask<ClusterConfig> ConfigureClusterAsync(ClusterConfig cluster, CancellationToken cancel)
             {
-                return new ValueTask<Cluster>(cluster);
+                return new ValueTask<ClusterConfig>(cluster);
             }
 
             public ValueTask<RouteConfig> ConfigureRouteAsync(RouteConfig route, CancellationToken cancel)
@@ -331,9 +331,9 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
 
         private class ClusterAndRouteFilter : IProxyConfigFilter
         {
-            public ValueTask<Cluster> ConfigureClusterAsync(Cluster cluster, CancellationToken cancel)
+            public ValueTask<ClusterConfig> ConfigureClusterAsync(ClusterConfig cluster, CancellationToken cancel)
             {
-                return new ValueTask<Cluster>(cluster with
+                return new ValueTask<ClusterConfig>(cluster with
                 {
                     HealthCheck = new HealthCheckOptions()
                     {
@@ -357,15 +357,15 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
                 ClusterId = "cluster1",
                 Match = new RouteMatch { Path = "/" }
             };
-            var cluster = new Cluster()
+            var cluster = new ClusterConfig()
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "d1", new Destination() { Address = "http://localhost" } }
                 }
             };
-            var services = CreateServices(new List<RouteConfig>() { route }, new List<Cluster>() { cluster }, proxyBuilder =>
+            var services = CreateServices(new List<RouteConfig>() { route }, new List<ClusterConfig>() { cluster }, proxyBuilder =>
             {
                 proxyBuilder.AddConfigFilter<ClusterAndRouteFilter>();
             });
@@ -377,15 +377,15 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
             var routeConfig = endpoint.Metadata.GetMetadata<RouteModel>();
             var clusterState = routeConfig.Cluster;
             Assert.NotNull(clusterState);
-            Assert.True(clusterState.Model.Options.HealthCheck.Enabled);
-            Assert.Equal(TimeSpan.FromSeconds(12), clusterState.Model.Options.HealthCheck.Active.Interval);
+            Assert.True(clusterState.Model.Config.HealthCheck.Enabled);
+            Assert.Equal(TimeSpan.FromSeconds(12), clusterState.Model.Config.HealthCheck.Active.Interval);
             var destination = Assert.Single(clusterState.DynamicState.AllDestinations);
             Assert.Equal("http://localhost", destination.Config.Options.Address);
         }
 
         private class ClusterAndRouteThrows : IProxyConfigFilter
         {
-            public ValueTask<Cluster> ConfigureClusterAsync(Cluster cluster, CancellationToken cancel)
+            public ValueTask<ClusterConfig> ConfigureClusterAsync(ClusterConfig cluster, CancellationToken cancel)
             {
                 throw new NotFiniteNumberException("Test exception");
             }
@@ -399,15 +399,15 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
         [Fact]
         public async Task LoadAsync_ConfigFilterClusterActionThrows_Throws()
         {
-            var cluster = new Cluster()
+            var cluster = new ClusterConfig()
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "d1", new Destination() { Address = "http://localhost" } }
                 }
             };
-            var services = CreateServices(new List<RouteConfig>(), new List<Cluster>() { cluster }, proxyBuilder =>
+            var services = CreateServices(new List<RouteConfig>(), new List<ClusterConfig>() { cluster }, proxyBuilder =>
             {
                 proxyBuilder.AddConfigFilter<ClusterAndRouteThrows>();
                 proxyBuilder.AddConfigFilter<ClusterAndRouteThrows>();
@@ -428,7 +428,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
         {
             var route1 = new RouteConfig { RouteId = "route1", Match = new RouteMatch { Hosts = new[] { "example.com" } }, Order = 1, ClusterId = "cluster1" };
             var route2 = new RouteConfig { RouteId = "route2", Match = new RouteMatch { Hosts = new[] { "example2.com" } }, Order = 1, ClusterId = "cluster2" };
-            var services = CreateServices(new List<RouteConfig>() { route1, route2 }, new List<Cluster>(), proxyBuilder =>
+            var services = CreateServices(new List<RouteConfig>() { route1, route2 }, new List<ClusterConfig>(), proxyBuilder =>
             {
                 proxyBuilder.AddConfigFilter<ClusterAndRouteThrows>();
                 proxyBuilder.AddConfigFilter<ClusterAndRouteThrows>();

--- a/test/ReverseProxy.Tests/Service/Proxy/LoadBalancingPoliciesTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/LoadBalancingPoliciesTests.cs
@@ -137,7 +137,7 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
 
             var context = new DefaultHttpContext();
 
-            var routeConfig = new RouteModel(new RouteConfig(), new ClusterInfo("cluster1"), transformer: null);
+            var routeConfig = new RouteModel(new RouteConfig(), new ClusterState("cluster1"), transformer: null);
             var feature = new ReverseProxyFeature()
             {
                 Route = routeConfig,

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/ClusterInfoTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/ClusterInfoTests.cs
@@ -81,7 +81,7 @@ namespace Yarp.ReverseProxy.RuntimeModel.Tests
             Assert.NotNull(state2);
             Assert.Empty(state2.AllDestinations);
 
-            cluster.Config = new ClusterConfig(new Cluster(), httpClient: new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object));
+            cluster.Model = new ClusterModel(new Cluster(), httpClient: new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object));
             Assert.Same(state2, cluster.DynamicState);
 
             cluster.UpdateDynamicState();
@@ -150,7 +150,7 @@ namespace Yarp.ReverseProxy.RuntimeModel.Tests
         private static void EnableHealthChecks(ClusterState cluster)
         {
             // Pretend that health checks are enabled so that destination health states are honored
-            cluster.Config = new ClusterConfig(
+            cluster.Model = new ClusterModel(
                 new Cluster
                 {
                     HealthCheck = new HealthCheckOptions

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/ClusterInfoTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/ClusterInfoTests.cs
@@ -18,7 +18,7 @@ namespace Yarp.ReverseProxy.RuntimeModel.Tests
         [Fact]
         public void DynamicState_WithoutHealthChecks_AssumesAllHealthy()
         {
-            var cluster = new ClusterInfo("abc");
+            var cluster = new ClusterState("abc");
             var destination1 = cluster.Destinations.GetOrAdd("d1", id => new DestinationInfo(id) { Health = { Active = DestinationHealth.Healthy } });
             var destination2 = cluster.Destinations.GetOrAdd("d2", id => new DestinationInfo(id) { Health = { Active = DestinationHealth.Unhealthy } });
             var destination3 = cluster.Destinations.GetOrAdd("d3", id => new DestinationInfo(id)); // Unknown health state
@@ -41,7 +41,7 @@ namespace Yarp.ReverseProxy.RuntimeModel.Tests
         [Fact]
         public void DynamicState_WithHealthChecks_HonorsHealthState()
         {
-            var cluster = new ClusterInfo("abc");
+            var cluster = new ClusterState("abc");
             EnableHealthChecks(cluster);
             var destination1 = cluster.Destinations.GetOrAdd("d1", id => new DestinationInfo(id) { Health = { Active = DestinationHealth.Healthy } });
             var destination2 = cluster.Destinations.GetOrAdd("d2", id => new DestinationInfo(id) { Health = { Active = DestinationHealth.Unhealthy } });
@@ -69,7 +69,7 @@ namespace Yarp.ReverseProxy.RuntimeModel.Tests
         [Fact]
         public void DynamicState_ManuallyUpdated()
         {
-            var cluster = new ClusterInfo("abc");
+            var cluster = new ClusterState("abc");
 
             var state1 = cluster.DynamicState;
             Assert.NotNull(state1);
@@ -93,7 +93,7 @@ namespace Yarp.ReverseProxy.RuntimeModel.Tests
         [Fact]
         public void DynamicState_ReactsToDestinationChanges()
         {
-            var cluster = new ClusterInfo("abc");
+            var cluster = new ClusterState("abc");
             cluster.ProcessDestinationChanges();
 
             var state1 = cluster.DynamicState;
@@ -117,7 +117,7 @@ namespace Yarp.ReverseProxy.RuntimeModel.Tests
         [Fact]
         public void DynamicState_ReactsToDestinationStateChanges()
         {
-            var cluster = new ClusterInfo("abc");
+            var cluster = new ClusterState("abc");
             EnableHealthChecks(cluster);
             cluster.ProcessDestinationChanges();
 
@@ -147,7 +147,7 @@ namespace Yarp.ReverseProxy.RuntimeModel.Tests
             Assert.Contains(destination, state4.HealthyDestinations);
         }
 
-        private static void EnableHealthChecks(ClusterInfo cluster)
+        private static void EnableHealthChecks(ClusterState cluster)
         {
             // Pretend that health checks are enabled so that destination health states are honored
             cluster.Config = new ClusterConfig(

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/ClusterInfoTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/ClusterInfoTests.cs
@@ -81,7 +81,7 @@ namespace Yarp.ReverseProxy.RuntimeModel.Tests
             Assert.NotNull(state2);
             Assert.Empty(state2.AllDestinations);
 
-            cluster.Model = new ClusterModel(new Cluster(), httpClient: new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object));
+            cluster.Model = new ClusterModel(new ClusterConfig(), httpClient: new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object));
             Assert.Same(state2, cluster.DynamicState);
 
             cluster.UpdateDynamicState();
@@ -151,7 +151,7 @@ namespace Yarp.ReverseProxy.RuntimeModel.Tests
         {
             // Pretend that health checks are enabled so that destination health states are honored
             cluster.Model = new ClusterModel(
-                new Cluster
+                new ClusterConfig
                 {
                     HealthCheck = new HealthCheckOptions
                     {

--- a/test/ReverseProxy.Tests/Service/SessionAffinity/AffinitizeTransformProviderTests.cs
+++ b/test/ReverseProxy.Tests/Service/SessionAffinity/AffinitizeTransformProviderTests.cs
@@ -20,9 +20,9 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
 
             var transformProvider = new AffinitizeTransformProvider(new[] { affinityProvider.Object });
             
-            var cluster = new Cluster
+            var cluster = new ClusterConfig
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 SessionAffinity = new SessionAffinityOptions()
                 {
                     Enabled = true,
@@ -55,9 +55,9 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
 
             var transformProvider = new AffinitizeTransformProvider(new[] { affinityProvider.Object });
 
-            var cluster = new Cluster
+            var cluster = new ClusterConfig
             {
-                Id = "cluster1",
+                ClusterId = "cluster1",
                 SessionAffinity = new SessionAffinityOptions()
                 {
                     Enabled = true,

--- a/test/ReverseProxy.Tests/Service/SessionAffinity/AffinitizeTransformTests.cs
+++ b/test/ReverseProxy.Tests/Service/SessionAffinity/AffinitizeTransformTests.cs
@@ -43,9 +43,9 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
             provider.Verify();
         }
 
-        internal ClusterInfo GetCluster()
+        internal ClusterState GetCluster()
         {
-            var cluster = new ClusterInfo("cluster-1");
+            var cluster = new ClusterState("cluster-1");
             cluster.Destinations.GetOrAdd("dest-A", id => new DestinationInfo(id));
             cluster.Config = new ClusterConfig(new Cluster
             {

--- a/test/ReverseProxy.Tests/Service/SessionAffinity/AffinitizeTransformTests.cs
+++ b/test/ReverseProxy.Tests/Service/SessionAffinity/AffinitizeTransformTests.cs
@@ -30,7 +30,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
             var context = new DefaultHttpContext();
             context.Features.Set<IReverseProxyFeature>(new ReverseProxyFeature()
             {
-                ClusterSnapshot = cluster.Config,
+                Cluster = cluster.Model,
                 ProxiedDestination = destination,
             });
 
@@ -47,7 +47,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
         {
             var cluster = new ClusterState("cluster-1");
             cluster.Destinations.GetOrAdd("dest-A", id => new DestinationInfo(id));
-            cluster.Config = new ClusterConfig(new Cluster
+            cluster.Model = new ClusterModel(new Cluster
             {
                 SessionAffinity = new SessionAffinityOptions
                 {

--- a/test/ReverseProxy.Tests/Service/SessionAffinity/AffinitizeTransformTests.cs
+++ b/test/ReverseProxy.Tests/Service/SessionAffinity/AffinitizeTransformTests.cs
@@ -47,7 +47,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
         {
             var cluster = new ClusterState("cluster-1");
             cluster.Destinations.GetOrAdd("dest-A", id => new DestinationInfo(id));
-            cluster.Model = new ClusterModel(new Cluster
+            cluster.Model = new ClusterModel(new ClusterConfig
             {
                 SessionAffinity = new SessionAffinityOptions
                 {

--- a/testassets/ReverseProxy.Code/InMemoryConfigProvider.cs
+++ b/testassets/ReverseProxy.Code/InMemoryConfigProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class InMemoryConfigProviderExtensions
     {
-        public static IReverseProxyBuilder LoadFromMemory(this IReverseProxyBuilder builder, IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
+        public static IReverseProxyBuilder LoadFromMemory(this IReverseProxyBuilder builder, IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
         {
             builder.Services.AddSingleton<IProxyConfigProvider>(new InMemoryConfigProvider(routes, clusters));
             return builder;
@@ -26,14 +26,14 @@ namespace Yarp.ReverseProxy.Configuration
     {
         private volatile InMemoryConfig _config;
 
-        public InMemoryConfigProvider(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
+        public InMemoryConfigProvider(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
         {
             _config = new InMemoryConfig(routes, clusters);
         }
 
         public IProxyConfig GetConfig() => _config;
 
-        public void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
+        public void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
         {
             var oldConfig = _config;
             _config = new InMemoryConfig(routes, clusters);
@@ -44,7 +44,7 @@ namespace Yarp.ReverseProxy.Configuration
         {
             private readonly CancellationTokenSource _cts = new CancellationTokenSource();
 
-            public InMemoryConfig(IReadOnlyList<RouteConfig> routes, IReadOnlyList<Cluster> clusters)
+            public InMemoryConfig(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
             {
                 Routes = routes;
                 Clusters = clusters;
@@ -53,7 +53,7 @@ namespace Yarp.ReverseProxy.Configuration
 
             public IReadOnlyList<RouteConfig> Routes { get; }
 
-            public IReadOnlyList<Cluster> Clusters { get; }
+            public IReadOnlyList<ClusterConfig> Clusters { get; }
 
             public IChangeToken ChangeToken { get; }
 

--- a/testassets/ReverseProxy.Code/Startup.cs
+++ b/testassets/ReverseProxy.Code/Startup.cs
@@ -39,9 +39,9 @@ namespace Yarp.ReverseProxy.Sample
             };
             var clusters = new[]
             {
-                new Cluster()
+                new ClusterConfig()
                 {
-                    Id = "cluster1",
+                    ClusterId = "cluster1",
                     SessionAffinity = new SessionAffinityOptions { Enabled = true, Mode = "Cookie" },
                     Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
                     {

--- a/testassets/ReverseProxy.Config/CustomConfigFilter.cs
+++ b/testassets/ReverseProxy.Config/CustomConfigFilter.cs
@@ -12,7 +12,7 @@ namespace Yarp.ReverseProxy.Sample
 {
     public class CustomConfigFilter : IProxyConfigFilter
     {
-        public ValueTask<Cluster> ConfigureClusterAsync(Cluster cluster, CancellationToken cancel)
+        public ValueTask<ClusterConfig> ConfigureClusterAsync(ClusterConfig cluster, CancellationToken cancel)
         {
             // How to use custom metadata to configure clusters
             if (cluster.Metadata?.TryGetValue("CustomHealth", out var customHealth) ?? false
@@ -50,7 +50,7 @@ namespace Yarp.ReverseProxy.Sample
                 };
             }
 
-            return new ValueTask<Cluster>(cluster);
+            return new ValueTask<ClusterConfig>(cluster);
         }
 
         public ValueTask<RouteConfig> ConfigureRouteAsync(RouteConfig route, CancellationToken cancel)


### PR DESCRIPTION
A continuation of #955
Cluster ->ClusterConfig
ClusterConfig -> ClusterModel
ClusterInfo -> ClusterState

I'll do Destinations in a 3rd PR.

Also fixed #909, Id -> ClusterId to match RouteId and DestinationId.