### PR TITLE
API renames: destinations

### DIFF
--- a/src/ReverseProxy.Kubernetes.Controller/Converters/ClusterTrasfer.cs
+++ b/src/ReverseProxy.Kubernetes.Controller/Converters/ClusterTrasfer.cs
@@ -8,7 +8,7 @@ namespace Yarp.ReverseProxy.Kubernetes.Controller.Services
 {
     internal sealed class ClusterTrasfer
     {
-        public Dictionary<string, Destination> Destinations { get; set; } = new Dictionary<string, Destination>();
+        public Dictionary<string, DestinationConfig> Destinations { get; set; } = new Dictionary<string, DestinationConfig>();
         public string ClusterId { get; set; }
     }
 }

--- a/src/ReverseProxy.Kubernetes.Controller/Converters/YarpParser.cs
+++ b/src/ReverseProxy.Kubernetes.Controller/Converters/YarpParser.cs
@@ -94,7 +94,7 @@ namespace Yarp.ReverseProxy.Kubernetes.Controller.Converters
 
                         var protocol = context.Options.Https ? "https" : "http";
                         var uri = $"{protocol}://{address.Ip}:{port.Port}";
-                        cluster.Destinations[uri] = new Destination()
+                        cluster.Destinations[uri] = new DestinationConfig()
                         {
                             Address = uri
                         };

--- a/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Discoverer.cs
+++ b/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Discoverer.cs
@@ -188,7 +188,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
             };
         }
 
-        private Destination BuildDestination(ReplicaWrapper replica, string listenerName, string healthListenerName)
+        private DestinationConfig BuildDestination(ReplicaWrapper replica, string listenerName, string healthListenerName)
         {
             if (!ServiceEndpointCollection.TryParseEndpointsString(replica.ReplicaAddress, out var serviceEndpointCollection))
             {
@@ -219,7 +219,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
                 }
             }
 
-            return new Destination
+            return new DestinationConfig
             {
                 Address = endpointUri.ToString(),
                 Health = healthEndpointUri?.ToString(),
@@ -242,7 +242,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
         /// and populates the specified <paramref name="cluster"/>'s <see cref="ClusterConfig.Destinations"/> accordingly.
         /// </summary>
         /// <remarks>All non-fatal exceptions are caught and logged.</remarks>
-        private async Task<IReadOnlyDictionary<string, Destination>> DiscoverDestinationsAsync(
+        private async Task<IReadOnlyDictionary<string, DestinationConfig>> DiscoverDestinationsAsync(
             ServiceFabricDiscoveryOptions options,
             ServiceWrapper service,
             Dictionary<string, string> serviceExtensionLabels,
@@ -259,7 +259,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
                 return null;
             }
 
-            var destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase);
+            var destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase);
 
             var listenerName = serviceExtensionLabels.GetValueOrDefault("YARP.Backend.ServiceFabric.ListenerName", string.Empty);
             var healthListenerName = serviceExtensionLabels.GetValueOrDefault("YARP.Backend.HealthCheck.Active.ServiceFabric.ListenerName", string.Empty);

--- a/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Util/LabelsParser.cs
+++ b/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Util/LabelsParser.cs
@@ -236,7 +236,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
             return routes;
         }
 
-        internal static ClusterConfig BuildCluster(Uri serviceName, Dictionary<string, string> labels, IReadOnlyDictionary<string, Destination> destinations)
+        internal static ClusterConfig BuildCluster(Uri serviceName, Dictionary<string, string> labels, IReadOnlyDictionary<string, DestinationConfig> destinations)
         {
             var clusterMetadata = new Dictionary<string, string>();
             Dictionary<string, string> sessionAffinitySettings = null;

--- a/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/ClusterConfig.cs
+++ b/src/ReverseProxy/Abstractions/ClusterDiscovery/Contract/ClusterConfig.cs
@@ -46,7 +46,7 @@ namespace Yarp.ReverseProxy.Abstractions
         /// <summary>
         /// The set of destinations associated with this cluster.
         /// </summary>
-        public IReadOnlyDictionary<string, Destination> Destinations { get; init; }
+        public IReadOnlyDictionary<string, DestinationConfig> Destinations { get; init; }
 
         /// <summary>
         /// Arbitrary key-value pairs that further describe this cluster.

--- a/src/ReverseProxy/Abstractions/DestinationConfig.cs
+++ b/src/ReverseProxy/Abstractions/DestinationConfig.cs
@@ -10,7 +10,7 @@ namespace Yarp.ReverseProxy.Abstractions
     /// <summary>
     /// Describes a destination of a cluster.
     /// </summary>
-    public sealed record Destination
+    public sealed record DestinationConfig
     {
         /// <summary>
         /// Address of this destination. E.g. <c>https://127.0.0.1:123/abcd1234/</c>.
@@ -28,7 +28,7 @@ namespace Yarp.ReverseProxy.Abstractions
         public IReadOnlyDictionary<string, string> Metadata { get; init; }
 
         /// <inheritdoc />
-        public bool Equals(Destination other)
+        public bool Equals(DestinationConfig other)
         {
             if (other == null)
             {

--- a/src/ReverseProxy/Configuration/ConfigurationConfigProvider.cs
+++ b/src/ReverseProxy/Configuration/ConfigurationConfigProvider.cs
@@ -146,7 +146,7 @@ namespace Yarp.ReverseProxy.Configuration
 
         private ClusterConfig CreateCluster(IConfigurationSection section)
         {
-            var destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase);
+            var destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase);
             foreach (var destination in section.GetSection(nameof(ClusterConfig.Destinations)).GetChildren())
             {
                 destinations.Add(destination.Key, CreateDestination(destination));
@@ -368,18 +368,18 @@ namespace Yarp.ReverseProxy.Configuration
             };
         }
 
-        private static Destination CreateDestination(IConfigurationSection section)
+        private static DestinationConfig CreateDestination(IConfigurationSection section)
         {
             if (!section.Exists())
             {
                 return null;
             }
 
-            return new Destination
+            return new DestinationConfig
             {
-                Address = section[nameof(Destination.Address)],
-                Health = section[nameof(Destination.Health)],
-                Metadata = section.GetSection(nameof(Destination.Metadata)).ReadStringDictionary(),
+                Address = section[nameof(DestinationConfig.Address)],
+                Health = section[nameof(DestinationConfig.Health)],
+                Metadata = section.GetSection(nameof(DestinationConfig.Metadata)).ReadStringDictionary(),
             };
         }
 

--- a/src/ReverseProxy/Middleware/IReverseProxyFeature.cs
+++ b/src/ReverseProxy/Middleware/IReverseProxyFeature.cs
@@ -24,17 +24,17 @@ namespace Yarp.ReverseProxy.Middleware
         /// <summary>
         /// All destinations for the current cluster.
         /// </summary>
-        IReadOnlyList<DestinationInfo> AllDestinations { get; }
+        IReadOnlyList<DestinationState> AllDestinations { get; }
 
         /// <summary>
         /// Cluster destinations that can handle the current request. This will initially include all destinations except those
         /// currently marked as unhealth if health checks are enabled.
         /// </summary>
-        IReadOnlyList<DestinationInfo> AvailableDestinations { get; set; }
+        IReadOnlyList<DestinationState> AvailableDestinations { get; set; }
 
         /// <summary>
         /// The actual destination that the request was proxied to.
         /// </summary>
-        DestinationInfo ProxiedDestination { get; set; }
+        DestinationState ProxiedDestination { get; set; }
     }
 }

--- a/src/ReverseProxy/Middleware/LoadBalancingMiddleware.cs
+++ b/src/ReverseProxy/Middleware/LoadBalancingMiddleware.cs
@@ -39,7 +39,7 @@ namespace Yarp.ReverseProxy.Middleware
             var destinations = proxyFeature.AvailableDestinations;
             var destinationCount = destinations.Count;
 
-            DestinationInfo destination;
+            DestinationState destination;
 
             if (destinationCount == 0)
             {
@@ -59,7 +59,7 @@ namespace Yarp.ReverseProxy.Middleware
             {
                 // We intentionally do not short circuit here, we allow for later middleware to decide how to handle this case.
                 Log.NoAvailableDestinations(_logger, proxyFeature.Cluster.Config.ClusterId);
-                proxyFeature.AvailableDestinations = Array.Empty<DestinationInfo>();
+                proxyFeature.AvailableDestinations = Array.Empty<DestinationState>();
             }
             else
             {

--- a/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
+++ b/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
@@ -64,10 +64,10 @@ namespace Yarp.ReverseProxy.Middleware
 
             reverseProxyFeature.ProxiedDestination = destination;
 
-            var destinationConfig = destination.Config;
-            if (destinationConfig == null)
+            var destinationModel = destination.Model;
+            if (destinationModel == null)
             {
-                throw new InvalidOperationException($"Chosen destination has no configs set: '{destination.DestinationId}'");
+                throw new InvalidOperationException($"Chosen destination has no model set: '{destination.DestinationId}'");
             }
 
             try
@@ -78,7 +78,7 @@ namespace Yarp.ReverseProxy.Middleware
                 ProxyTelemetry.Log.ProxyInvoke(cluster.ClusterId, route.Config.RouteId, destination.DestinationId);
 
                 var clusterConfig = reverseProxyFeature.Cluster;
-                await _httpProxy.ProxyAsync(context, destinationConfig.Options.Address, clusterConfig.HttpClient, clusterConfig.Config.HttpRequest, route.Transformer);
+                await _httpProxy.ProxyAsync(context, destinationModel.Options.Address, clusterConfig.HttpClient, clusterConfig.Config.HttpRequest, route.Transformer);
             }
             finally
             {

--- a/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
+++ b/src/ReverseProxy/Middleware/ProxyInvokerMiddleware.cs
@@ -78,7 +78,7 @@ namespace Yarp.ReverseProxy.Middleware
                 ProxyTelemetry.Log.ProxyInvoke(cluster.ClusterId, route.Config.RouteId, destination.DestinationId);
 
                 var clusterConfig = reverseProxyFeature.Cluster;
-                await _httpProxy.ProxyAsync(context, destinationModel.Options.Address, clusterConfig.HttpClient, clusterConfig.Config.HttpRequest, route.Transformer);
+                await _httpProxy.ProxyAsync(context, destinationModel.Config.Address, clusterConfig.HttpClient, clusterConfig.Config.HttpRequest, route.Transformer);
             }
             finally
             {

--- a/src/ReverseProxy/Middleware/ReverseProxyFeature.cs
+++ b/src/ReverseProxy/Middleware/ReverseProxyFeature.cs
@@ -18,12 +18,12 @@ namespace Yarp.ReverseProxy.Middleware
         public ClusterModel Cluster { get; set; }
 
         /// <inheritdoc/>
-        public IReadOnlyList<DestinationInfo> AllDestinations { get; init; }
+        public IReadOnlyList<DestinationState> AllDestinations { get; init; }
 
         /// <inheritdoc/>
-        public IReadOnlyList<DestinationInfo> AvailableDestinations { get; set; }
+        public IReadOnlyList<DestinationState> AvailableDestinations { get; set; }
 
         /// <inheritdoc/>
-        public DestinationInfo ProxiedDestination { get; set; }
+        public DestinationState ProxiedDestination { get; set; }
     }
 }

