### PR TITLE
Empty values in QueryParameterTransform and headers *Remove transforms

### DIFF
--- a/docs/docfx/articles/transforms.md
+++ b/docs/docfx/articles/transforms.md
@@ -432,6 +432,7 @@ MyHeader: MyValue
 ```
 
 This sets or appends the value for the named header. Set replaces any existing header. Append adds an additional header with the given value.
+Note: setting "" as a header value is not recommended and can cause an undefined behavior.
 
 ### RequestHeaderRemove
 
@@ -656,6 +657,7 @@ HeaderName: value
 ```
 
 This sets or appends the value for the named header. Set replaces any existing header. Append adds an additional header with the given value.
+Note: setting "" as a header value is not recommended and can cause an undefined behavior.
 
 `When` specifies if the response header should be included for successful responses or for all responses. Any response with a status code less than 400 is considered a success.
 

--- a/docs/docfx/articles/transforms.md
+++ b/docs/docfx/articles/transforms.md
@@ -431,7 +431,35 @@ Example:
 MyHeader: MyValue
 ```
 
-This sets or appends the value for the named header. Set replaces any existing header. Set a header to empty to remove it (e.g. `"Set": ""`). Append adds an additional header with the given value.
+This sets or appends the value for the named header. Set replaces any existing header. Append adds an additional header with the given value.
+
+### RequestHeaderRemove
+
+| Key | Value | Required |
+|-----|-------|----------|
+| RequestHeaderRemove | The header name | yes |
+
+Config:
+```JSON
+{
+  "RequestHeaderRemove": "MyHeader"
+}
+```
+Code:
+```csharp
+proxyRoute = proxyRoute.WithTransformRequestHeaderRemove(headerName: "MyHeader");
+```
+```C#
+transformBuilderContext.AddRequestHeaderRemove(headerName: "MyHeader");
+```
+
+Example:
+```
+MyHeader: MyValue
+AnotherHeader: AnotherValue
+```
+
+This removes the named header.
 
 ### X-Forwarded
 
@@ -627,7 +655,38 @@ Example:
 HeaderName: value
 ```
 
-This sets or appends the value for the named header. Set replaces any existing header. Set a header to empty to remove it (e.g. `"Set": ""`). Append adds an additional header with the given value.
+This sets or appends the value for the named header. Set replaces any existing header. Append adds an additional header with the given value.
+
+`When` specifies if the response header should be included for successful responses or for all responses. Any response with a status code less than 400 is considered a success.
+
+### ResponseHeaderRemove
+
+| Key | Value | Default | Required |
+|-----|-------|---------|----------|
+| ResponseHeaderRemove | The header name | (none) | yes |
+| When | Success/Always | Success | no |
+
+Config:
+```JSON
+{
+  "ResponseHeaderRemove": "HeaderName",
+  "When": "Success"
+}
+```
+Code:
+```csharp
+proxyRoute = proxyRoute.WithTransformResponseHeaderRemove(headerName: "HeaderName", always: false);
+```
+```C#
+transformBuilderContext.AddResponseHeaderRemove(headerName: "HeaderName", always: false);
+```
+Example:
+```
+HeaderName: value
+AnotherHeader: another-value
+```
+
+This removes the named header.
 
 `When` specifies if the response header should be included for successful responses or for all responses. Any response with a status code less than 400 is considered a success.
 
@@ -682,6 +741,37 @@ HeaderName: value
 Response trailers are headers sent at the end of the response body. Support for trailers is uncommon in HTTP/1.1 implementations but is becoming common in HTTP/2 implementations. Check your client and server for support.
 
 ResponseTrailer follows the same structure and guidance as ResponseHeader.
+
+### ResponseTrailerRemove
+
+| Key | Value | Default | Required |
+|-----|-------|---------|----------|
+| ResponseTrailerRemove | The header name | (none) | yes |
+| When | Success/Always | Success | no |
+
+Config:
+```JSON
+{
+  "ResponseTrailerRemove": "HeaderName",
+  "When": "Success"
+}
+```
+Code:
+```csharp
+proxyRoute = proxyRoute.WithTransformResponseTrailerRemove(headerName: "HeaderName", always: false);
+```
+```C#
+transformBuilderContext.AddResponseTrailerRemove(headerName: "HeaderName", always: false);
+```
+Example:
+```
+HeaderName: value
+AnotherHeader: another-value
+```
+
+This removes the named trailing header.
+
+ResponseTrailerRemove follows the same structure and guidance as ResponseHeaderRemove.
 
 ## Extensibility
 

--- a/src/ReverseProxy/Abstractions/Config/RequestHeadersTransformExtensions.cs
+++ b/src/ReverseProxy/Abstractions/Config/RequestHeadersTransformExtensions.cs
@@ -47,11 +47,31 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         }
 
         /// <summary>
+        /// Clones the route and adds the transform which will remove the request header.
+        /// </summary>
+        public static RouteConfig WithTransformRequestHeaderRemove(this RouteConfig route, string headerName)
+        {
+            return route.WithTransform(transform =>
+            {
+                transform[RequestHeadersTransformFactory.RequestHeaderRemoveKey] = headerName;
+            });
+        }
+
+        /// <summary>
         /// Adds the transform which will append or set the request header.
         /// </summary>
         public static TransformBuilderContext AddRequestHeader(this TransformBuilderContext context, string headerName, string value, bool append = true)
         {
             context.RequestTransforms.Add(new RequestHeaderValueTransform(headerName, value, append));
+            return context;
+        }
+
+        /// <summary>
+        /// Adds the transform which will remove the request header.
+        /// </summary>
+        public static TransformBuilderContext AddRequestHeaderRemove(this TransformBuilderContext context, string headerName)
+        {
+            context.RequestTransforms.Add(new RequestHeaderRemoveTransform(headerName));
             return context;
         }
 

--- a/src/ReverseProxy/Abstractions/Config/ResponseTransformExtensions.cs
+++ b/src/ReverseProxy/Abstractions/Config/ResponseTransformExtensions.cs
@@ -49,11 +49,33 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         }
 
         /// <summary>
+        /// Clones the route and adds the transform which will remove the response header.
+        /// </summary>
+        public static RouteConfig WithTransformResponseHeaderRemove(this RouteConfig route, string headerName, bool always = true)
+        {
+            var when = always ? ResponseTransformFactory.AlwaysValue : ResponseTransformFactory.SuccessValue;
+            return route.WithTransform(transform =>
+            {
+                transform[ResponseTransformFactory.ResponseHeaderRemoveKey] = headerName;
+                transform[ResponseTransformFactory.WhenKey] = when;
+            });
+        }
+
+        /// <summary>
         /// Adds the transform which will append or set the response header.
         /// </summary>
         public static TransformBuilderContext AddResponseHeader(this TransformBuilderContext context, string headerName, string value, bool append = true, bool always = true)
         {
             context.ResponseTransforms.Add(new ResponseHeaderValueTransform(headerName, value, append, always));
+            return context;
+        }
+
+        /// <summary>
+        /// Adds the transform which will remove the response header.
+        /// </summary>
+        public static TransformBuilderContext AddResponseHeaderRemove(this TransformBuilderContext context, string headerName, bool always = true)
+        {
+            context.ResponseTransforms.Add(new ResponseHeaderRemoveTransform(headerName, always));
             return context;
         }
 
@@ -79,6 +101,28 @@ namespace Yarp.ReverseProxy.Abstractions.Config
         {
             context.ResponseTrailersTransforms.Add(new ResponseTrailerValueTransform(headerName, value, append, always));
             return context;
+        }
+
+        /// <summary>
+        /// Adds the transform which will remove the response trailer.
+        /// </summary>
+        public static TransformBuilderContext AddResponseTrailerRemove(this TransformBuilderContext context, string headerName, bool always = true)
+        {
+            context.ResponseTrailersTransforms.Add(new ResponseTrailerRemoveTransform(headerName, always));
+            return context;
+        }
+
+        /// <summary>
+        /// Clones the route and adds the transform which will remove the response trailer.
+        /// </summary>
+        public static RouteConfig WithTransformResponseTrailerRemove(this RouteConfig route, string headerName, bool always = true)
+        {
+            var when = always ? ResponseTransformFactory.AlwaysValue : ResponseTransformFactory.SuccessValue;
+            return route.WithTransform(transform =>
+            {
+                transform[ResponseTransformFactory.ResponseTrailerRemoveKey] = headerName;
+                transform[ResponseTransformFactory.WhenKey] = when;
+            });
         }
     }
 }

--- a/src/ReverseProxy/Service/Config/RequestHeadersTransformFactory.cs
+++ b/src/ReverseProxy/Service/Config/RequestHeadersTransformFactory.cs
@@ -12,6 +12,7 @@ namespace Yarp.ReverseProxy.Service.Config
         internal static readonly string RequestHeadersCopyKey = "RequestHeadersCopy";
         internal static readonly string RequestHeaderOriginalHostKey = "RequestHeaderOriginalHost";
         internal static readonly string RequestHeaderKey = "RequestHeader";
+        internal static readonly string RequestHeaderRemoveKey = "RequestHeaderRemove";
         internal static readonly string AppendKey = "Append";
         internal static readonly string SetKey = "Set";
 
@@ -40,6 +41,10 @@ namespace Yarp.ReverseProxy.Service.Config
                 {
                     context.Errors.Add(new ArgumentException($"Unexpected parameters for RequestHeader: {string.Join(';', transformValues.Keys)}. Expected 'Set' or 'Append'"));
                 }