--- a/src/ReverseProxy/Middleware/SessionAffinityMiddleware.cs
+++ b/src/ReverseProxy/Middleware/SessionAffinityMiddleware.cs
@@ -15,7 +15,7 @@ using Yarp.ReverseProxy.Utilities;
 namespace Yarp.ReverseProxy.Middleware
 {
     /// <summary>
-    /// Looks up an affinitized <see cref="DestinationInfo"/> matching the request's affinity key if any is set
+    /// Looks up an affinitized <see cref="DestinationState"/> matching the request's affinity key if any is set
     /// </summary>
     internal sealed class SessionAffinityMiddleware
     {

--- a/src/ReverseProxy/Service/HealthChecks/ActiveHealthCheckMonitor.cs
+++ b/src/ReverseProxy/Service/HealthChecks/ActiveHealthCheckMonitor.cs
@@ -124,7 +124,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                     var cts = new CancellationTokenSource(timeout);
                     try
                     {
-                        var request = _probingRequestFactory.CreateRequest(clusterModel, destination.Config);
+                        var request = _probingRequestFactory.CreateRequest(clusterModel, destination.Model);
 
                         Log.SendingHealthProbeToEndpointOfDestination(_logger, request.RequestUri, destination.DestinationId, cluster.ClusterId);
 

--- a/src/ReverseProxy/Service/HealthChecks/ConsecutiveFailuresHealthPolicy.cs
+++ b/src/ReverseProxy/Service/HealthChecks/ConsecutiveFailuresHealthPolicy.cs
@@ -17,7 +17,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
     {
         private readonly ConsecutiveFailuresHealthPolicyOptions _options;
         private readonly ConditionalWeakTable<ClusterState, ParsedMetadataEntry<double>> _clusterThresholds = new ConditionalWeakTable<ClusterState, ParsedMetadataEntry<double>>();
-        private readonly ConditionalWeakTable<DestinationInfo, AtomicCounter> _failureCounters = new ConditionalWeakTable<DestinationInfo, AtomicCounter>();
+        private readonly ConditionalWeakTable<DestinationState, AtomicCounter> _failureCounters = new ConditionalWeakTable<DestinationState, AtomicCounter>();
         private readonly IDestinationHealthUpdater _healthUpdater;
 
         public string Name => HealthCheckConstants.ActivePolicy.ConsecutiveFailures;

--- a/src/ReverseProxy/Service/HealthChecks/DefaultProbingRequestFactory.cs
+++ b/src/ReverseProxy/Service/HealthChecks/DefaultProbingRequestFactory.cs
@@ -10,7 +10,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 {
     internal sealed class DefaultProbingRequestFactory : IProbingRequestFactory
     {
-        public HttpRequestMessage CreateRequest(ClusterModel cluster, DestinationConfig destination)
+        public HttpRequestMessage CreateRequest(ClusterModel cluster, DestinationModel destination)
         {
             var probeAddress = !string.IsNullOrEmpty(destination.Options.Health) ? destination.Options.Health : destination.Options.Address;
             var probePath = cluster.Config.HealthCheck.Active.Path;

--- a/src/ReverseProxy/Service/HealthChecks/DefaultProbingRequestFactory.cs
+++ b/src/ReverseProxy/Service/HealthChecks/DefaultProbingRequestFactory.cs
@@ -12,7 +12,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
     {
         public HttpRequestMessage CreateRequest(ClusterModel cluster, DestinationModel destination)
         {
-            var probeAddress = !string.IsNullOrEmpty(destination.Options.Health) ? destination.Options.Health : destination.Options.Address;
+            var probeAddress = !string.IsNullOrEmpty(destination.Config.Health) ? destination.Config.Health : destination.Config.Address;
             var probePath = cluster.Config.HealthCheck.Active.Path;
             UriHelper.FromAbsolute(probeAddress, out var destinationScheme, out var destinationHost, out var destinationPathBase, out _, out _);
             var probeUri = UriHelper.BuildAbsolute(destinationScheme, destinationHost, destinationPathBase, probePath, default);

--- a/src/ReverseProxy/Service/HealthChecks/DestinationHealthUpdater.cs
+++ b/src/ReverseProxy/Service/HealthChecks/DestinationHealthUpdater.cs
@@ -13,12 +13,12 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 {
     internal sealed class DestinationHealthUpdater : IDestinationHealthUpdater, IDisposable
     {
-        private readonly EntityActionScheduler<(ClusterState Cluster, DestinationInfo Destination)> _scheduler;
+        private readonly EntityActionScheduler<(ClusterState Cluster, DestinationState Destination)> _scheduler;
         private readonly ILogger<DestinationHealthUpdater> _logger;
 
         public DestinationHealthUpdater(ITimerFactory timerFactory, ILogger<DestinationHealthUpdater> logger)
         {
-            _scheduler = new EntityActionScheduler<(ClusterState Cluster, DestinationInfo Destination)>(d => Reactivate(d.Cluster, d.Destination), autoStart: true, runOnce: true, timerFactory);
+            _scheduler = new EntityActionScheduler<(ClusterState Cluster, DestinationState Destination)>(d => Reactivate(d.Cluster, d.Destination), autoStart: true, runOnce: true, timerFactory);
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
@@ -52,12 +52,12 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             }
         }
 
-        public void SetPassive(ClusterState cluster, DestinationInfo destination, DestinationHealth newHealth, TimeSpan reactivationPeriod)
+        public void SetPassive(ClusterState cluster, DestinationState destination, DestinationHealth newHealth, TimeSpan reactivationPeriod)
         {
             _ = SetPassiveAsync(cluster, destination, newHealth, reactivationPeriod);
         }
 
-        internal Task SetPassiveAsync(ClusterState cluster, DestinationInfo destination, DestinationHealth newHealth, TimeSpan reactivationPeriod)
+        internal Task SetPassiveAsync(ClusterState cluster, DestinationState destination, DestinationHealth newHealth, TimeSpan reactivationPeriod)
         {
             var healthState = destination.Health;
             if (newHealth != healthState.Passive)
@@ -69,7 +69,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             return Task.CompletedTask;
         }
 
-        private void ScheduleReactivation(ClusterState cluster, DestinationInfo destination, DestinationHealth newHealth, TimeSpan reactivationPeriod)
+        private void ScheduleReactivation(ClusterState cluster, DestinationState destination, DestinationHealth newHealth, TimeSpan reactivationPeriod)
         {
             if (newHealth == DestinationHealth.Unhealthy)
             {
@@ -83,7 +83,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             _scheduler.Dispose();
         }
 
-        private Task Reactivate(ClusterState cluster, DestinationInfo destination)
+        private Task Reactivate(ClusterState cluster, DestinationState destination)
         {
             var healthState = destination.Health;
             if (healthState.Passive == DestinationHealth.Unhealthy)

--- a/src/ReverseProxy/Service/HealthChecks/DestinationProbingResult.cs
+++ b/src/ReverseProxy/Service/HealthChecks/DestinationProbingResult.cs
@@ -12,7 +12,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
     /// </summary>
     public readonly struct DestinationProbingResult
     {
-        public DestinationProbingResult(DestinationInfo destination, HttpResponseMessage response, Exception exception)
+        public DestinationProbingResult(DestinationState destination, HttpResponseMessage response, Exception exception)
         {
             Destination = destination;
             Response = response;
@@ -22,7 +22,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         /// <summary>
         /// Probed destination.
         /// </summary>
-        public DestinationInfo Destination { get; }
+        public DestinationState Destination { get; }
 
         /// <summary>
         /// Response recieved.

--- a/src/ReverseProxy/Service/HealthChecks/IDestinationHealthUpdater.cs
+++ b/src/ReverseProxy/Service/HealthChecks/IDestinationHealthUpdater.cs
@@ -22,7 +22,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         /// <param name="reactivationPeriod">If <paramref name="newHealth"/> is <see cref="DestinationHealth.Unhealthy"/>,
         /// this parameter specifies a reactivation period after which the destination's <see cref="DestinationHealthState.Passive"/> value
         /// will be reset to <see cref="DestinationHealth.Unknown"/>. Otherwise, it's not used.</param>
-        void SetPassive(ClusterState cluster, DestinationInfo destination, DestinationHealth newHealth, TimeSpan reactivationPeriod);
+        void SetPassive(ClusterState cluster, DestinationState destination, DestinationHealth newHealth, TimeSpan reactivationPeriod);
 
         /// <summary>
         /// Sets the active health values on the given destinations.

--- a/src/ReverseProxy/Service/HealthChecks/IPassiveHealthCheckPolicy.cs
+++ b/src/ReverseProxy/Service/HealthChecks/IPassiveHealthCheckPolicy.cs
@@ -23,6 +23,6 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         /// <param name="cluster">Request's cluster.</param>
         /// <param name="destination">Request's destination.</param>
         /// <param name="context">Context.</param>
-        void RequestProxied(ClusterState cluster, DestinationInfo destination, HttpContext context);
+        void RequestProxied(ClusterState cluster, DestinationState destination, HttpContext context);
     }
 }

--- a/src/ReverseProxy/Service/HealthChecks/IProbingRequestFactory.cs
+++ b/src/ReverseProxy/Service/HealthChecks/IProbingRequestFactory.cs
@@ -17,6 +17,6 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         /// <param name="cluster">The cluster being probed.</param>
         /// <param name="destination">The destination being probed.</param>
         /// <returns>Probing <see cref="HttpRequestMessage"/>.</returns>
-        HttpRequestMessage CreateRequest(ClusterModel cluster, DestinationConfig destination);
+        HttpRequestMessage CreateRequest(ClusterModel cluster, DestinationModel destination);
     }
 }

--- a/src/ReverseProxy/Service/HealthChecks/NewActiveDestinationHealth.cs
+++ b/src/ReverseProxy/Service/HealthChecks/NewActiveDestinationHealth.cs
@@ -10,13 +10,13 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
     /// </summary>
     public readonly struct NewActiveDestinationHealth
     {
-        public NewActiveDestinationHealth(DestinationInfo destination, DestinationHealth newActiveHealth)
+        public NewActiveDestinationHealth(DestinationState destination, DestinationHealth newActiveHealth)
         {
             Destination = destination;
             NewActiveHealth = newActiveHealth;
         }
 
-        public DestinationInfo Destination { get; }
+        public DestinationState Destination { get; }
 
         public DestinationHealth NewActiveHealth { get; }
     }

--- a/src/ReverseProxy/Service/HealthChecks/TransportFailureRateHealthPolicy.cs
+++ b/src/ReverseProxy/Service/HealthChecks/TransportFailureRateHealthPolicy.cs
@@ -31,7 +31,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         private readonly TransportFailureRateHealthPolicyOptions _policyOptions;
         private readonly IClock _clock;
         private readonly ConditionalWeakTable<ClusterState, ParsedMetadataEntry<double>> _clusterFailureRateLimits = new ConditionalWeakTable<ClusterState, ParsedMetadataEntry<double>>();
-        private readonly ConditionalWeakTable<DestinationInfo, ProxiedRequestHistory> _requestHistories = new ConditionalWeakTable<DestinationInfo, ProxiedRequestHistory>();
+        private readonly ConditionalWeakTable<DestinationState, ProxiedRequestHistory> _requestHistories = new ConditionalWeakTable<DestinationState, ProxiedRequestHistory>();
 
         public string Name => HealthCheckConstants.PassivePolicy.TransportFailureRate;
 
@@ -45,7 +45,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             _healthUpdater = healthUpdater ?? throw new ArgumentNullException(nameof(healthUpdater));
         }
 
-        public void RequestProxied(ClusterState cluster, DestinationInfo destination, HttpContext context)
+        public void RequestProxied(ClusterState cluster, DestinationState destination, HttpContext context)
         {
             var error = context.Features.Get<IProxyErrorFeature>();
             var newHealth = EvaluateProxiedRequest(cluster, destination, error != null);
@@ -53,7 +53,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             _healthUpdater.SetPassive(cluster, destination, newHealth, reactivationPeriod);
         }
 
-        private DestinationHealth EvaluateProxiedRequest(ClusterState cluster, DestinationInfo destination, bool failed)
+        private DestinationHealth EvaluateProxiedRequest(ClusterState cluster, DestinationState destination, bool failed)
         {
             var history = _requestHistories.GetOrCreateValue(destination);
             var rateLimitEntry = _clusterFailureRateLimits.GetValue(cluster, c => new ParsedMetadataEntry<double>(TryParse, c, TransportFailureRateHealthPolicyOptions.FailureRateLimitMetadataName));

--- a/src/ReverseProxy/Service/LoadBalancing/FirstLoadBalancingPolicy.cs
+++ b/src/ReverseProxy/Service/LoadBalancing/FirstLoadBalancingPolicy.cs
@@ -12,7 +12,7 @@ namespace Yarp.ReverseProxy.Service.LoadBalancing
     {
         public string Name => LoadBalancingPolicies.First;
 
-        public DestinationInfo PickDestination(HttpContext context, IReadOnlyList<DestinationInfo> availableDestinations)
+        public DestinationState PickDestination(HttpContext context, IReadOnlyList<DestinationState> availableDestinations)
         {
             if (availableDestinations.Count == 0)
             {

--- a/src/ReverseProxy/Service/LoadBalancing/ILoadBalancingPolicy.cs
+++ b/src/ReverseProxy/Service/LoadBalancing/ILoadBalancingPolicy.cs
@@ -22,8 +22,8 @@ namespace Yarp.ReverseProxy.Service.LoadBalancing
         /// Picks a destination to send traffic to.
         /// </summary>
         // TODO: How to ensure retries pick a different destination when available?
-        DestinationInfo PickDestination(
+        DestinationState PickDestination(
             HttpContext context,
-            IReadOnlyList<DestinationInfo> availableDestinations);
+            IReadOnlyList<DestinationState> availableDestinations);
     }
 }

--- a/src/ReverseProxy/Service/LoadBalancing/LeastRequestsLoadBalancingPolicy.cs
+++ b/src/ReverseProxy/Service/LoadBalancing/LeastRequestsLoadBalancingPolicy.cs
@@ -12,7 +12,7 @@ namespace Yarp.ReverseProxy.Service.LoadBalancing
     {
         public string Name => LoadBalancingPolicies.LeastRequests;
 
-        public DestinationInfo PickDestination(HttpContext context, IReadOnlyList<DestinationInfo> availableDestinations)
+        public DestinationState PickDestination(HttpContext context, IReadOnlyList<DestinationState> availableDestinations)
         {
             if (availableDestinations.Count == 0)
             {

--- a/src/ReverseProxy/Service/LoadBalancing/PowerOfTwoChoicesLoadBalancingPolicy.cs
+++ b/src/ReverseProxy/Service/LoadBalancing/PowerOfTwoChoicesLoadBalancingPolicy.cs
@@ -20,7 +20,7 @@ namespace Yarp.ReverseProxy.Service.LoadBalancing
 
         public string Name => LoadBalancingPolicies.PowerOfTwoChoices;
 
-        public DestinationInfo PickDestination(HttpContext context, IReadOnlyList<DestinationInfo> availableDestinations)
+        public DestinationState PickDestination(HttpContext context, IReadOnlyList<DestinationState> availableDestinations)
         {
             if (availableDestinations.Count == 0)
             {

--- a/src/ReverseProxy/Service/LoadBalancing/RandomLoadBalancingPolicy.cs
+++ b/src/ReverseProxy/Service/LoadBalancing/RandomLoadBalancingPolicy.cs
@@ -20,7 +20,7 @@ namespace Yarp.ReverseProxy.Service.LoadBalancing
 
         public string Name => LoadBalancingPolicies.Random;
 
-        public DestinationInfo PickDestination(HttpContext context, IReadOnlyList<DestinationInfo> availableDestinations)
+        public DestinationState PickDestination(HttpContext context, IReadOnlyList<DestinationState> availableDestinations)
         {
             if (availableDestinations.Count == 0)
             {

--- a/src/ReverseProxy/Service/LoadBalancing/RoundRobinLoadBalancingPolicy.cs
+++ b/src/ReverseProxy/Service/LoadBalancing/RoundRobinLoadBalancingPolicy.cs
@@ -17,7 +17,7 @@ namespace Yarp.ReverseProxy.Service.LoadBalancing
 
         public string Name => LoadBalancingPolicies.RoundRobin;
 
-        public DestinationInfo PickDestination(HttpContext context, IReadOnlyList<DestinationInfo> availableDestinations)
+        public DestinationState PickDestination(HttpContext context, IReadOnlyList<DestinationState> availableDestinations)
         {
             if (availableDestinations.Count == 0)
             {

--- a/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
@@ -426,7 +426,7 @@ namespace Yarp.ReverseProxy.Service.Management
             }
         }
 
-        private bool UpdateRuntimeDestinations(IReadOnlyDictionary<string, Destination> incomingDestinations, ConcurrentDictionary<string, DestinationState> currentDestinations)
+        private bool UpdateRuntimeDestinations(IReadOnlyDictionary<string, DestinationConfig> incomingDestinations, ConcurrentDictionary<string, DestinationState> currentDestinations)
         {
             var desiredDestinations = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var changed = false;

--- a/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
@@ -426,7 +426,7 @@ namespace Yarp.ReverseProxy.Service.Management
             }
         }
 
-        private bool UpdateRuntimeDestinations(IReadOnlyDictionary<string, Destination> incomingDestinations, ConcurrentDictionary<string, DestinationInfo> currentDestinations)
+        private bool UpdateRuntimeDestinations(IReadOnlyDictionary<string, Destination> incomingDestinations, ConcurrentDictionary<string, DestinationState> currentDestinations)
         {
             var desiredDestinations = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var changed = false;
@@ -447,7 +447,7 @@ namespace Yarp.ReverseProxy.Service.Management
                 else
                 {
                     Log.DestinationAdded(_logger, incomingDestination.Key);
-                    var newDestination = new DestinationInfo(incomingDestination.Key)
+                    var newDestination = new DestinationState(incomingDestination.Key)
                     {
                         Config = new DestinationConfig(incomingDestination.Value),
                     };

--- a/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Service/Management/ProxyConfigManager.cs
@@ -437,10 +437,10 @@ namespace Yarp.ReverseProxy.Service.Management
 
                 if (currentDestinations.TryGetValue(incomingDestination.Key, out var currentDestination))
                 {
-                    if (currentDestination.Config.HasChanged(incomingDestination.Value))
+                    if (currentDestination.Model.HasChanged(incomingDestination.Value))
                     {
                         Log.DestinationChanged(_logger, incomingDestination.Key);
-                        currentDestination.Config = new DestinationConfig(incomingDestination.Value);
+                        currentDestination.Model = new DestinationModel(incomingDestination.Value);
                         changed = true;
                     }
                 }
@@ -449,7 +449,7 @@ namespace Yarp.ReverseProxy.Service.Management
                     Log.DestinationAdded(_logger, incomingDestination.Key);
                     var newDestination = new DestinationState(incomingDestination.Key)
                     {
-                        Config = new DestinationConfig(incomingDestination.Value),
+                        Model = new DestinationModel(incomingDestination.Value),
                     };
                     var added = currentDestinations.TryAdd(newDestination.DestinationId, newDestination);
                     Debug.Assert(added);

--- a/src/ReverseProxy/Service/RuntimeModel/ClusterDynamicState.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/ClusterDynamicState.cs
@@ -9,15 +9,15 @@ namespace Yarp.ReverseProxy.RuntimeModel
     public sealed class ClusterDynamicState
     {
         public ClusterDynamicState(
-            IReadOnlyList<DestinationInfo> allDestinations,
-            IReadOnlyList<DestinationInfo> healthyDestinations)
+            IReadOnlyList<DestinationState> allDestinations,
+            IReadOnlyList<DestinationState> healthyDestinations)
         {
             AllDestinations = allDestinations ?? throw new ArgumentNullException(nameof(allDestinations));
             HealthyDestinations = healthyDestinations ?? throw new ArgumentNullException(nameof(healthyDestinations));
         }
 
-        public IReadOnlyList<DestinationInfo> AllDestinations { get; }
+        public IReadOnlyList<DestinationState> AllDestinations { get; }
 
-        public IReadOnlyList<DestinationInfo> HealthyDestinations { get; }
+        public IReadOnlyList<DestinationState> HealthyDestinations { get; }
     }
 }

--- a/src/ReverseProxy/Service/RuntimeModel/ClusterState.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/ClusterState.cs
@@ -16,8 +16,8 @@ namespace Yarp.ReverseProxy.RuntimeModel
     public sealed class ClusterState
     {
         private readonly object _stateLock = new object();
-        private volatile ClusterDynamicState _dynamicState = new ClusterDynamicState(Array.Empty<DestinationInfo>(), Array.Empty<DestinationInfo>());
-        private volatile IReadOnlyList<DestinationInfo> _destinationsSnapshot;
+        private volatile ClusterDynamicState _dynamicState = new ClusterDynamicState(Array.Empty<DestinationState>(), Array.Empty<DestinationState>());
+        private volatile IReadOnlyList<DestinationState> _destinationsSnapshot;
         private volatile ClusterModel _model;
         private readonly SemaphoreSlim _updateRequests = new SemaphoreSlim(2);
 
@@ -49,7 +49,7 @@ namespace Yarp.ReverseProxy.RuntimeModel
         /// and should only be directly modified in a test environment.
         /// Call <see cref="ProcessDestinationChanges"/> after modifying this collection.
         /// </summary>
-        public ConcurrentDictionary<string, DestinationInfo> Destinations { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public ConcurrentDictionary<string, DestinationState> Destinations { get; } = new(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Encapsulates parts of a cluster that can change atomically
@@ -85,7 +85,7 @@ namespace Yarp.ReverseProxy.RuntimeModel
         {
             // Values already makes a copy of the collection, downcast to avoid making a second copy.
             // https://github.com/dotnet/runtime/blob/e164551f1c96138521b4e58f14f8ac1e4369005d/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs#L2145-L2168
-            _destinationsSnapshot = (IReadOnlyList<DestinationInfo>)Destinations.Values;
+            _destinationsSnapshot = (IReadOnlyList<DestinationState>)Destinations.Values;
             UpdateDynamicStateInternal(force: true);
         }
 

--- a/src/ReverseProxy/Service/RuntimeModel/DestinationModel.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/DestinationModel.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using Yarp.ReverseProxy.Abstractions;
 
 namespace Yarp.ReverseProxy.RuntimeModel
@@ -14,16 +13,23 @@ namespace Yarp.ReverseProxy.RuntimeModel
     /// </summary>
     /// <remarks>
     /// All members must remain immutable to avoid thread safety issues.
-    /// Instead, instances of <see cref="DestinationConfig"/> are replaced
-    /// in ther entirety when values need to change.
+    /// Instead, instances of <see cref="DestinationModel"/> are replaced
+    /// in their entirety when values need to change.
     /// </remarks>
-    public sealed class DestinationConfig
+    public sealed class DestinationModel
     {
-        public DestinationConfig(Destination destination)
+        /// <summary>
+        /// Creates a new instance. This constructor is for tests and infrastructure, this type is normally constructed by
+        /// the configuration loading infrastructure.
+        /// </summary>
+        public DestinationModel(Destination destination)
         {
             Options = destination ?? throw new ArgumentNullException(nameof(destination));
         }
 
+        /// <summary>
+        /// This destination's configuration.
+        /// </summary>
         public Destination Options { get; }
 
         internal bool HasChanged(Destination destination)

--- a/src/ReverseProxy/Service/RuntimeModel/DestinationModel.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/DestinationModel.cs
@@ -22,19 +22,19 @@ namespace Yarp.ReverseProxy.RuntimeModel
         /// Creates a new instance. This constructor is for tests and infrastructure, this type is normally constructed by
         /// the configuration loading infrastructure.
         /// </summary>
-        public DestinationModel(Destination destination)
+        public DestinationModel(DestinationConfig destination)
         {
-            Options = destination ?? throw new ArgumentNullException(nameof(destination));
+            Config = destination ?? throw new ArgumentNullException(nameof(destination));
         }
 
         /// <summary>
         /// This destination's configuration.
         /// </summary>
-        public Destination Options { get; }
+        public DestinationConfig Config { get; }
 
-        internal bool HasChanged(Destination destination)
+        internal bool HasChanged(DestinationConfig destination)
         {
-            return Options != destination;
+            return Config != destination;
         }
     }
 }

--- a/src/ReverseProxy/Service/RuntimeModel/DestinationState.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/DestinationState.cs
@@ -11,18 +11,15 @@ namespace Yarp.ReverseProxy.RuntimeModel
     /// <summary>
     /// Representation of a cluster's destination for use at runtime.
     /// </summary>
-    /// <remarks>
-    /// Note that while this class is immutable, specific members such as
-    /// <see cref="Config"/> and <see cref="Health"/> hold mutable references
-    /// that can be updated and which will always have latest information
-    /// relevant to this endpoint.
-    /// All members are thread safe.
-    /// </remarks>
-    public sealed class DestinationInfo : IReadOnlyList<DestinationInfo>
+    public sealed class DestinationState : IReadOnlyList<DestinationState>
     {
         private volatile DestinationConfig _config;
 
-        public DestinationInfo(string destinationId)
+        /// <summary>
+        /// Creates a new instance. This constructor is for tests and infrastructure, this type is normally constructed by
+        /// the configuration loading infrastructure.
+        /// </summary>
+        public DestinationState(string destinationId)
         {
             if (string.IsNullOrEmpty(destinationId))
             {
@@ -31,6 +28,9 @@ namespace Yarp.ReverseProxy.RuntimeModel
             DestinationId = destinationId;
         }
 
+        /// <summary>
+        /// The destination's unique id.
+        /// </summary>
         public string DestinationId { get; }
 
         /// <summary>
@@ -59,37 +59,41 @@ namespace Yarp.ReverseProxy.RuntimeModel
 
         internal AtomicCounter ConcurrencyCounter { get; } = new AtomicCounter();
 
-        DestinationInfo IReadOnlyList<DestinationInfo>.this[int index]
+        /// <inheritdoc/>
+        DestinationState IReadOnlyList<DestinationState>.this[int index]
             => index == 0 ? this : throw new IndexOutOfRangeException();
 
-        int IReadOnlyCollection<DestinationInfo>.Count => 1;
+        /// <inheritdoc/>
+        int IReadOnlyCollection<DestinationState>.Count => 1;
 
-        public Enumerator GetEnumerator()
+        private Enumerator GetEnumerator()
         {
             return new Enumerator(this);
         }
 
-        IEnumerator<DestinationInfo> IEnumerable<DestinationInfo>.GetEnumerator()
+        /// <inheritdoc/>
+        IEnumerator<DestinationState> IEnumerable<DestinationState>.GetEnumerator()
         {
             return GetEnumerator();
         }
 
+        /// <inheritdoc/>
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
         }
 
-        public struct Enumerator : IEnumerator<DestinationInfo>
+        private struct Enumerator : IEnumerator<DestinationState>
         {
             private bool _read;
 
-            internal Enumerator(DestinationInfo destinationInfo)
+            internal Enumerator(DestinationState destinationInfo)
             {
                 Current = destinationInfo;
                 _read = false;
             }
 
-            public DestinationInfo Current { get; }
+            public DestinationState Current { get; }
 
             object IEnumerator.Current => Current;
 

--- a/src/ReverseProxy/Service/RuntimeModel/DestinationState.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/DestinationState.cs
@@ -13,7 +13,7 @@ namespace Yarp.ReverseProxy.RuntimeModel
     /// </summary>
     public sealed class DestinationState : IReadOnlyList<DestinationState>
     {
-        private volatile DestinationConfig _config;
+        private volatile DestinationModel _model;
 
         /// <summary>
         /// Creates a new instance. This constructor is for tests and infrastructure, this type is normally constructed by
@@ -36,10 +36,10 @@ namespace Yarp.ReverseProxy.RuntimeModel
         /// <summary>
         /// A snapshot of the current configuration
         /// </summary>
-        public DestinationConfig Config
+        public DestinationModel Model
         {
-            get => _config;
-            internal set => _config = value ?? throw new ArgumentNullException(nameof(value));
+            get => _model;
+            internal set => _model = value ?? throw new ArgumentNullException(nameof(value));
         }
 
         /// <summary>

--- a/src/ReverseProxy/Service/RuntimeModel/DestinationState.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/DestinationState.cs
@@ -87,9 +87,9 @@ namespace Yarp.ReverseProxy.RuntimeModel
         {
             private bool _read;
 
-            internal Enumerator(DestinationState destinationInfo)
+            internal Enumerator(DestinationState instance)
             {
-                Current = destinationInfo;
+                Current = instance;
                 _read = false;
             }
 

--- a/src/ReverseProxy/Service/SessionAffinity/AffinitizeTransform.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/AffinitizeTransform.cs
@@ -11,7 +11,7 @@ using Yarp.ReverseProxy.Service.RuntimeModel.Transforms;
 namespace Yarp.ReverseProxy.Service.SessionAffinity
 {
     /// <summary>
-    /// Affinitizes the request to a chosen <see cref="DestinationInfo"/>.
+    /// Affinitizes the request to a chosen <see cref="DestinationState"/>.
     /// </summary>
     internal sealed class AffinitizeTransform : ResponseTransform
     {

--- a/src/ReverseProxy/Service/SessionAffinity/AffinityResult.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/AffinityResult.cs
@@ -11,11 +11,11 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
     /// </summary>
     public readonly struct AffinityResult
     {
-        public IReadOnlyList<DestinationInfo> Destinations { get; }
+        public IReadOnlyList<DestinationState> Destinations { get; }
 
         public AffinityStatus Status { get; }
 
-        public AffinityResult(IReadOnlyList<DestinationInfo> destinations, AffinityStatus status)
+        public AffinityResult(IReadOnlyList<DestinationState> destinations, AffinityStatus status)
         {
             Destinations = destinations;
             Status = status;

--- a/src/ReverseProxy/Service/SessionAffinity/BaseSessionAffinityProvider.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/BaseSessionAffinityProvider.cs
@@ -26,7 +26,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
 
         public abstract string Mode { get; }
 
-        public virtual void AffinitizeRequest(HttpContext context, SessionAffinityOptions options, DestinationInfo destination)
+        public virtual void AffinitizeRequest(HttpContext context, SessionAffinityOptions options, DestinationState destination)
         {
             if (!options.Enabled.GetValueOrDefault())
             {
@@ -41,7 +41,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
             }
         }
 
-        public virtual AffinityResult FindAffinitizedDestinations(HttpContext context, IReadOnlyList<DestinationInfo> destinations, string clusterId, SessionAffinityOptions options)
+        public virtual AffinityResult FindAffinitizedDestinations(HttpContext context, IReadOnlyList<DestinationState> destinations, string clusterId, SessionAffinityOptions options)
         {
             if (!options.Enabled.GetValueOrDefault())
             {
@@ -55,7 +55,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
                 return new AffinityResult(null, requestAffinityKey.ExtractedSuccessfully ? AffinityStatus.AffinityKeyNotSet : AffinityStatus.AffinityKeyExtractionFailed);
             }
 
-            IReadOnlyList<DestinationInfo> matchingDestinations = null;
+            IReadOnlyList<DestinationState> matchingDestinations = null;
             if (destinations.Count > 0)
             {
                 for (var i = 0; i < destinations.Count; i++)
@@ -100,7 +100,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
             return value;
         }
 
-        protected abstract T GetDestinationAffinityKey(DestinationInfo destination);
+        protected abstract T GetDestinationAffinityKey(DestinationState destination);
 
         protected abstract (T Key, bool ExtractedSuccessfully) GetRequestAffinityKey(HttpContext context, SessionAffinityOptions options);
 

--- a/src/ReverseProxy/Service/SessionAffinity/CookieSessionAffinityProvider.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/CookieSessionAffinityProvider.cs
@@ -27,7 +27,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
 
         public override string Mode => SessionAffinityConstants.Modes.Cookie;
 
-        protected override string GetDestinationAffinityKey(DestinationInfo destination)
+        protected override string GetDestinationAffinityKey(DestinationState destination)
         {
             return destination.DestinationId;
         }

--- a/src/ReverseProxy/Service/SessionAffinity/CustomHeaderSessionAffinityProvider.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/CustomHeaderSessionAffinityProvider.cs
@@ -25,7 +25,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
 
         public override string Mode => SessionAffinityConstants.Modes.CustomHeader;
 
-        protected override string GetDestinationAffinityKey(DestinationInfo destination)
+        protected override string GetDestinationAffinityKey(DestinationState destination)
         {
             return destination.DestinationId;
         }

--- a/src/ReverseProxy/Service/SessionAffinity/ISessionAffinityProvider.cs
+++ b/src/ReverseProxy/Service/SessionAffinity/ISessionAffinityProvider.cs
@@ -19,21 +19,21 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
         string Mode { get; }
 
         /// <summary>
-        /// Finds <see cref="DestinationInfo"/> to which the current request is affinitized by the affinity key.
+        /// Finds <see cref="DestinationState"/> to which the current request is affinitized by the affinity key.
         /// </summary>
         /// <param name="context">Current request's context.</param>
-        /// <param name="destinations"><see cref="DestinationInfo"/>s available for the request.</param>
+        /// <param name="destinations"><see cref="DestinationState"/>s available for the request.</param>
         /// <param name="clusterId">Target cluster ID.</param>
         /// <param name="options">Affinity options.</param>
         /// <returns><see cref="AffinityResult"/> carrying the found affinitized destinations if any and the <see cref="AffinityStatus"/>.</returns>
-        AffinityResult FindAffinitizedDestinations(HttpContext context, IReadOnlyList<DestinationInfo> destinations, string clusterId, SessionAffinityOptions options);
+        AffinityResult FindAffinitizedDestinations(HttpContext context, IReadOnlyList<DestinationState> destinations, string clusterId, SessionAffinityOptions options);
 
         /// <summary>
-        /// Affinitize the current request to the given <see cref="DestinationInfo"/> by setting the affinity key extracted from <see cref="DestinationInfo"/>.
+        /// Affinitize the current request to the given <see cref="DestinationState"/> by setting the affinity key extracted from <see cref="DestinationState"/>.
         /// </summary>
         /// <param name="context">Current request's context.</param>
         /// <param name="options">Affinity options.</param>
-        /// <param name="destination"><see cref="DestinationInfo"/> to which request is to be affinitized.</param>
-        void AffinitizeRequest(HttpContext context, SessionAffinityOptions options, DestinationInfo destination);
+        /// <param name="destination"><see cref="DestinationState"/> to which request is to be affinitized.</param>
+        void AffinitizeRequest(HttpContext context, SessionAffinityOptions options, DestinationState destination);
     }
 }

--- a/test/ReverseProxy.FunctionalTests/Common/TestEnvironment.cs
+++ b/test/ReverseProxy.FunctionalTests/Common/TestEnvironment.cs
@@ -96,9 +96,9 @@ namespace Yarp.ReverseProxy.Common
                     var cluster = new ClusterConfig
                     {
                         ClusterId = clusterId,
-                        Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
+                        Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
                         {
-                            { "destination1",  new Destination() { Address = destinationAddress } }
+                            { "destination1",  new DestinationConfig() { Address = destinationAddress } }
                         },
                         HttpClient = new ProxyHttpClientOptions
                         {

--- a/test/ReverseProxy.ServiceFabric.Tests/Helpers/SFTestHelpers.cs
+++ b/test/ReverseProxy.ServiceFabric.Tests/Helpers/SFTestHelpers.cs
@@ -70,12 +70,12 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
         }
 
         /// <summary>
-        /// Build a <see cref="Destination" /> from a Service Fabric <see cref="ReplicaWrapper" />.
+        /// Build a <see cref="DestinationConfig" /> from a Service Fabric <see cref="ReplicaWrapper" />.
         /// </summary>
         /// <remarks>
         /// The address JSON of the replica is expected to have exactly one endpoint, and that one will be used.
         /// </remarks>
-        internal static KeyValuePair<string, Destination> BuildDestinationFromReplica(ReplicaWrapper replica, string healthListenerName = null)
+        internal static KeyValuePair<string, DestinationConfig> BuildDestinationFromReplica(ReplicaWrapper replica, string healthListenerName = null)
         {
             ServiceEndpointCollection.TryParseEndpointsString(replica.ReplicaAddress, out var endpoints);
             endpoints.TryGetFirstEndpointAddress(out var address);
@@ -88,7 +88,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
 
             return KeyValuePair.Create(
                 replica.Id.ToString(),
-                new Destination
+                new DestinationConfig
                 {
                     Address = address,
                     Health = healthAddressUri,

--- a/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/DiscovererTests.cs
+++ b/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/DiscovererTests.cs
@@ -331,7 +331,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
 
             var expectedClusters = new[]
             {
-                LabelsParser.BuildCluster(_testServiceName, labels, new Dictionary<string, Destination>()),
+                LabelsParser.BuildCluster(_testServiceName, labels, new Dictionary<string, DestinationConfig>()),
             };
             var expectedRoutes = LabelsParser.BuildRoutes(_testServiceName, labels);
 
@@ -361,7 +361,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
 
             var expectedClusters = new[]
             {
-                LabelsParser.BuildCluster(_testServiceName, labels, new Dictionary<string, Destination>()),
+                LabelsParser.BuildCluster(_testServiceName, labels, new Dictionary<string, DestinationConfig>()),
             };
             var expectedRoutes = LabelsParser.BuildRoutes(_testServiceName, labels);
 
@@ -393,7 +393,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
 
             var expectedClusters = new[]
             {
-                LabelsParser.BuildCluster(_testServiceName, labels, new Dictionary<string, Destination>()),
+                LabelsParser.BuildCluster(_testServiceName, labels, new Dictionary<string, DestinationConfig>()),
             };
             var expectedRoutes = LabelsParser.BuildRoutes(_testServiceName, labels);
 
@@ -568,7 +568,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
 
             var expectedClusters = new[]
             {
-                LabelsParser.BuildCluster(_testServiceName, labels, new Dictionary<string, Destination>()),
+                LabelsParser.BuildCluster(_testServiceName, labels, new Dictionary<string, DestinationConfig>()),
             };
 
             clusters.Should().BeEquivalentTo(expectedClusters);
@@ -576,9 +576,9 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
         }
 
         private static ClusterConfig ClusterWithDestinations(Uri serviceName, Dictionary<string, string> labels,
-            params KeyValuePair<string, Destination>[] destinations)
+            params KeyValuePair<string, DestinationConfig>[] destinations)
         {
-            var newDestinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase);
+            var newDestinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase);
             foreach (var destination in destinations)
             {
                 newDestinations.Add(destination.Key, destination.Value);

--- a/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/ClusterTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/ClusterTests.cs
@@ -20,11 +20,11 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
             var options1 = new ClusterConfig
             {
                 ClusterId = "cluster1",
-                Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
+                Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
                 {
                     {
                         "destinationA",
-                        new Destination
+                        new DestinationConfig
                         {
                             Address = "https://localhost:10000/destA",
                             Health = "https://localhost:20000/destA",
@@ -33,7 +33,7 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
                     },
                     {
                         "destinationB",
-                        new Destination
+                        new DestinationConfig
                         {
                             Address = "https://localhost:10000/destB",
                             Health = "https://localhost:20000/destB",
@@ -90,11 +90,11 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
             var options2 = new ClusterConfig
             {
                 ClusterId = "cluster1",
-                Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
+                Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
                 {
                     {
                         "destinationA",
-                        new Destination
+                        new DestinationConfig
                         {
                             Address = "https://localhost:10000/destA",
                             Health = "https://localhost:20000/destA",
@@ -103,7 +103,7 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
                     },
                     {
                         "destinationB",
-                        new Destination
+                        new DestinationConfig
                         {
                             Address = "https://localhost:10000/destB",
                             Health = "https://localhost:20000/destB",
@@ -170,11 +170,11 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
             var options1 = new ClusterConfig
             {
                 ClusterId = "cluster1",
-                Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
+                Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
                 {
                     {
                         "destinationA",
-                        new Destination
+                        new DestinationConfig
                         {
                             Address = "https://localhost:10000/destA",
                             Health = "https://localhost:20000/destA",
@@ -183,7 +183,7 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
                     },
                     {
                         "destinationB",
-                        new Destination
+                        new DestinationConfig
                         {
                             Address = "https://localhost:10000/destB",
                             Health = "https://localhost:20000/destB",
@@ -235,7 +235,7 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
             };
 
             Assert.False(options1.Equals(options1 with { ClusterId = "different" }));
-            Assert.False(options1.Equals(options1 with { Destinations = new Dictionary<string, Destination>() }));
+            Assert.False(options1.Equals(options1 with { Destinations = new Dictionary<string, DestinationConfig>() }));
             Assert.False(options1.Equals(options1 with { HealthCheck = new HealthCheckOptions() }));
             Assert.False(options1.Equals(options1 with { LoadBalancingPolicy = "different" }));
             Assert.False(options1.Equals(options1 with

--- a/test/ReverseProxy.Tests/Abstractions/DestinationDiscovery/Contract/DestinationTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/DestinationDiscovery/Contract/DestinationTests.cs
@@ -11,14 +11,14 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
         [Fact]
         public void Equals_Same_Value_Returns_True()
         {
-            var options1 = new Destination
+            var options1 = new DestinationConfig
             {
                 Address = "https://localhost:10000/destA",
                 Health = "https://localhost:20000/destA",
                 Metadata = new Dictionary<string, string> { { "destA-K1", "destA-V1" }, { "destA-K2", "destA-V2" } }
             };
 
-            var options2 = new Destination
+            var options2 = new DestinationConfig
             {
                 Address = "https://localhost:10000/destA",
                 Health = "https://localhost:20000/destA",
@@ -36,7 +36,7 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
         public void Equals_Different_Value_Returns_False()
         {
 
-            var options1 = new Destination
+            var options1 = new DestinationConfig
             {
                 Address = "https://localhost:10000/destA",
                 Health = "https://localhost:20000/destA",
@@ -57,7 +57,7 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
         [Fact]
         public void Equals_Second_Null_Returns_False()
         {
-            var options1 = new Destination();
+            var options1 = new DestinationConfig();
 
             var equals = options1.Equals(null);
 

--- a/test/ReverseProxy.Tests/Configuration/ConfigurationConfigProviderTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigurationConfigProviderTests.cs
@@ -36,11 +36,11 @@ namespace Yarp.ReverseProxy.Configuration
                     new ClusterConfig
                     {
                         ClusterId = "cluster1",
-                        Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
+                        Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
                         {
                             {
                                 "destinationA",
-                                new Destination
+                                new DestinationConfig
                                 {
                                     Address = "https://localhost:10000/destA",
                                     Health = "https://localhost:20000/destA",
@@ -49,7 +49,7 @@ namespace Yarp.ReverseProxy.Configuration
                             },
                             {
                                 "destinationB",
-                                new Destination
+                                new DestinationConfig
                                 {
                                     Address = "https://localhost:10000/destB",
                                     Health = "https://localhost:20000/destB",
@@ -107,10 +107,10 @@ namespace Yarp.ReverseProxy.Configuration
                     new ClusterConfig
                     {
                         ClusterId = "cluster2",
-                        Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
+                        Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
                         {
-                            { "destinationC", new Destination { Address = "https://localhost:10001/destC" } },
-                            { "destinationD", new Destination { Address = "https://localhost:10000/destB" } }
+                            { "destinationC", new DestinationConfig { Address = "https://localhost:10001/destC" } },
+                            { "destinationD", new DestinationConfig { Address = "https://localhost:10000/destB" } }
                         },
                         LoadBalancingPolicy = LoadBalancingPolicies.RoundRobin
                     }

--- a/test/ReverseProxy.Tests/IntegrationTests/RoutingTests.cs
+++ b/test/ReverseProxy.Tests/IntegrationTests/RoutingTests.cs
@@ -327,9 +327,9 @@ namespace Yarp.ReverseProxy.IntegrationTests
                 new ClusterConfig()
                 {
                     ClusterId = "cluster1",
-                    Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
+                    Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
                     {
-                        { "d1", new Destination() { Address = "http://localhost/" }  }
+                        { "d1", new DestinationConfig() { Address = "http://localhost/" }  }
                     }
                 }
             };

--- a/test/ReverseProxy.Tests/Middleware/LoadBalancerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/LoadBalancerMiddlewareTests.cs
@@ -43,8 +43,8 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             const string PolicyName = "NonExistentPolicy";
             var context = CreateContext(PolicyName, new[]
             {
-                new DestinationInfo("destination1"),
-                new DestinationInfo("destination2")
+                new DestinationState("destination1"),
+                new DestinationState("destination2")
             });
 
             var sut = CreateMiddleware(_ => Task.CompletedTask);
@@ -58,7 +58,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
         {
             var context = CreateContext(LoadBalancingPolicies.First, new[]
             {
-                new DestinationInfo("destination1")
+                new DestinationState("destination1")
             });
 
             var sut = CreateMiddleware(_ => Task.CompletedTask);
@@ -79,8 +79,8 @@ namespace Yarp.ReverseProxy.Middleware.Tests
         {
             var context = CreateContext(LoadBalancingPolicies.First, new[]
             {
-                new DestinationInfo("destination1"),
-                new DestinationInfo("destination2")
+                new DestinationState("destination1"),
+                new DestinationState("destination2")
             });
 
             var sut = CreateMiddleware(_ => Task.CompletedTask, new FirstLoadBalancingPolicy());
@@ -99,7 +99,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
         [Fact]
         public async Task Invoke_WithoutDestinations_503()
         {
-            var context = CreateContext(LoadBalancingPolicies.First, Array.Empty<DestinationInfo>());
+            var context = CreateContext(LoadBalancingPolicies.First, Array.Empty<DestinationState>());
 
             var sut = CreateMiddleware(context =>
             {
@@ -124,8 +124,8 @@ namespace Yarp.ReverseProxy.Middleware.Tests
 
             var context = CreateContext(PolicyName, new[]
             {
-                new DestinationInfo("destination1"),
-                new DestinationInfo("destination2")
+                new DestinationState("destination1"),
+                new DestinationState("destination2")
             });
 
             var policy = new Mock<ILoadBalancingPolicy>();
@@ -133,8 +133,8 @@ namespace Yarp.ReverseProxy.Middleware.Tests
                 .Setup(p => p.Name)
                 .Returns(PolicyName);
             policy
-                .Setup(p => p.PickDestination(It.IsAny<HttpContext>(), It.IsAny<IReadOnlyList<DestinationInfo>>()))
-                .Returns((DestinationInfo)null);
+                .Setup(p => p.PickDestination(It.IsAny<HttpContext>(), It.IsAny<IReadOnlyList<DestinationState>>()))
+                .Returns((DestinationState)null);
 
             var sut = CreateMiddleware(context =>
             {
@@ -158,8 +158,8 @@ namespace Yarp.ReverseProxy.Middleware.Tests
         {
             var destinations = new[]
             {
-                new DestinationInfo("destination1"),
-                new DestinationInfo("destination2")
+                new DestinationState("destination1"),
+                new DestinationState("destination2")
             };
             var context = CreateContext(loadBalancingPolicy: null, destinations);
 
@@ -168,8 +168,8 @@ namespace Yarp.ReverseProxy.Middleware.Tests
                 .Setup(p => p.Name)
                 .Returns(LoadBalancingPolicies.PowerOfTwoChoices);
             policy
-                .Setup(p => p.PickDestination(It.IsAny<HttpContext>(), It.IsAny<IReadOnlyList<DestinationInfo>>()))
-                .Returns(destinations[0]);
+                .Setup(p => p.PickDestination(It.IsAny<HttpContext>(), It.IsAny<IReadOnlyList<DestinationState>>()))
+                .Returns((DestinationState)destinations[0]);
 
             var sut = CreateMiddleware(_ => Task.CompletedTask, policy.Object);
 
@@ -178,7 +178,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             policy.Verify(p => p.PickDestination(context, destinations), Times.Once);
         }
 
-        private static HttpContext CreateContext(string loadBalancingPolicy, IReadOnlyList<DestinationInfo> destinations)
+        private static HttpContext CreateContext(string loadBalancingPolicy, IReadOnlyList<DestinationState> destinations)
         {
             var cluster = new ClusterState("cluster1")
             {

--- a/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/PassiveHealthCheckMiddlewareTests.cs
@@ -109,7 +109,7 @@ namespace Yarp.ReverseProxy.Middleware
             return policy;
         }
 
-        private IReverseProxyFeature GetProxyFeature(ClusterState clusterState, DestinationInfo destination)
+        private IReverseProxyFeature GetProxyFeature(ClusterState clusterState, DestinationState destination)
         {
             return new ReverseProxyFeature()
             {
@@ -137,8 +137,8 @@ namespace Yarp.ReverseProxy.Middleware
                 null);
             var clusterState = new ClusterState(id);
             clusterState.Model = clusterModel;
-            clusterState.Destinations.GetOrAdd("destination0", id => new DestinationInfo(id));
-            clusterState.Destinations.GetOrAdd("destination1", id => new DestinationInfo(id));
+            clusterState.Destinations.GetOrAdd("destination0", id => new DestinationState(id));
+            clusterState.Destinations.GetOrAdd("destination1", id => new DestinationState(id));
 
             clusterState.ProcessDestinationChanges();
 

--- a/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
@@ -55,7 +55,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
                 "destination1",
                 id => new DestinationState(id)
                 {
-                    Config = new DestinationConfig(new Destination { Address = "https://localhost:123/a/b/" })
+                    Model = new DestinationModel(new Destination { Address = "https://localhost:123/a/b/" })
                 });
             var routeConfig = new RouteModel(
                 config: new RouteConfig() { RouteId = "Route-1" },

--- a/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
@@ -53,7 +53,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
                 httpClient);
             var destination1 = cluster1.Destinations.GetOrAdd(
                 "destination1",
-                id => new DestinationInfo(id)
+                id => new DestinationState(id)
                 {
                     Config = new DestinationConfig(new Destination { Address = "https://localhost:123/a/b/" })
                 });
@@ -65,7 +65,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             httpContext.Features.Set<IReverseProxyFeature>(
                 new ReverseProxyFeature()
             {
-                    AvailableDestinations = new List<DestinationInfo>() { destination1 }.AsReadOnly(),
+                    AvailableDestinations = new List<DestinationState>() { destination1 }.AsReadOnly(),
                     Cluster = clusterModel,
                     Route = routeConfig,
                 });
@@ -144,7 +144,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             httpContext.Features.Set<IReverseProxyFeature>(
                 new ReverseProxyFeature()
                 {
-                    AvailableDestinations = Array.Empty<DestinationInfo>(),
+                    AvailableDestinations = Array.Empty<DestinationState>(),
                     Cluster = clusterModel,
                     Route = routeConfig,
                 });

--- a/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyInvokerMiddlewareTests.cs
@@ -55,7 +55,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
                 "destination1",
                 id => new DestinationState(id)
                 {
-                    Model = new DestinationModel(new Destination { Address = "https://localhost:123/a/b/" })
+                    Model = new DestinationModel(new DestinationConfig { Address = "https://localhost:123/a/b/" })
                 });
             var routeConfig = new RouteModel(
                 config: new RouteConfig() { RouteId = "Route-1" },

--- a/test/ReverseProxy.Tests/Middleware/ProxyPipelineInitializerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyPipelineInitializerMiddlewareTests.cs
@@ -42,7 +42,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             cluster1.Model = new ClusterModel(new ClusterConfig(), httpClient);
             var destination1 = cluster1.Destinations.GetOrAdd(
                 "destination1",
-                id => new DestinationState(id) { Model = new DestinationModel(new Destination { Address = "https://localhost:123/a/b/" }) });
+                id => new DestinationState(id) { Model = new DestinationModel(new DestinationConfig { Address = "https://localhost:123/a/b/" }) });
             cluster1.ProcessDestinationChanges();
 
             var aspNetCoreEndpoints = new List<Endpoint>();
@@ -93,7 +93,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
                 "destination1",
                 id => new DestinationState(id)
                 {
-                    Model = new DestinationModel(new Destination { Address = "https://localhost:123/a/b/" }),
+                    Model = new DestinationModel(new DestinationConfig { Address = "https://localhost:123/a/b/" }),
                     Health = { Active = DestinationHealth.Unhealthy },
                 });
             cluster1.ProcessDestinationChanges();

--- a/test/ReverseProxy.Tests/Middleware/ProxyPipelineInitializerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyPipelineInitializerMiddlewareTests.cs
@@ -42,7 +42,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             cluster1.Model = new ClusterModel(new ClusterConfig(), httpClient);
             var destination1 = cluster1.Destinations.GetOrAdd(
                 "destination1",
-                id => new DestinationInfo(id) { Config = new DestinationConfig(new Destination { Address = "https://localhost:123/a/b/" }) });
+                id => new DestinationState(id) { Config = new DestinationConfig(new Destination { Address = "https://localhost:123/a/b/" }) });
             cluster1.ProcessDestinationChanges();
 
             var aspNetCoreEndpoints = new List<Endpoint>();
@@ -91,7 +91,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
                 httpClient);
             var destination1 = cluster1.Destinations.GetOrAdd(
                 "destination1",
-                id => new DestinationInfo(id)
+                id => new DestinationState(id)
                 {
                     Config = new DestinationConfig(new Destination { Address = "https://localhost:123/a/b/" }),
                     Health = { Active = DestinationHealth.Unhealthy },

--- a/test/ReverseProxy.Tests/Middleware/ProxyPipelineInitializerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/ProxyPipelineInitializerMiddlewareTests.cs
@@ -42,7 +42,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
             cluster1.Model = new ClusterModel(new ClusterConfig(), httpClient);
             var destination1 = cluster1.Destinations.GetOrAdd(
                 "destination1",
-                id => new DestinationState(id) { Config = new DestinationConfig(new Destination { Address = "https://localhost:123/a/b/" }) });
+                id => new DestinationState(id) { Model = new DestinationModel(new Destination { Address = "https://localhost:123/a/b/" }) });
             cluster1.ProcessDestinationChanges();
 
             var aspNetCoreEndpoints = new List<Endpoint>();
@@ -93,7 +93,7 @@ namespace Yarp.ReverseProxy.Middleware.Tests
                 "destination1",
                 id => new DestinationState(id)
                 {
-                    Config = new DestinationConfig(new Destination { Address = "https://localhost:123/a/b/" }),
+                    Model = new DestinationModel(new Destination { Address = "https://localhost:123/a/b/" }),
                     Health = { Active = DestinationHealth.Unhealthy },
                 });
             cluster1.ProcessDestinationChanges();

--- a/test/ReverseProxy.Tests/Middleware/SessionAffinityMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Middleware/SessionAffinityMiddlewareTests.cs
@@ -39,7 +39,7 @@ namespace Yarp.ReverseProxy.Middleware
         {
             var cluster = GetCluster();
             var endpoint = GetEndpoint(cluster);
-            DestinationInfo foundDestination = null;
+            DestinationState foundDestination = null;
             if (foundDestinationId != null)
             {
                 cluster.Destinations.TryGetValue(foundDestinationId, out foundDestination);
@@ -50,7 +50,7 @@ namespace Yarp.ReverseProxy.Middleware
                 true,
                 cluster.Destinations.Values.ToList(),
                 cluster.ClusterId,
-                ("Mode-A", AffinityStatus.DestinationNotFound, (DestinationInfo)null, (Action<ISessionAffinityProvider>)(p => throw new InvalidOperationException($"Provider {p.Mode} call is not expected."))),
+                ("Mode-A", AffinityStatus.DestinationNotFound, (DestinationState)null, (Action<ISessionAffinityProvider>)(p => throw new InvalidOperationException($"Provider {p.Mode} call is not expected."))),
                 (expectedMode, status, foundDestination, p => invokedMode = p.Mode));
             var nextInvoked = false;
             var middleware = new SessionAffinityMiddleware(c => {
@@ -132,9 +132,9 @@ namespace Yarp.ReverseProxy.Middleware
         {
             var cluster = new ClusterState("cluster-1");
             var destinationManager = cluster.Destinations;
-            destinationManager.GetOrAdd("dest-A", id => new DestinationInfo(id));
-            destinationManager.GetOrAdd(AffinitizedDestinationName, id => new DestinationInfo(id));
-            destinationManager.GetOrAdd("dest-C", id => new DestinationInfo(id));
+            destinationManager.GetOrAdd("dest-A", id => new DestinationState(id));
+            destinationManager.GetOrAdd(AffinitizedDestinationName, id => new DestinationState(id));
+            destinationManager.GetOrAdd("dest-C", id => new DestinationState(id));
             cluster.Model = ClusterConfig;
             cluster.ProcessDestinationChanges();
             return cluster;
@@ -142,9 +142,9 @@ namespace Yarp.ReverseProxy.Middleware
 
         internal IReadOnlyList<Mock<ISessionAffinityProvider>> RegisterAffinityProviders(
             bool lookupMiddlewareTest,
-            IReadOnlyList<DestinationInfo> expectedDestinations,
+            IReadOnlyList<DestinationState> expectedDestinations,
             string expectedCluster,
-            params (string Mode, AffinityStatus? Status, DestinationInfo Destinations, Action<ISessionAffinityProvider> Callback)[] prototypes)
+            params (string Mode, AffinityStatus? Status, DestinationState Destinations, Action<ISessionAffinityProvider> Callback)[] prototypes)
         {
             var result = new List<Mock<ISessionAffinityProvider>>();
             foreach (var (mode, status, destinations, callback) in prototypes)
@@ -189,7 +189,7 @@ namespace Yarp.ReverseProxy.Middleware
             return result.AsReadOnly();
         }
 
-        internal IReverseProxyFeature GetDestinationsFeature(IReadOnlyList<DestinationInfo> destinations, ClusterModel clusterModel)
+        internal IReverseProxyFeature GetDestinationsFeature(IReadOnlyList<DestinationState> destinations, ClusterModel clusterModel)
         {
             return new ReverseProxyFeature()
             {

--- a/test/ReverseProxy.Tests/Service/HealthChecks/ActiveHealthCheckMonitorTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/ActiveHealthCheckMonitorTests.cs
@@ -208,7 +208,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             foreach (var destination in cluster2.Destinations.Values)
             {
                 var d = cluster2.Destinations.GetOrAdd(destination.DestinationId, id => new DestinationState(id));
-                d.Config = new DestinationConfig(new Destination { Address = destination.Config.Options.Address });
+                d.Model = new DestinationModel(new Destination { Address = destination.Model.Options.Address });
             }
 
             monitor.OnClusterChanged(cluster2);
@@ -642,11 +642,11 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             clusterState.Model = clusterModel;
             for (var i = 0; i < destinationCount; i++)
             {
-                var destinationConfig = new DestinationConfig(new Destination { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });
+                var destinationModel = new DestinationModel(new Destination { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });
                 var destinationId = $"destination{i}";
                 clusterState.Destinations.GetOrAdd(destinationId, id => new DestinationState(id)
                 {
-                    Config = destinationConfig
+                    Model = destinationModel
                 });
             }
             clusterState.ProcessDestinationChanges();

--- a/test/ReverseProxy.Tests/Service/HealthChecks/ActiveHealthCheckMonitorTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/ActiveHealthCheckMonitorTests.cs
@@ -207,7 +207,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 
             foreach (var destination in cluster2.Destinations.Values)
             {
-                var d = cluster2.Destinations.GetOrAdd(destination.DestinationId, id => new DestinationInfo(id));
+                var d = cluster2.Destinations.GetOrAdd(destination.DestinationId, id => new DestinationState(id));
                 d.Config = new DestinationConfig(new Destination { Address = destination.Config.Options.Address });
             }
 
@@ -644,7 +644,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             {
                 var destinationConfig = new DestinationConfig(new Destination { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });
                 var destinationId = $"destination{i}";
-                clusterState.Destinations.GetOrAdd(destinationId, id => new DestinationInfo(id)
+                clusterState.Destinations.GetOrAdd(destinationId, id => new DestinationState(id)
                 {
                     Config = destinationConfig
                 });

--- a/test/ReverseProxy.Tests/Service/HealthChecks/ActiveHealthCheckMonitorTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/ActiveHealthCheckMonitorTests.cs
@@ -208,7 +208,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             foreach (var destination in cluster2.Destinations.Values)
             {
                 var d = cluster2.Destinations.GetOrAdd(destination.DestinationId, id => new DestinationState(id));
-                d.Model = new DestinationModel(new Destination { Address = destination.Model.Options.Address });
+                d.Model = new DestinationModel(new DestinationConfig { Address = destination.Model.Config.Address });
             }
 
             monitor.OnClusterChanged(cluster2);
@@ -642,7 +642,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             clusterState.Model = clusterModel;
             for (var i = 0; i < destinationCount; i++)
             {
-                var destinationModel = new DestinationModel(new Destination { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });
+                var destinationModel = new DestinationModel(new DestinationConfig { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });
                 var destinationId = $"destination{i}";
                 clusterState.Destinations.GetOrAdd(destinationId, id => new DestinationState(id)
                 {

--- a/test/ReverseProxy.Tests/Service/HealthChecks/ConsecutiveFailuresHealthPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/ConsecutiveFailuresHealthPolicyTests.cs
@@ -145,7 +145,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             {
                 var destinationConfig = new DestinationConfig(new Destination { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });
                 var destinationId = $"destination{i}";
-                clusterState.Destinations.GetOrAdd(destinationId, id => new DestinationInfo(id)
+                clusterState.Destinations.GetOrAdd(destinationId, id => new DestinationState(id)
                 {
                     Config = destinationConfig
                 });
@@ -168,7 +168,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                 cluster.UpdateDynamicState();
             }
 
-            public void SetPassive(ClusterState cluster, DestinationInfo destination, DestinationHealth newHealth, TimeSpan reactivationPeriod)
+            public void SetPassive(ClusterState cluster, DestinationState destination, DestinationHealth newHealth, TimeSpan reactivationPeriod)
             {
                 throw new NotImplementedException();
             }

--- a/test/ReverseProxy.Tests/Service/HealthChecks/ConsecutiveFailuresHealthPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/ConsecutiveFailuresHealthPolicyTests.cs
@@ -143,7 +143,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             clusterState.Model = clusterModel;
             for (var i = 0; i < destinationCount; i++)
             {
-                var destinationModel = new DestinationModel(new Destination { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });
+                var destinationModel = new DestinationModel(new DestinationConfig { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });
                 var destinationId = $"destination{i}";
                 clusterState.Destinations.GetOrAdd(destinationId, id => new DestinationState(id)
                 {

--- a/test/ReverseProxy.Tests/Service/HealthChecks/ConsecutiveFailuresHealthPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/ConsecutiveFailuresHealthPolicyTests.cs
@@ -143,11 +143,11 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             clusterState.Model = clusterModel;
             for (var i = 0; i < destinationCount; i++)
             {
-                var destinationConfig = new DestinationConfig(new Destination { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });
+                var destinationModel = new DestinationModel(new Destination { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });
                 var destinationId = $"destination{i}";
                 clusterState.Destinations.GetOrAdd(destinationId, id => new DestinationState(id)
                 {
-                    Config = destinationConfig
+                    Model = destinationModel
                 });
             }
 

--- a/test/ReverseProxy.Tests/Service/HealthChecks/DefaultProbingRequestFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/DefaultProbingRequestFactoryTests.cs
@@ -29,10 +29,10 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                     Policy = "policy",
                     Path = healthPath,
                 }, HttpVersion.Version20);
-            var destinationConfig = new DestinationConfig(new Destination { Address = address, Health = health });
+            var destinationModel = new DestinationModel(new Destination { Address = address, Health = health });
             var factory = new DefaultProbingRequestFactory();
 
-            var request = factory.CreateRequest(clusterModel, destinationConfig);
+            var request = factory.CreateRequest(clusterModel, destinationModel);
 
             Assert.Equal(expectedRequestUri, request.RequestUri.AbsoluteUri);
         }
@@ -54,10 +54,10 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                 , HttpVersionPolicy.RequestVersionExact
 #endif
                 );
-            var destinationConfig = new DestinationConfig(new Destination { Address = "https://localhost:10000/" });
+            var destinationModel = new DestinationModel(new Destination { Address = "https://localhost:10000/" });
             var factory = new DefaultProbingRequestFactory();
 
-            var request = factory.CreateRequest(clusterModel, destinationConfig);
+            var request = factory.CreateRequest(clusterModel, destinationModel);
 
             Assert.Equal(version ?? HttpVersion.Version20, request.Version);
 #if NET

--- a/test/ReverseProxy.Tests/Service/HealthChecks/DefaultProbingRequestFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/DefaultProbingRequestFactoryTests.cs
@@ -29,7 +29,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                     Policy = "policy",
                     Path = healthPath,
                 }, HttpVersion.Version20);
-            var destinationModel = new DestinationModel(new Destination { Address = address, Health = health });
+            var destinationModel = new DestinationModel(new DestinationConfig { Address = address, Health = health });
             var factory = new DefaultProbingRequestFactory();
 
             var request = factory.CreateRequest(clusterModel, destinationModel);
@@ -54,7 +54,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                 , HttpVersionPolicy.RequestVersionExact
 #endif
                 );
-            var destinationModel = new DestinationModel(new Destination { Address = "https://localhost:10000/" });
+            var destinationModel = new DestinationModel(new DestinationConfig { Address = "https://localhost:10000/" });
             var factory = new DefaultProbingRequestFactory();
 
             var request = factory.CreateRequest(clusterModel, destinationModel);

--- a/test/ReverseProxy.Tests/Service/HealthChecks/DestinationHealthUpdaterTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/DestinationHealthUpdaterTests.cs
@@ -18,7 +18,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         [Fact]
         public async Task SetPassiveAsync_DestinationBecameUnhealthy_SetUnhealthyAndScheduleReactivation()
         {
-            var destination = new DestinationInfo("destination0");
+            var destination = new DestinationState("destination0");
             destination.Health.Active = DestinationHealth.Healthy;
             destination.Health.Passive = DestinationHealth.Healthy;
             var cluster = CreateCluster(passive: true, active: false, destination);
@@ -44,7 +44,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         [Fact]
         public async Task SetPassiveAsync_DestinationBecameHealthy_SetNewState()
         {
-            var destination = new DestinationInfo("destination0");
+            var destination = new DestinationState("destination0");
             destination.Health.Active = DestinationHealth.Healthy;
             destination.Health.Passive = DestinationHealth.Unhealthy;
             var cluster = CreateCluster(passive: true, active: false, destination);
@@ -66,7 +66,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         [InlineData(DestinationHealth.Unknown)]
         public async Task SetPassiveAsync_HealthSateIsNotChanged_DoNothing(DestinationHealth health)
         {
-            var destination = new DestinationInfo("destination0");
+            var destination = new DestinationState("destination0");
             destination.Health.Active = DestinationHealth.Healthy;
             destination.Health.Passive = health;
             var cluster = CreateCluster(passive: true, active: false, destination);
@@ -83,16 +83,16 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
         [Fact]
         public void SetActive_ChangedAndUnchangedHealthStates_SetChangedStates()
         {
-            var destination0 = new DestinationInfo("destination0");
+            var destination0 = new DestinationState("destination0");
             destination0.Health.Active = DestinationHealth.Healthy;
             destination0.Health.Passive = DestinationHealth.Healthy;
-            var destination1 = new DestinationInfo("destination1");
+            var destination1 = new DestinationState("destination1");
             destination1.Health.Active = DestinationHealth.Healthy;
             destination1.Health.Passive = DestinationHealth.Healthy;
-            var destination2 = new DestinationInfo("destination2");
+            var destination2 = new DestinationState("destination2");
             destination2.Health.Active = DestinationHealth.Unhealthy;
             destination2.Health.Passive = DestinationHealth.Healthy;
-            var destination3 = new DestinationInfo("destination3");
+            var destination3 = new DestinationState("destination3");
             destination3.Health.Active = DestinationHealth.Unhealthy;
             destination3.Health.Passive = DestinationHealth.Healthy;
             var cluster = CreateCluster(passive: false, active: true, destination0, destination1, destination2, destination3);
@@ -115,7 +115,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             Assert.Contains(cluster.DynamicState.HealthyDestinations, d => d == destination3);
         }
 
-        private static ClusterState CreateCluster(bool passive, bool active, params DestinationInfo[] destinations)
+        private static ClusterState CreateCluster(bool passive, bool active, params DestinationState[] destinations)
         {
             var cluster = new ClusterState("cluster0");
             cluster.Model = new ClusterModel(

--- a/test/ReverseProxy.Tests/Service/HealthChecks/TransportFailureRateHealthPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/TransportFailureRateHealthPolicyTests.cs
@@ -229,11 +229,11 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             clusterState.Model = clusterModel;
             for (var i = 0; i < destinationCount; i++)
             {
-                var destinationConfig = new DestinationConfig(new Destination { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });
+                var destinationModel = new DestinationModel(new Destination { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });
                 var destinationId = $"destination{i}";
                 clusterState.Destinations.GetOrAdd(destinationId, id => new DestinationState(id)
                 {
-                    Config = destinationConfig
+                    Model = destinationModel
                 });
             }
 

--- a/test/ReverseProxy.Tests/Service/HealthChecks/TransportFailureRateHealthPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/TransportFailureRateHealthPolicyTests.cs
@@ -231,7 +231,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             {
                 var destinationConfig = new DestinationConfig(new Destination { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });
                 var destinationId = $"destination{i}";
-                clusterState.Destinations.GetOrAdd(destinationId, id => new DestinationInfo(id)
+                clusterState.Destinations.GetOrAdd(destinationId, id => new DestinationState(id)
                 {
                     Config = destinationConfig
                 });

--- a/test/ReverseProxy.Tests/Service/HealthChecks/TransportFailureRateHealthPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/TransportFailureRateHealthPolicyTests.cs
@@ -229,7 +229,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             clusterState.Model = clusterModel;
             for (var i = 0; i < destinationCount; i++)
             {
-                var destinationModel = new DestinationModel(new Destination { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });
+                var destinationModel = new DestinationModel(new DestinationConfig { Address = $"https://localhost:1000{i}/{id}/", Health = $"https://localhost:2000{i}/{id}/" });
                 var destinationId = $"destination{i}";
                 clusterState.Destinations.GetOrAdd(destinationId, id => new DestinationState(id)
                 {

--- a/test/ReverseProxy.Tests/Service/Management/ProxyConfigManagerTests.cs
+++ b/test/ReverseProxy.Tests/Service/Management/ProxyConfigManagerTests.cs
@@ -141,8 +141,8 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
             var actualDestinations = clusterState.Destinations.Values;
             var destination = Assert.Single(actualDestinations);
             Assert.Equal("d1", destination.DestinationId);
-            Assert.NotNull(destination.Config);
-            Assert.Equal(TestAddress, destination.Config.Options.Address);
+            Assert.NotNull(destination.Model);
+            Assert.Equal(TestAddress, destination.Model.Options.Address);
         }
 
         [Fact]
@@ -380,7 +380,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
             Assert.True(clusterState.Model.Config.HealthCheck.Enabled);
             Assert.Equal(TimeSpan.FromSeconds(12), clusterState.Model.Config.HealthCheck.Active.Interval);
             var destination = Assert.Single(clusterState.DynamicState.AllDestinations);
-            Assert.Equal("http://localhost", destination.Config.Options.Address);
+            Assert.Equal("http://localhost", destination.Model.Options.Address);
         }
 
         private class ClusterAndRouteThrows : IProxyConfigFilter

--- a/test/ReverseProxy.Tests/Service/Management/ProxyConfigManagerTests.cs
+++ b/test/ReverseProxy.Tests/Service/Management/ProxyConfigManagerTests.cs
@@ -105,9 +105,9 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
             var cluster = new ClusterConfig
             {
                 ClusterId = "cluster1",
-                Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
+                Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "d1", new Destination { Address = TestAddress } }
+                    { "d1", new DestinationConfig { Address = TestAddress } }
                 }
             };
             var route = new RouteConfig
@@ -142,7 +142,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
             var destination = Assert.Single(actualDestinations);
             Assert.Equal("d1", destination.DestinationId);
             Assert.NotNull(destination.Model);
-            Assert.Equal(TestAddress, destination.Model.Options.Address);
+            Assert.Equal(TestAddress, destination.Model.Config.Address);
         }
 
         [Fact]
@@ -154,9 +154,9 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
             var cluster = new ClusterConfig
             {
                 ClusterId = "cluster1",
-                Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
+                Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "d1", new Destination { Address = TestAddress } }
+                    { "d1", new DestinationConfig { Address = TestAddress } }
                 },
                 HttpClient = new ProxyHttpClientOptions
                 {
@@ -255,9 +255,9 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
             var cluster = new ClusterConfig
             {
                 ClusterId = "cluster1",
-                Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
+                Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "d1", new Destination { Address = TestAddress } }
+                    { "d1", new DestinationConfig { Address = TestAddress } }
                 },
                 HttpRequest = new RequestProxyOptions() { Version = new Version(1, 2) }
             };
@@ -360,9 +360,9 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
             var cluster = new ClusterConfig()
             {
                 ClusterId = "cluster1",
-                Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
+                Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "d1", new Destination() { Address = "http://localhost" } }
+                    { "d1", new DestinationConfig() { Address = "http://localhost" } }
                 }
             };
             var services = CreateServices(new List<RouteConfig>() { route }, new List<ClusterConfig>() { cluster }, proxyBuilder =>
@@ -380,7 +380,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
             Assert.True(clusterState.Model.Config.HealthCheck.Enabled);
             Assert.Equal(TimeSpan.FromSeconds(12), clusterState.Model.Config.HealthCheck.Active.Interval);
             var destination = Assert.Single(clusterState.DynamicState.AllDestinations);
-            Assert.Equal("http://localhost", destination.Model.Options.Address);
+            Assert.Equal("http://localhost", destination.Model.Config.Address);
         }
 
         private class ClusterAndRouteThrows : IProxyConfigFilter
@@ -402,9 +402,9 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
             var cluster = new ClusterConfig()
             {
                 ClusterId = "cluster1",
-                Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
+                Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "d1", new Destination() { Address = "http://localhost" } }
+                    { "d1", new DestinationConfig() { Address = "http://localhost" } }
                 }
             };
             var services = CreateServices(new List<RouteConfig>(), new List<ClusterConfig>() { cluster }, proxyBuilder =>

--- a/test/ReverseProxy.Tests/Service/Proxy/LoadBalancingPoliciesTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/LoadBalancingPoliciesTests.cs
@@ -32,9 +32,9 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
         {
             var destinations = new[]
             {
-                new DestinationInfo("d1"),
-                new DestinationInfo("d2"),
-                new DestinationInfo("d3")
+                new DestinationState("d1"),
+                new DestinationState("d2"),
+                new DestinationState("d3")
             };
 
             var context = new DefaultHttpContext();
@@ -53,9 +53,9 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
         {
             var destinations = new[]
             {
-                new DestinationInfo("d1"),
-                new DestinationInfo("d2"),
-                new DestinationInfo("d3")
+                new DestinationState("d1"),
+                new DestinationState("d2"),
+                new DestinationState("d3")
             };
 
             const int Iterations = 10;
@@ -78,9 +78,9 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
         {
             var destinations = new[]
             {
-                new DestinationInfo("d1"),
-                new DestinationInfo("d2"),
-                new DestinationInfo("d3")
+                new DestinationState("d1"),
+                new DestinationState("d2"),
+                new DestinationState("d3")
             };
             destinations[0].ConcurrentRequestCount++;
 
@@ -107,9 +107,9 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
         {
             var destinations = new[]
             {
-                new DestinationInfo("d1"),
-                new DestinationInfo("d2"),
-                new DestinationInfo("d3")
+                new DestinationState("d1"),
+                new DestinationState("d2"),
+                new DestinationState("d3")
             };
             destinations[0].ConcurrentRequestCount++;
 
@@ -129,9 +129,9 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
         {
             var destinations = new[]
             {
-                new DestinationInfo("d1"),
-                new DestinationInfo("d2"),
-                new DestinationInfo("d3")
+                new DestinationState("d1"),
+                new DestinationState("d2"),
+                new DestinationState("d3")
             };
             destinations[0].ConcurrentRequestCount++;
 

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/ClusterInfoTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/ClusterInfoTests.cs
@@ -19,10 +19,10 @@ namespace Yarp.ReverseProxy.RuntimeModel.Tests
         public void DynamicState_WithoutHealthChecks_AssumesAllHealthy()
         {
             var cluster = new ClusterState("abc");
-            var destination1 = cluster.Destinations.GetOrAdd("d1", id => new DestinationInfo(id) { Health = { Active = DestinationHealth.Healthy } });
-            var destination2 = cluster.Destinations.GetOrAdd("d2", id => new DestinationInfo(id) { Health = { Active = DestinationHealth.Unhealthy } });
-            var destination3 = cluster.Destinations.GetOrAdd("d3", id => new DestinationInfo(id)); // Unknown health state
-            var destination4 = cluster.Destinations.GetOrAdd("d4", id => new DestinationInfo(id) { Health = { Passive = DestinationHealth.Healthy } });
+            var destination1 = cluster.Destinations.GetOrAdd("d1", id => new DestinationState(id) { Health = { Active = DestinationHealth.Healthy } });
+            var destination2 = cluster.Destinations.GetOrAdd("d2", id => new DestinationState(id) { Health = { Active = DestinationHealth.Unhealthy } });
+            var destination3 = cluster.Destinations.GetOrAdd("d3", id => new DestinationState(id)); // Unknown health state
+            var destination4 = cluster.Destinations.GetOrAdd("d4", id => new DestinationState(id) { Health = { Passive = DestinationHealth.Healthy } });
             cluster.ProcessDestinationChanges();
 
             var sorted = cluster.DynamicState.AllDestinations.OrderBy(d => d.DestinationId).ToList();
@@ -43,11 +43,11 @@ namespace Yarp.ReverseProxy.RuntimeModel.Tests
         {
             var cluster = new ClusterState("abc");
             EnableHealthChecks(cluster);
-            var destination1 = cluster.Destinations.GetOrAdd("d1", id => new DestinationInfo(id) { Health = { Active = DestinationHealth.Healthy } });
-            var destination2 = cluster.Destinations.GetOrAdd("d2", id => new DestinationInfo(id) { Health = { Active = DestinationHealth.Unhealthy } });
-            var destination3 = cluster.Destinations.GetOrAdd("d3", id => new DestinationInfo(id)); // Unknown health state
-            var destination4 = cluster.Destinations.GetOrAdd("d4", id => new DestinationInfo(id) { Health = { Passive = DestinationHealth.Healthy } });
-            var destination5 = cluster.Destinations.GetOrAdd("d5", id => new DestinationInfo(id) { Health = { Passive = DestinationHealth.Unhealthy } });
+            var destination1 = cluster.Destinations.GetOrAdd("d1", id => new DestinationState(id) { Health = { Active = DestinationHealth.Healthy } });
+            var destination2 = cluster.Destinations.GetOrAdd("d2", id => new DestinationState(id) { Health = { Active = DestinationHealth.Unhealthy } });
+            var destination3 = cluster.Destinations.GetOrAdd("d3", id => new DestinationState(id)); // Unknown health state
+            var destination4 = cluster.Destinations.GetOrAdd("d4", id => new DestinationState(id) { Health = { Passive = DestinationHealth.Healthy } });
+            var destination5 = cluster.Destinations.GetOrAdd("d5", id => new DestinationState(id) { Health = { Passive = DestinationHealth.Unhealthy } });
             cluster.ProcessDestinationChanges();
 
             Assert.Equal(5, cluster.DynamicState.AllDestinations.Count);
@@ -100,7 +100,7 @@ namespace Yarp.ReverseProxy.RuntimeModel.Tests
             Assert.NotNull(state1);
             Assert.Empty(state1.AllDestinations);
 
-            var destination = cluster.Destinations.GetOrAdd("d1", id => new DestinationInfo(id));
+            var destination = cluster.Destinations.GetOrAdd("d1", id => new DestinationState(id));
             cluster.ProcessDestinationChanges();
             Assert.NotSame(state1, cluster.DynamicState);
             var state2 = cluster.DynamicState;
@@ -125,7 +125,7 @@ namespace Yarp.ReverseProxy.RuntimeModel.Tests
             Assert.NotNull(state1);
             Assert.Empty(state1.AllDestinations);
 
-            var destination = cluster.Destinations.GetOrAdd("d1", id => new DestinationInfo(id));
+            var destination = cluster.Destinations.GetOrAdd("d1", id => new DestinationState(id));
             cluster.ProcessDestinationChanges();
             Assert.NotSame(state1, cluster.DynamicState);
             var state2 = cluster.DynamicState;

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/DestinationInfoTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/DestinationInfoTests.cs
@@ -13,8 +13,8 @@ namespace Yarp.ReverseProxy.Service.RuntimeModel
         [Fact]
         public void DestinationInfoEnumerator()
         {
-            var destinationInfo = new DestinationInfo("destionation1");
-            var list = new List<DestinationInfo>();
+            var destinationInfo = new DestinationState("destionation1");
+            var list = new List<DestinationState>();
 
             foreach (var item in destinationInfo)
             {
@@ -28,9 +28,9 @@ namespace Yarp.ReverseProxy.Service.RuntimeModel
         [Fact]
         public void DestionationInfoReadOnlyList()
         {
-            var destinationInfo = new DestinationInfo("destionation2");
+            var destinationInfo = new DestinationState("destionation2");
 
-            IReadOnlyList<DestinationInfo> list = destinationInfo;
+            IReadOnlyList<DestinationState> list = destinationInfo;
 
             Assert.Equal(1, list.Count);
             Assert.Same(destinationInfo, list[0]);

--- a/test/ReverseProxy.Tests/Service/SessionAffinity/AffinitizeTransformTests.cs
+++ b/test/ReverseProxy.Tests/Service/SessionAffinity/AffinitizeTransformTests.cs
@@ -23,7 +23,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
             var cluster = GetCluster();
             var destination = cluster.Destinations.Values.First();
             var provider = new Mock<ISessionAffinityProvider>(MockBehavior.Strict);
-            provider.Setup(p => p.AffinitizeRequest(It.IsAny<HttpContext>(), It.IsNotNull<SessionAffinityOptions>(), It.IsAny<DestinationInfo>()));
+            provider.Setup(p => p.AffinitizeRequest(It.IsAny<HttpContext>(), It.IsNotNull<SessionAffinityOptions>(), It.IsAny<DestinationState>()));
 
             var transform = new AffinitizeTransform(provider.Object);
 
@@ -46,7 +46,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
         internal ClusterState GetCluster()
         {
             var cluster = new ClusterState("cluster-1");
-            cluster.Destinations.GetOrAdd("dest-A", id => new DestinationInfo(id));
+            cluster.Destinations.GetOrAdd("dest-A", id => new DestinationState(id));
             cluster.Model = new ClusterModel(new ClusterConfig
             {
                 SessionAffinity = new SessionAffinityOptions

--- a/test/ReverseProxy.Tests/Service/SessionAffinity/BaseSesstionAffinityProviderTests.cs
+++ b/test/ReverseProxy.Tests/Service/SessionAffinity/BaseSesstionAffinityProviderTests.cs
@@ -32,9 +32,9 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
         [MemberData(nameof(FindAffinitizedDestinationsCases))]
         public void Request_FindAffinitizedDestinations(
             HttpContext context,
-            DestinationInfo[] allDestinations,
+            DestinationState[] allDestinations,
             AffinityStatus expectedStatus,
-            DestinationInfo expectedDestination,
+            DestinationState expectedDestination,
             byte[] expectedEncryptedKey,
             bool unprotectCalled,
             LogLevel? expectedLogLevel,
@@ -81,7 +81,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
                 FailurePolicy = _defaultOptions.FailurePolicy,
                 Settings = _defaultOptions.Settings,
             };
-            Assert.Throws<InvalidOperationException>(() => provider.FindAffinitizedDestinations(new DefaultHttpContext(), new[] { new DestinationInfo("1") }, "cluster-1", options));
+            Assert.Throws<InvalidOperationException>(() => provider.FindAffinitizedDestinations(new DefaultHttpContext(), new[] { new DestinationState("1") }, "cluster-1", options));
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
         {
             var dataProtector = GetDataProtector();
             var provider = new ProviderStub(dataProtector.Object, AffinityTestHelper.GetLogger<BaseSessionAffinityProvider<string>>().Object);
-            Assert.Throws<InvalidOperationException>(() => provider.AffinitizeRequest(new DefaultHttpContext(), new SessionAffinityOptions(), new DestinationInfo("id")));
+            Assert.Throws<InvalidOperationException>(() => provider.AffinitizeRequest(new DefaultHttpContext(), new SessionAffinityOptions(), new DestinationState("id")));
         }
 
         [Fact]
@@ -99,7 +99,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
             var provider = new ProviderStub(dataProtector.Object, AffinityTestHelper.GetLogger<BaseSessionAffinityProvider<string>>().Object);
             var context = new DefaultHttpContext();
             provider.DirectlySetExtractedKeyOnContext(context, "ExtractedKey");
-            provider.AffinitizeRequest(context, _defaultOptions, new DestinationInfo("id"));
+            provider.AffinitizeRequest(context, _defaultOptions, new DestinationState("id"));
             Assert.Null(provider.LastSetEncryptedKey);
             dataProtector.Verify(p => p.Protect(It.IsAny<byte[]>()), Times.Never);
         }
@@ -109,7 +109,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
         {
             var dataProtector = GetDataProtector();
             var provider = new ProviderStub(dataProtector.Object, AffinityTestHelper.GetLogger<BaseSessionAffinityProvider<string>>().Object);
-            var destination = new DestinationInfo("dest-A");
+            var destination = new DestinationState("dest-A");
             provider.AffinitizeRequest(new DefaultHttpContext(), _defaultOptions, destination);
             Assert.Equal("ZGVzdC1B", provider.LastSetEncryptedKey);
             var keyBytes = Encoding.UTF8.GetBytes(destination.DestinationId);
@@ -121,7 +121,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
         {
             var provider = new ProviderStub(GetDataProtector().Object, AffinityTestHelper.GetLogger<BaseSessionAffinityProvider<string>>().Object);
             var options = GetOptionsWithUnknownSetting();
-            Assert.Throws<ArgumentException>(() => provider.FindAffinitizedDestinations(new DefaultHttpContext(), new[] { new DestinationInfo("dest-A") }, "cluster-1", options));
+            Assert.Throws<ArgumentException>(() => provider.FindAffinitizedDestinations(new DefaultHttpContext(), new[] { new DestinationState("dest-A") }, "cluster-1", options));
         }
 
         [Fact]
@@ -129,7 +129,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
         {
             var provider = new ProviderStub(GetDataProtector().Object, AffinityTestHelper.GetLogger<BaseSessionAffinityProvider<string>>().Object);
             var options = GetOptionsWithUnknownSetting();
-            Assert.Throws<ArgumentException>(() => provider.AffinitizeRequest(new DefaultHttpContext(), options, new DestinationInfo("dest-A")));
+            Assert.Throws<ArgumentException>(() => provider.AffinitizeRequest(new DefaultHttpContext(), options, new DestinationState("dest-A")));
         }
 
         [Fact]
@@ -143,11 +143,11 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
 
         public static IEnumerable<object[]> FindAffinitizedDestinationsCases()
         {
-            var destinations = new[] { new DestinationInfo("dest-A"), new DestinationInfo("dest-B"), new DestinationInfo("dest-C") };
+            var destinations = new[] { new DestinationState("dest-A"), new DestinationState("dest-B"), new DestinationState("dest-C") };
             yield return new object[] { GetHttpContext(new[] { ("SomeKey", "SomeValue") }), destinations, AffinityStatus.AffinityKeyNotSet, null, null, false, null, null };
             yield return new object[] { GetHttpContext(new[] { (KeyName, "dest-B") }), destinations, AffinityStatus.OK, destinations[1], Encoding.UTF8.GetBytes("dest-B"), true, null, null };
             yield return new object[] { GetHttpContext(new[] { (KeyName, "dest-Z") }), destinations, AffinityStatus.DestinationNotFound, null, Encoding.UTF8.GetBytes("dest-Z"), true, LogLevel.Warning, EventIds.DestinationMatchingToAffinityKeyNotFound };
-            yield return new object[] { GetHttpContext(new[] { (KeyName, "dest-B") }), new DestinationInfo[0], AffinityStatus.DestinationNotFound, null, Encoding.UTF8.GetBytes("dest-B"), true, LogLevel.Warning, EventIds.AffinityCannotBeEstablishedBecauseNoDestinationsFoundOnCluster };
+            yield return new object[] { GetHttpContext(new[] { (KeyName, "dest-B") }), new DestinationState[0], AffinityStatus.DestinationNotFound, null, Encoding.UTF8.GetBytes("dest-B"), true, LogLevel.Warning, EventIds.AffinityCannotBeEstablishedBecauseNoDestinationsFoundOnCluster };
             yield return new object[] { GetHttpContext(new[] { (KeyName, "/////") }, false), destinations, AffinityStatus.AffinityKeyExtractionFailed, null, Encoding.UTF8.GetBytes(InvalidKeyNull), false, LogLevel.Error, EventIds.RequestAffinityKeyDecryptionFailed };
             yield return new object[] { GetHttpContext(new[] { (KeyName, InvalidKeyNull) }), destinations, AffinityStatus.AffinityKeyExtractionFailed, null, Encoding.UTF8.GetBytes(InvalidKeyNull), true, LogLevel.Error, EventIds.RequestAffinityKeyDecryptionFailed };
             yield return new object[] { GetHttpContext(new[] { (KeyName, InvalidKeyThrow) }), destinations, AffinityStatus.AffinityKeyExtractionFailed, null, Encoding.UTF8.GetBytes(InvalidKeyThrow), true, LogLevel.Error, EventIds.RequestAffinityKeyDecryptionFailed };
@@ -203,7 +203,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
                 context.Items[AffinityKeyId] = key;
             }
 
-            protected override string GetDestinationAffinityKey(DestinationInfo destination)
+            protected override string GetDestinationAffinityKey(DestinationState destination)
             {
                 return destination.DestinationId;
             }

--- a/test/ReverseProxy.Tests/Service/SessionAffinity/CookieSessionAffinityProviderTests.cs
+++ b/test/ReverseProxy.Tests/Service/SessionAffinity/CookieSessionAffinityProviderTests.cs
@@ -21,7 +21,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
             Mode = "Cookie",
             FailurePolicy = "Return503",
         };
-        private readonly IReadOnlyList<DestinationInfo> _destinations = new[] { new DestinationInfo("dest-A"), new DestinationInfo("dest-B"), new DestinationInfo("dest-C") };
+        private readonly IReadOnlyList<DestinationState> _destinations = new[] { new DestinationState("dest-A"), new DestinationState("dest-B"), new DestinationState("dest-C") };
 
         [Fact]
         public void FindAffinitizedDestination_AffinityKeyIsNotSetOnRequest_ReturnKeyNotSet()
@@ -119,7 +119,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
             Assert.False(context.Response.Headers.ContainsKey("Cookie"));
         }
 
-        private string[] GetCookieWithAffinity(DestinationInfo affinitizedDestination)
+        private string[] GetCookieWithAffinity(DestinationState affinitizedDestination)
         {
             return new[] { $"Some-Cookie=ZZZ", $"{_defaultProviderOptions.Cookie.Name}={affinitizedDestination.DestinationId.ToUTF8BytesInBase64()}" };
         }

--- a/test/ReverseProxy.Tests/Service/SessionAffinity/CustomHeaderSessionAffinityProviderTests.cs
+++ b/test/ReverseProxy.Tests/Service/SessionAffinity/CustomHeaderSessionAffinityProviderTests.cs
@@ -20,7 +20,7 @@ namespace Yarp.ReverseProxy.Service.SessionAffinity
             FailurePolicy = "Return503",
             Settings = new Dictionary<string, string> { { "CustomHeaderName", AffinityHeaderName } },
         };
-        private readonly IReadOnlyList<DestinationInfo> _destinations = new[] { new DestinationInfo("dest-A"), new DestinationInfo("dest-B"), new DestinationInfo("dest-C") };
+        private readonly IReadOnlyList<DestinationState> _destinations = new[] { new DestinationState("dest-A"), new DestinationState("dest-B"), new DestinationState("dest-C") };
 
         [Fact]
         public void FindAffinitizedDestination_AffinityKeyIsNotSetOnRequest_ReturnKeyNotSet()

--- a/testassets/ReverseProxy.Code/Startup.cs
+++ b/testassets/ReverseProxy.Code/Startup.cs
@@ -43,9 +43,9 @@ namespace Yarp.ReverseProxy.Sample
                 {
                     ClusterId = "cluster1",
                     SessionAffinity = new SessionAffinityOptions { Enabled = true, Mode = "Cookie" },
-                    Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
+                    Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
                     {
-                        { "destination1", new Destination() { Address = "https://localhost:10000" } }
+                        { "destination1", new DestinationConfig() { Address = "https://localhost:10000" } }
                     }
                 }
             };


### PR DESCRIPTION
Continuation of #963
Destination -> DestinationConfig
DestinationConfig -> DestinationModel
DestinationInfo -> DestinationState

I moved DestinationConfig up two folders because it was the only thing in that directory.