+            }
+            else if (transformValues.TryGetValue(RequestHeaderRemoveKey, out var _))
+            {
+                TransformHelpers.TryCheckTooManyParameters(context, transformValues, expected: 1);
             }
             else
             {
@@ -76,6 +81,11 @@ namespace Yarp.ReverseProxy.Service.Config
                 {
                     throw new ArgumentException($"Unexpected parameters for RequestHeader: {string.Join(';', transformValues.Keys)}. Expected 'Set' or 'Append'");
                 }
+            }
+            else if (transformValues.TryGetValue(RequestHeaderOriginalHostKey, out var removeHeaderName))
+            {
+                TransformHelpers.CheckTooManyParameters(transformValues, expected: 1);
+                context.AddRequestHeaderRemove(removeHeaderName);
             }
             else
             {

--- a/src/ReverseProxy/Service/Config/ResponseTransformFactory.cs
+++ b/src/ReverseProxy/Service/Config/ResponseTransformFactory.cs
@@ -13,6 +13,8 @@ namespace Yarp.ReverseProxy.Service.Config
         internal static readonly string ResponseTrailersCopyKey = "ResponseTrailersCopy";
         internal static readonly string ResponseHeaderKey = "ResponseHeader";
         internal static readonly string ResponseTrailerKey = "ResponseTrailer";
+        internal static readonly string ResponseHeaderRemoveKey = "ResponseHeaderRemove";
+        internal static readonly string ResponseTrailerRemoveKey = "ResponseTrailerRemove";
         internal static readonly string WhenKey = "When";
         internal static readonly string AlwaysValue = "Always";
         internal static readonly string SuccessValue = "Success";
@@ -75,6 +77,36 @@ namespace Yarp.ReverseProxy.Service.Config
                 if (!transformValues.TryGetValue(SetKey, out var _) && !transformValues.TryGetValue(AppendKey, out var _))
                 {
                     context.Errors.Add(new ArgumentException($"Unexpected parameters for ResponseTrailer: {string.Join(';', transformValues.Keys)}. Expected 'Set' or 'Append'"));
+                }
+            }
+            else if (transformValues.TryGetValue(ResponseHeaderRemoveKey, out var _))
+            {
+                if (transformValues.TryGetValue(WhenKey, out var whenValue))
+                {
+                    TransformHelpers.TryCheckTooManyParameters(context, transformValues, expected: 2);
+                    if (!string.Equals(AlwaysValue, whenValue, StringComparison.OrdinalIgnoreCase) && !string.Equals(SuccessValue, whenValue, StringComparison.OrdinalIgnoreCase))
+                    {
+                        context.Errors.Add(new ArgumentException($"Unexpected value for ResponseHeaderRemove:When: {whenValue}. Expected 'Always' or 'Success'"));
+                    }
+                }
+                else
+                {
+                    TransformHelpers.TryCheckTooManyParameters(context, transformValues, expected: 1);
+                }
+            }
+            else if (transformValues.TryGetValue(ResponseTrailerRemoveKey, out var _))
+            {
+                if (transformValues.TryGetValue(WhenKey, out var whenValue))
+                {
+                    TransformHelpers.TryCheckTooManyParameters(context, transformValues, expected: 2);
+                    if (!string.Equals(AlwaysValue, whenValue, StringComparison.OrdinalIgnoreCase) && !string.Equals(SuccessValue, whenValue, StringComparison.OrdinalIgnoreCase))
+                    {
+                        context.Errors.Add(new ArgumentException($"Unexpected value for ResponseTrailerRemove:When: {whenValue}. Expected 'Always' or 'Success'"));
+                    }
+                }
+                else
+                {
+                    TransformHelpers.TryCheckTooManyParameters(context, transformValues, expected: 1);
                 }
             }
             else
@@ -148,6 +180,36 @@ namespace Yarp.ReverseProxy.Service.Config
                 {
                     throw new ArgumentException($"Unexpected parameters for ResponseTrailer: {string.Join(';', transformValues.Keys)}. Expected 'Set' or 'Append'");
                 }
+            }
+            else if (transformValues.TryGetValue(ResponseHeaderKey, out var removeResponseHeaderName))
+            {
+                var always = false;
+                if (transformValues.TryGetValue(WhenKey, out var whenValue))
+                {
+                    TransformHelpers.CheckTooManyParameters(transformValues, expected: 2);
+                    always = string.Equals(AlwaysValue, whenValue, StringComparison.OrdinalIgnoreCase);
+                }
+                else
+                {
+                    TransformHelpers.CheckTooManyParameters(transformValues, expected: 1);
+                }
+
+                context.AddResponseHeaderRemove(removeResponseHeaderName, always);
+            }
+            else if (transformValues.TryGetValue(ResponseTrailerRemoveKey, out var removeResponseTrailerName))
+            {
+                var always = false;
+                if (transformValues.TryGetValue(WhenKey, out var whenValue))
+                {
+                    TransformHelpers.CheckTooManyParameters(transformValues, expected: 2);
+                    always = string.Equals(AlwaysValue, whenValue, StringComparison.OrdinalIgnoreCase);
+                }
+                else
+                {
+                    TransformHelpers.CheckTooManyParameters(transformValues, expected: 1);
+                }
+
+                context.AddResponseTrailerRemove(removeResponseTrailerName, always);
             }
             else
             {

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/QueryParameterFromStaticTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/QueryParameterFromStaticTransform.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Yarp.ReverseProxy.Service.RuntimeModel.Transforms
 {
     public class QueryParameterFromStaticTransform : QueryParameterTransform
@@ -8,7 +10,7 @@ namespace Yarp.ReverseProxy.Service.RuntimeModel.Transforms
         public QueryParameterFromStaticTransform(QueryStringTransformMode mode, string key, string value)
             : base(mode, key)
         {
-            Value = value;
+            Value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
         internal string Value { get; }

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/QueryParameterTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/QueryParameterTransform.cs
@@ -28,7 +28,7 @@ namespace Yarp.ReverseProxy.Service.RuntimeModel.Transforms
             }
 
             var value = GetValue(context);
-            if (!string.IsNullOrEmpty(value))
+            if (value != null)
             {
                 switch (Mode)
                 {

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/QueryTransformContext.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/QueryTransformContext.cs
@@ -36,8 +36,13 @@ namespace Yarp.ReverseProxy.Service.RuntimeModel.Transforms
                     return _originalQueryString;
                 }
 
-                var queryBuilder = new QueryBuilder(_modifiedQueryParameters
-                    .SelectMany(kvp => StringValues.IsNullOrEmpty(kvp.Value) ? _emptyString : kvp.Value, (kvp, v) => KeyValuePair.Create(kvp.Key, v)));
+#if NET
+                var queryBuilder = new QueryBuilder(_modifiedQueryParameters);
+#elif NETCOREAPP3_1
+                var queryBuilder = new QueryBuilder(_modifiedQueryParameters.SelectMany(kvp => kvp.Value, (kvp, v) => KeyValuePair.Create(kvp.Key, v)));
+#else
+#error A target framework was added to the project and needs to be added to this condition.
+#endif
                 return queryBuilder.ToQueryString();
             }
         }

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/QueryTransformContext.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/QueryTransformContext.cs
@@ -15,7 +15,6 @@ namespace Yarp.ReverseProxy.Service.RuntimeModel.Transforms
     /// </summary>
     public class QueryTransformContext
     {
-        private static readonly IEnumerable<string> _emptyString = new[] { string.Empty };
         private readonly HttpRequest _request;
         private readonly QueryString _originalQueryString;
         private Dictionary<string, StringValues> _modifiedQueryParameters;

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/QueryTransformContext.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/QueryTransformContext.cs
@@ -15,6 +15,7 @@ namespace Yarp.ReverseProxy.Service.RuntimeModel.Transforms
     /// </summary>
     public class QueryTransformContext
     {
+        private static readonly IEnumerable<string> _emptyString = new[] { string.Empty };
         private readonly HttpRequest _request;
         private readonly QueryString _originalQueryString;
         private Dictionary<string, StringValues> _modifiedQueryParameters;
@@ -35,13 +36,8 @@ namespace Yarp.ReverseProxy.Service.RuntimeModel.Transforms
                     return _originalQueryString;
                 }
 
-#if NET
-                var queryBuilder = new QueryBuilder(_modifiedQueryParameters);
-#elif NETCOREAPP3_1
-                var queryBuilder = new QueryBuilder(_modifiedQueryParameters.SelectMany(kvp => kvp.Value, (kvp, v) => KeyValuePair.Create(kvp.Key, v)));
-#else
-#error A target framework was added to the project and needs to be added to this condition.
-#endif
+                var queryBuilder = new QueryBuilder(_modifiedQueryParameters
+                    .SelectMany(kvp => StringValues.IsNullOrEmpty(kvp.Value) ? _emptyString : kvp.Value, (kvp, v) => KeyValuePair.Create(kvp.Key, v)));
                 return queryBuilder.ToQueryString();
             }
         }

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderRemoveTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderRemoveTransform.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Yarp.ReverseProxy.Service.RuntimeModel.Transforms
+{
+    /// <summary>
+    /// Removes a request header.
+    /// </summary>
+    public class RequestHeaderRemoveTransform : RequestTransform
+    {
+        public RequestHeaderRemoveTransform(string headerName)
+        {
+            HeaderName = headerName ?? throw new ArgumentNullException(nameof(headerName));
+        }
+
+        internal string HeaderName { get; }
+
+        /// <inheritdoc/>
+        public override ValueTask ApplyAsync(RequestTransformContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (!context.ProxyRequest.Headers.Remove(HeaderName))
+            {
+                context.ProxyRequest.Content?.Headers.Remove(HeaderName);
+            }
+
+            return default;
+        }
+    }
+}

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderValueTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/RequestHeaderValueTransform.cs
@@ -40,7 +40,7 @@ namespace Yarp.ReverseProxy.Service.RuntimeModel.Transforms
                 var values = StringValues.Concat(existingValues, Value);
                 AddHeader(context, HeaderName, values);
             }
-            else if (!string.IsNullOrEmpty(Value))
+            else
             {
                 // Set
                 AddHeader(context, HeaderName, Value);

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/ResponseHeaderRemoveTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/ResponseHeaderRemoveTransform.cs
@@ -32,10 +32,7 @@ namespace Yarp.ReverseProxy.Service.RuntimeModel.Transforms
 
             if (Always || Success(context))
             {
-                if (!context.ProxyResponse.Headers.Remove(HeaderName))
-                {
-                    context.ProxyResponse.Content?.Headers.Remove(HeaderName);
-                }
+                context.HttpContext.Response.Headers.Remove(HeaderName);
             }
 
             return default;

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/ResponseTrailerRemoveTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/ResponseTrailerRemoveTransform.cs
@@ -40,10 +40,7 @@ namespace Yarp.ReverseProxy.Service.RuntimeModel.Transforms
                 Debug.Assert(responseTrailers != null);
                 Debug.Assert(!responseTrailers.IsReadOnly);
 
-                if (!responseTrailers.Remove(HeaderName) && !context.HeadersCopied)
-                {
-                    context.ProxyResponse.TrailingHeaders.Remove(HeaderName);
-                }
+                responseTrailers.Remove(HeaderName);
             }
 
             return default;

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/ResponseTrailersTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/ResponseTrailersTransform.cs
@@ -65,5 +65,11 @@ namespace Yarp.ReverseProxy.Service.RuntimeModel.Transforms
 
             responseTrailers[headerName] = values;
         }
+
+        internal static bool Success(ResponseTrailersTransformContext context)
+        {
+            // TODO: How complex should this get? Compare with http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header
+            return context.HttpContext.Response.StatusCode < 400;
+        }
     }
 }

--- a/src/ReverseProxy/Service/RuntimeModel/Transforms/ResponseTransform.cs
+++ b/src/ReverseProxy/Service/RuntimeModel/Transforms/ResponseTransform.cs
@@ -52,5 +52,11 @@ namespace Yarp.ReverseProxy.Service.RuntimeModel.Transforms
         {
             context.HttpContext.Response.Headers[headerName] = values;
         }
+
+        internal static bool Success(ResponseTransformContext context)
+        {
+            // TODO: How complex should this get? Compare with http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header
+            return context.HttpContext.Response.StatusCode < 400;
+        }
     }
 }

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/QueryParameterFromStaticTransformTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/QueryParameterFromStaticTransformTests.cs
@@ -66,5 +66,78 @@ namespace Yarp.ReverseProxy.Service.RuntimeModel.Transforms
             await transform.ApplyAsync(context);
             Assert.Equal("?z=foo", context.Query.QueryString.Value);
         }
+
+        [Fact]
+        public async Task Set_AddsNewEmptyQueryStringParameter()
+        {
+            var httpContext = new DefaultHttpContext();
+            var context = new RequestTransformContext()
+            {
+                Query = new QueryTransformContext(httpContext.Request),
+                HttpContext = httpContext
+            };
+            var transform = new QueryParameterFromStaticTransform(QueryStringTransformMode.Set, "z", "");
+            await transform.ApplyAsync(context);
+            Assert.Equal("?z=", context.Query.QueryString.Value);
+        }
+
+        [Fact]
+        public async Task Set_OverwritesExistingParamWithEmptyValue()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.QueryString = new QueryString("?z=foo");
+            var context = new RequestTransformContext()
+            {
+                Query = new QueryTransformContext(httpContext.Request),
+                HttpContext = httpContext
+            };
+            var transform = new QueryParameterFromStaticTransform(QueryStringTransformMode.Set, "z", "");
+            await transform.ApplyAsync(context);
+            Assert.Equal("?z=", context.Query.QueryString.Value);
+        }
+
+        [Fact]
+        public async Task Set_AddNewEmptyParamToExistingQueryStringParameter()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.QueryString = new QueryString("?x=1");
+            var context = new RequestTransformContext()
+            {
+                Query = new QueryTransformContext(httpContext.Request),
+                HttpContext = httpContext
+            };
+            var transform = new QueryParameterFromStaticTransform(QueryStringTransformMode.Set, "z", "");
+            await transform.ApplyAsync(context);
+            Assert.Equal("?x=1&z=", context.Query.QueryString.Value);
+        }
+
+        [Fact]
+        public async Task Append_AddsNewEmptyQueryStringParameter()
+        {
+            var httpContext = new DefaultHttpContext();
+            var context = new RequestTransformContext()
+            {
+                Query = new QueryTransformContext(httpContext.Request),
+                HttpContext = httpContext
+            };
+            var transform = new QueryParameterFromStaticTransform(QueryStringTransformMode.Append, "z", "");
+            await transform.ApplyAsync(context);
+            Assert.Equal("?z=", context.Query.QueryString.Value);
+        }
+
+        [Fact]
+        public async Task Append_AppendsEmptyValueToExistingParam()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.QueryString = new QueryString("?z=foo");
+            var context = new RequestTransformContext()
+            {
+                Query = new QueryTransformContext(httpContext.Request),
+                HttpContext = httpContext
+            };
+            var transform = new QueryParameterFromStaticTransform(QueryStringTransformMode.Append, "z", "");
+            await transform.ApplyAsync(context);
+            Assert.Equal("?z=foo&z=", context.Query.QueryString.Value);
+        }
     }
 }

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/RequestHeaderRemoveTransformTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/RequestHeaderRemoveTransformTests.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+using Yarp.ReverseProxy.Utilities.Tests;
+
+namespace Yarp.ReverseProxy.Service.RuntimeModel.Transforms
+{
+    public class RequestHeaderRemoveTransformTests
+    {
+        [Theory]
+        [InlineData("header1", "value1", "header1", "")]
+        [InlineData("header1", "value1", "headerX", "header1")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", "header2", "header1; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", "headerX", "header1; header2; header3")]
+        [InlineData("header1; header2; header2; header3", "value1, value2-1, value2-2, value3", "header2", "header1; header3")]
+        public async Task RemoveHeader_Success(string names, string values, string removedHeader, string expected)
+        {
+            var httpContext = new DefaultHttpContext();
+            var proxyRequest = new HttpRequestMessage();
+            foreach (var pair in TestResources.ParseNameAndValues(names, values))
+            {
+                proxyRequest.Headers.Add(pair.Name, pair.Values);
+            }
+
+            var transform = new RequestHeaderRemoveTransform(removedHeader);
+            await transform.ApplyAsync(new RequestTransformContext()
+            {
+                HttpContext = httpContext,
+                ProxyRequest = proxyRequest,
+                HeadersCopied = true,
+            });
+
+            var expectedHeaders = expected.Split("; ", StringSplitOptions.RemoveEmptyEntries);
+            Assert.Equal(expectedHeaders, proxyRequest.Headers.Select(h => h.Key));
+        }
+    }
+}

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/ResponseHeaderRemoveTransformTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/ResponseHeaderRemoveTransformTests.cs
@@ -41,7 +41,7 @@ namespace Yarp.ReverseProxy.Service.RuntimeModel.Transforms
             var proxyResponse = new HttpResponseMessage();
             foreach (var pair in TestResources.ParseNameAndValues(names, values))
             {
-                proxyResponse.Headers.Add(pair.Name, pair.Values);
+                httpContext.Response.Headers.Add(pair.Name, pair.Values);
             }
 
             var transform = new ResponseHeaderRemoveTransform(removedHeader, always);
@@ -53,7 +53,7 @@ namespace Yarp.ReverseProxy.Service.RuntimeModel.Transforms
             });
 
             var expectedHeaders = expected.Split("; ", StringSplitOptions.RemoveEmptyEntries);
-            Assert.Equal(expectedHeaders, proxyResponse.Headers.Select(h => h.Key));
+            Assert.Equal(expectedHeaders, httpContext.Response.Headers.Select(h => h.Key));
         }
     }
 }

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/ResponseHeaderRemoveTransformTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/ResponseHeaderRemoveTransformTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+using Yarp.ReverseProxy.Utilities.Tests;
+
+namespace Yarp.ReverseProxy.Service.RuntimeModel.Transforms
+{
+    public class ResponseHeaderRemoveTransformTests
+    {
+        [Theory]
+        [InlineData("header1", "value1", 200, false, "header1", "")]
+        [InlineData("header1", "value1", 404, false, "header1", "header1")]
+        [InlineData("header1", "value1", 200, true, "header1", "")]
+        [InlineData("header1", "value1", 404, true, "header1", "")]
+        [InlineData("header1", "value1", 200, false, "headerX", "header1")]
+        [InlineData("header1", "value1", 404, false, "headerX", "header1")]
+        [InlineData("header1", "value1", 200, true, "headerX", "header1")]
+        [InlineData("header1", "value1", 404, true, "headerX", "header1")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 200, false, "header2", "header1; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 404, false, "header2", "header1; header2; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 200, true, "header2", "header1; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 404, true, "header2", "header1; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 200, false, "headerX", "header1; header2; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 404, false, "headerX", "header1; header2; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 200, true, "headerX", "header1; header2; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 404, true, "headerX", "header1; header2; header3")]
+        [InlineData("header1; header2; header2; header3", "value1, value2-1, value2-2, value3", 200, false, "header2", "header1; header3")]
+        [InlineData("header1; header2; header2; header3", "value1, value2-1, value2-2, value3", 404, false, "header2", "header1; header2; header3")]
+        [InlineData("header1; header2; header2; header3", "value1, value2-1, value2-2, value3", 200, true, "header2", "header1; header3")]
+        [InlineData("header1; header2; header2; header3", "value1, value2-1, value2-2, value3", 404, true, "header2", "header1; header3")]
+        public async Task RemoveHeader_Success(string names, string values, int status, bool always, string removedHeader, string expected)
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Response.StatusCode = status;
+            var proxyResponse = new HttpResponseMessage();
+            foreach (var pair in TestResources.ParseNameAndValues(names, values))
+            {
+                proxyResponse.Headers.Add(pair.Name, pair.Values);
+            }
+
+            var transform = new ResponseHeaderRemoveTransform(removedHeader, always);
+            await transform.ApplyAsync(new ResponseTransformContext()
+            {
+                HttpContext = httpContext,
+                ProxyResponse = proxyResponse,
+                HeadersCopied = true,
+            });
+
+            var expectedHeaders = expected.Split("; ", StringSplitOptions.RemoveEmptyEntries);
+            Assert.Equal(expectedHeaders, proxyResponse.Headers.Select(h => h.Key));
+        }
+    }
+}

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/ResponseTrailerRemoveTransformTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/ResponseTrailerRemoveTransformTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Xunit;
+using Yarp.ReverseProxy.Utilities.Tests;
+
+namespace Yarp.ReverseProxy.Service.RuntimeModel.Transforms
+{
+    public class ResponseTrailerRemoveTransformTests
+    {
+        [Theory]
+        [InlineData("header1", "value1", 200, false, "header1", "")]
+        [InlineData("header1", "value1", 404, false, "header1", "header1")]
+        [InlineData("header1", "value1", 200, true, "header1", "")]
+        [InlineData("header1", "value1", 404, true, "header1", "")]
+        [InlineData("header1", "value1", 200, false, "headerX", "header1")]
+        [InlineData("header1", "value1", 404, false, "headerX", "header1")]
+        [InlineData("header1", "value1", 200, true, "headerX", "header1")]
+        [InlineData("header1", "value1", 404, true, "headerX", "header1")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 200, false, "header2", "header1; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 404, false, "header2", "header1; header2; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 200, true, "header2", "header1; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 404, true, "header2", "header1; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 200, false, "headerX", "header1; header2; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 404, false, "headerX", "header1; header2; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 200, true, "headerX", "header1; header2; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 404, true, "headerX", "header1; header2; header3")]
+        [InlineData("header1; header2; header2; header3", "value1, value2-1, value2-2, value3", 200, false, "header2", "header1; header3")]
+        [InlineData("header1; header2; header2; header3", "value1, value2-1, value2-2, value3", 404, false, "header2", "header1; header2; header3")]
+        [InlineData("header1; header2; header2; header3", "value1, value2-1, value2-2, value3", 200, true, "header2", "header1; header3")]
+        [InlineData("header1; header2; header2; header3", "value1, value2-1, value2-2, value3", 404, true, "header2", "header1; header3")]
+        public async Task RemoveTrailer_Success(string names, string values, int status, bool always, string removedHeader, string expected)
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Response.StatusCode = status;
+            var trailerFeature = new TestTrailersFeature();
+            httpContext.Features.Set<IHttpResponseTrailersFeature>(trailerFeature);
+            var proxyResponse = new HttpResponseMessage();
+            foreach (var pair in TestResources.ParseNameAndValues(names, values))
+            {
+                proxyResponse.TrailingHeaders.Add(pair.Name, pair.Values);
+            }
+
+            var transform = new ResponseTrailerRemoveTransform(removedHeader, always);
+            await transform.ApplyAsync(new ResponseTrailersTransformContext()
+            {
+                HttpContext = httpContext,
+                ProxyResponse = proxyResponse,
+                HeadersCopied = false,
+            });
+
+            var expectedHeaders = expected.Split("; ", StringSplitOptions.RemoveEmptyEntries);
+            Assert.Equal(expectedHeaders, proxyResponse.TrailingHeaders.Select(h => h.Key));
+        }
+
+        [Theory]
+        [InlineData("header1", "value1", 200, false, "header1", "")]
+        [InlineData("header1", "value1", 404, false, "header1", "header1")]
+        [InlineData("header1", "value1", 200, true, "header1", "")]
+        [InlineData("header1", "value1", 404, true, "header1", "")]
+        [InlineData("header1", "value1", 200, false, "headerX", "header1")]
+        [InlineData("header1", "value1", 404, false, "headerX", "header1")]
+        [InlineData("header1", "value1", 200, true, "headerX", "header1")]
+        [InlineData("header1", "value1", 404, true, "headerX", "header1")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 200, false, "header2", "header1; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 404, false, "header2", "header1; header2; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 200, true, "header2", "header1; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 404, true, "header2", "header1; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 200, false, "headerX", "header1; header2; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 404, false, "headerX", "header1; header2; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 200, true, "headerX", "header1; header2; header3")]
+        [InlineData("header1; header2; header3", "value1, value2, value3", 404, true, "headerX", "header1; header2; header3")]
+        [InlineData("header1; header2; header2; header3", "value1, value2-1, value2-2, value3", 200, false, "header2", "header1; header3")]
+        [InlineData("header1; header2; header2; header3", "value1, value2-1, value2-2, value3", 404, false, "header2", "header1; header2; header3")]
+        [InlineData("header1; header2; header2; header3", "value1, value2-1, value2-2, value3", 200, true, "header2", "header1; header3")]
+        [InlineData("header1; header2; header2; header3", "value1, value2-1, value2-2, value3", 404, true, "header2", "header1; header3")]
+        public async Task RemoveTrailerFromFeature_Success(string names, string values, int status, bool always, string removedHeader, string expected)
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Response.StatusCode = status;
+            var trailerFeature = new TestTrailersFeature();
+            httpContext.Features.Set<IHttpResponseTrailersFeature>(trailerFeature);
+            var proxyResponse = new HttpResponseMessage();
+            foreach (var pair in TestResources.ParseNameAndValues(names, values))
+            {
+                trailerFeature.Trailers.Add(pair.Name, pair.Values);
+            }
+
+            var transform = new ResponseTrailerRemoveTransform(removedHeader, always);
+            await transform.ApplyAsync(new ResponseTrailersTransformContext()
+            {
+                HttpContext = httpContext,
+                ProxyResponse = proxyResponse,
+                HeadersCopied = true,
+            });
+
+            var expectedHeaders = expected.Split("; ", StringSplitOptions.RemoveEmptyEntries);
+            Assert.Equal(expectedHeaders, trailerFeature.Trailers.Select(h => h.Key));
+        }
+
+        private class TestTrailersFeature : IHttpResponseTrailersFeature
+        {
+            public IHeaderDictionary Trailers { get; set; } = new HeaderDictionary();
+        }
+    }
+}

--- a/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/ResponseTrailerRemoveTransformTests.cs
+++ b/test/ReverseProxy.Tests/Service/RuntimeModel/Transforms/ResponseTrailerRemoveTransformTests.cs
@@ -35,51 +35,6 @@ namespace Yarp.ReverseProxy.Service.RuntimeModel.Transforms
         [InlineData("header1; header2; header2; header3", "value1, value2-1, value2-2, value3", 404, false, "header2", "header1; header2; header3")]
         [InlineData("header1; header2; header2; header3", "value1, value2-1, value2-2, value3", 200, true, "header2", "header1; header3")]
         [InlineData("header1; header2; header2; header3", "value1, value2-1, value2-2, value3", 404, true, "header2", "header1; header3")]
-        public async Task RemoveTrailer_Success(string names, string values, int status, bool always, string removedHeader, string expected)
-        {
-            var httpContext = new DefaultHttpContext();
-            httpContext.Response.StatusCode = status;
-            var trailerFeature = new TestTrailersFeature();
-            httpContext.Features.Set<IHttpResponseTrailersFeature>(trailerFeature);
-            var proxyResponse = new HttpResponseMessage();
-            foreach (var pair in TestResources.ParseNameAndValues(names, values))
-            {
-                proxyResponse.TrailingHeaders.Add(pair.Name, pair.Values);
-            }
-
-            var transform = new ResponseTrailerRemoveTransform(removedHeader, always);
-            await transform.ApplyAsync(new ResponseTrailersTransformContext()
-            {
-                HttpContext = httpContext,
-                ProxyResponse = proxyResponse,
-                HeadersCopied = false,
-            });
-
-            var expectedHeaders = expected.Split("; ", StringSplitOptions.RemoveEmptyEntries);
-            Assert.Equal(expectedHeaders, proxyResponse.TrailingHeaders.Select(h => h.Key));
-        }
-
-        [Theory]
-        [InlineData("header1", "value1", 200, false, "header1", "")]
-        [InlineData("header1", "value1", 404, false, "header1", "header1")]
-        [InlineData("header1", "value1", 200, true, "header1", "")]
-        [InlineData("header1", "value1", 404, true, "header1", "")]
-        [InlineData("header1", "value1", 200, false, "headerX", "header1")]
-        [InlineData("header1", "value1", 404, false, "headerX", "header1")]
-        [InlineData("header1", "value1", 200, true, "headerX", "header1")]
-        [InlineData("header1", "value1", 404, true, "headerX", "header1")]
-        [InlineData("header1; header2; header3", "value1, value2, value3", 200, false, "header2", "header1; header3")]
-        [InlineData("header1; header2; header3", "value1, value2, value3", 404, false, "header2", "header1; header2; header3")]
-        [InlineData("header1; header2; header3", "value1, value2, value3", 200, true, "header2", "header1; header3")]
-        [InlineData("header1; header2; header3", "value1, value2, value3", 404, true, "header2", "header1; header3")]
-        [InlineData("header1; header2; header3", "value1, value2, value3", 200, false, "headerX", "header1; header2; header3")]
-        [InlineData("header1; header2; header3", "value1, value2, value3", 404, false, "headerX", "header1; header2; header3")]
-        [InlineData("header1; header2; header3", "value1, value2, value3", 200, true, "headerX", "header1; header2; header3")]
-        [InlineData("header1; header2; header3", "value1, value2, value3", 404, true, "headerX", "header1; header2; header3")]
-        [InlineData("header1; header2; header2; header3", "value1, value2-1, value2-2, value3", 200, false, "header2", "header1; header3")]
-        [InlineData("header1; header2; header2; header3", "value1, value2-1, value2-2, value3", 404, false, "header2", "header1; header2; header3")]
-        [InlineData("header1; header2; header2; header3", "value1, value2-1, value2-2, value3", 200, true, "header2", "header1; header3")]
-        [InlineData("header1; header2; header2; header3", "value1, value2-1, value2-2, value3", 404, true, "header2", "header1; header3")]
         public async Task RemoveTrailerFromFeature_Success(string names, string values, int status, bool always, string removedHeader, string expected)
         {
             var httpContext = new DefaultHttpContext();

--- a/test/ReverseProxy.Tests/Utilities/TestResources.cs
+++ b/test/ReverseProxy.Tests/Utilities/TestResources.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
@@ -63,5 +65,8 @@ namespace Yarp.ReverseProxy.Utilities.Tests
             var basePath = Path.Combine(Directory.GetCurrentDirectory(), "TestCertificates");
             return Path.Combine(basePath, fileName);
         }
+
+        public static IEnumerable<(string Name, string[] Values)> ParseNameAndValues(string names, string values) =>
+            names.Split("; ").Zip(values.Split(", ")).GroupBy(p => p.First, (k, g) => (Name: k, Values: g.Select(i => i.Second).ToArray()));
     }
 }


### PR DESCRIPTION
Adds support for empty string value in QueryParameterTransform. It changes the way the empty string "" value is handled, now it doesn't remove the given query parameter or header anymore, instead the "" is treated as a normal string value. To remove a query parameter the existing QueryParameterRemoveTransform can be used. To remove headers, the new transforms RequestHeaderRemoveTransform, ResponseHeaderRemoveTransform, and ResponseTrailerRemoveTransforms are added by this PR.
Note, setting "" as a header value is not recommended and can cause an undefined behavior.

Fixes #619