### PR TITLE
Flow RequestHeaderEncoding as a string

### DIFF
--- a/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Util/LabelsParser.cs
+++ b/src/ReverseProxy.ServiceFabric/ServiceDiscovery/Util/LabelsParser.cs
@@ -268,7 +268,6 @@ namespace Yarp.ReverseProxy.ServiceFabric
 
 #if NET
             var versionPolicyLabel = GetLabel<string>(labels, "YARP.Backend.HttpRequest.VersionPolicy", null);
-            var requestHeaderEncodingLabel = GetLabel<string>(labels, "YARP.Backend.HttpClient.RequestHeaderEncoding", null);
 #endif
 
             var cluster = new ClusterConfig
@@ -315,7 +314,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
                     SslProtocols = !string.IsNullOrEmpty(sslProtocolsLabel) ? Enum.Parse<SslProtocols>(sslProtocolsLabel) : null,
 #if NET
                     EnableMultipleHttp2Connections = GetLabel<bool?>(labels, "YARP.Backend.HttpClient.EnableMultipleHttp2Connections", null),
-                    RequestHeaderEncoding = !string.IsNullOrEmpty(requestHeaderEncodingLabel) ? Encoding.GetEncoding(requestHeaderEncodingLabel) : null,
+                    RequestHeaderEncoding = GetLabel<string>(labels, "YARP.Backend.HttpClient.RequestHeaderEncoding", null),
 #endif
                     WebProxy = new WebProxyConfig
                     {
@@ -323,7 +322,6 @@ namespace Yarp.ReverseProxy.ServiceFabric
                         BypassOnLocal = GetLabel<bool?>(labels, "YARP.Backend.HttpClient.WebProxy.BypassOnLocal", null),
                         UseDefaultCredentials = GetLabel<bool?>(labels, "YARP.Backend.HttpClient.WebProxy.UseDefaultCredentials", null),
                     }
-                    //TODO: ClientCertificate =
                 },
                 Metadata = clusterMetadata,
                 Destinations = destinations,

--- a/src/ReverseProxy/Abstractions/HttpClientConfig.cs
+++ b/src/ReverseProxy/Abstractions/HttpClientConfig.cs
@@ -60,7 +60,7 @@ namespace Yarp.ReverseProxy.Abstractions
         /// <summary>
         /// Enables non-ASCII header encoding for outgoing requests.
         /// </summary>
-        public Encoding RequestHeaderEncoding { get; init; }
+        public string RequestHeaderEncoding { get; init; }
 #endif
 
         /// <inheritdoc />

--- a/src/ReverseProxy/Configuration/ConfigurationConfigProvider.cs
+++ b/src/ReverseProxy/Configuration/ConfigurationConfigProvider.cs
@@ -344,7 +344,7 @@ namespace Yarp.ReverseProxy.Configuration
                 MaxConnectionsPerServer = section.ReadInt32(nameof(HttpClientConfig.MaxConnectionsPerServer)),
 #if NET
                 EnableMultipleHttp2Connections = section.ReadBool(nameof(HttpClientConfig.EnableMultipleHttp2Connections)),
-                RequestHeaderEncoding = section[nameof(HttpClientConfig.RequestHeaderEncoding)] is string encoding ? Encoding.GetEncoding(encoding) : null,
+                RequestHeaderEncoding = section[nameof(HttpClientConfig.RequestHeaderEncoding)],
 #endif
                 ActivityContextHeaders = section.ReadEnum<ActivityContextHeaders>(nameof(HttpClientConfig.ActivityContextHeaders)),
                 WebProxy = webProxy

--- a/src/ReverseProxy/Service/Config/ConfigValidator.cs
+++ b/src/ReverseProxy/Service/Config/ConfigValidator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -342,6 +343,20 @@ namespace Yarp.ReverseProxy.Service
             {
                 errors.Add(new ArgumentException($"Max connections per server limit set on the cluster '{cluster.ClusterId}' must be positive."));
             }
+#if NET
+            var encoding = cluster.HttpClient.RequestHeaderEncoding;
+            if (encoding != null)
+            {
+                try
+                {
+                    Encoding.GetEncoding(encoding);
+                }
+                catch (ArgumentException aex)
+                {
+                    errors.Add(new ArgumentException($"Invalid header encoding '{encoding}'.", aex));
+                }
+            }
+#endif
         }
 
         private static void ValidateProxyHttpRequest(IList<Exception> errors, ClusterConfig cluster)

--- a/src/ReverseProxy/Service/Proxy/Infrastructure/ProxyHttpClientFactory.cs
+++ b/src/ReverseProxy/Service/Proxy/Infrastructure/ProxyHttpClientFactory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Yarp.ReverseProxy.Abstractions;
@@ -103,7 +104,8 @@ namespace Yarp.ReverseProxy.Service.Proxy.Infrastructure
 
             if (newConfig.RequestHeaderEncoding != null)
             {
-                handler.RequestHeaderEncodingSelector = (_, _) => newConfig.RequestHeaderEncoding;
+                var encoding = Encoding.GetEncoding(newConfig.RequestHeaderEncoding);
+                handler.RequestHeaderEncodingSelector = (_, _) => encoding;
             }
 #endif
             var webProxy = TryCreateWebProxy(newConfig.WebProxy);

--- a/test/ReverseProxy.FunctionalTests/Common/TestEnvironment.cs
+++ b/test/ReverseProxy.FunctionalTests/Common/TestEnvironment.cs
@@ -104,7 +104,7 @@ namespace Yarp.ReverseProxy.Common
                         {
                             DangerousAcceptAnyServerCertificate = useHttps,
 #if NET
-                            RequestHeaderEncoding = requestHeaderEncoding,
+                            RequestHeaderEncoding = requestHeaderEncoding?.WebName,
 #endif
                         }
                     };

--- a/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/Util/LabelsParserTests.cs
+++ b/test/ReverseProxy.ServiceFabric.Tests/ServiceDiscovery/Util/LabelsParserTests.cs
@@ -111,7 +111,7 @@ namespace Yarp.ReverseProxy.ServiceFabric.Tests
                     DangerousAcceptAnyServerCertificate = true,
 #if NET
                     EnableMultipleHttp2Connections = false,
-                    RequestHeaderEncoding = Encoding.GetEncoding("utf-8"),
+                    RequestHeaderEncoding = "utf-8",
 #endif
                     MaxConnectionsPerServer = 1000,
                     SslProtocols = SslProtocols.Tls12,

--- a/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/ClusterTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/ClusterTests.cs
@@ -74,7 +74,7 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
                     DangerousAcceptAnyServerCertificate = true,
                     ActivityContextHeaders = ActivityContextHeaders.CorrelationContext,
 #if NET
-                    RequestHeaderEncoding = Encoding.UTF8
+                    RequestHeaderEncoding = Encoding.UTF8.WebName
 #endif
                 },
                 HttpRequest = new RequestProxyConfig
@@ -144,7 +144,7 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
                     DangerousAcceptAnyServerCertificate = true,
                     ActivityContextHeaders = ActivityContextHeaders.CorrelationContext,
 #if NET
-                    RequestHeaderEncoding = Encoding.UTF8
+                    RequestHeaderEncoding = Encoding.UTF8.WebName
 #endif
                 },
                 HttpRequest = new RequestProxyConfig

--- a/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/ProxyHttpClientOptionsTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/ProxyHttpClientOptionsTests.cs
@@ -22,7 +22,7 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
                 MaxConnectionsPerServer = 20,
                 WebProxy = new WebProxyConfig() { Address = new Uri("http://localhost:8080"), BypassOnLocal = true, UseDefaultCredentials = true },
 #if NET
-                RequestHeaderEncoding = Encoding.UTF8
+                RequestHeaderEncoding = Encoding.UTF8.WebName
 #endif
             };
 
@@ -34,7 +34,7 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
                 MaxConnectionsPerServer = 20,
                 WebProxy = new WebProxyConfig() { Address = new Uri("http://localhost:8080"), BypassOnLocal = true, UseDefaultCredentials = true },
 #if NET
-                RequestHeaderEncoding = Encoding.UTF8
+                RequestHeaderEncoding = Encoding.UTF8.WebName
 #endif
             };
 
@@ -55,7 +55,7 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
                 ClientCertificate = TestResources.GetTestCertificate(),
                 MaxConnectionsPerServer = 20,
 #if NET
-                RequestHeaderEncoding = Encoding.UTF8
+                RequestHeaderEncoding = Encoding.UTF8.WebName
 #endif
             };
 
@@ -66,7 +66,7 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
                 ClientCertificate = TestResources.GetTestCertificate(),
                 MaxConnectionsPerServer = 20,
 #if NET
-                RequestHeaderEncoding = Encoding.Latin1
+                RequestHeaderEncoding = Encoding.Latin1.WebName
 #endif
             };
 

--- a/test/ReverseProxy.Tests/Configuration/ConfigurationConfigProviderTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigurationConfigProviderTests.cs
@@ -606,7 +606,7 @@ namespace Yarp.ReverseProxy.Configuration
             Assert.Equal(cluster1.HttpClient.MaxConnectionsPerServer, abstractCluster1.HttpClient.MaxConnectionsPerServer);
 #if NET
             Assert.Equal(cluster1.HttpClient.EnableMultipleHttp2Connections, abstractCluster1.HttpClient.EnableMultipleHttp2Connections);
-            Assert.Equal(Encoding.UTF8, abstractCluster1.HttpClient.RequestHeaderEncoding);
+            Assert.Equal(Encoding.UTF8.WebName, abstractCluster1.HttpClient.RequestHeaderEncoding);
 #endif
             Assert.Equal(cluster1.HttpClient.ActivityContextHeaders, abstractCluster1.HttpClient.ActivityContextHeaders);
             Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, abstractCluster1.HttpClient.SslProtocols);

--- a/test/ReverseProxy.Tests/Service/Config/ConfigValidatorTests.cs
+++ b/test/ReverseProxy.Tests/Service/Config/ConfigValidatorTests.cs
@@ -848,5 +848,47 @@ namespace Yarp.ReverseProxy.Service.Tests
             Assert.Contains(expectedError, errors[0].Message);
             Assert.IsType<ArgumentException>(errors[0]);
         }
+#if NET
+        [Fact]
+        public async Task HttpClient_HeaderEncoding_Valid()
+        {
+            var services = CreateServices();
+            var validator = services.GetRequiredService<IConfigValidator>();
+
+            var cluster = new ClusterConfig
+            {
+                ClusterId = "cluster1",
+                HttpClient = new HttpClientConfig
+                {
+                    RequestHeaderEncoding = "utf-8"
+                }
+            };
+
+            var errors = await validator.ValidateClusterAsync(cluster);
+
+            Assert.Equal(0, errors.Count);
+        }
+
+        [Fact]
+        public async Task HttpClient_HeaderEncoding_Invalid()
+        {
+            var services = CreateServices();
+            var validator = services.GetRequiredService<IConfigValidator>();
+
+            var cluster = new ClusterConfig
+            {
+                ClusterId = "cluster1",
+                HttpClient = new HttpClientConfig
+                {
+                    RequestHeaderEncoding = "base64"
+                }
+            };
+
+            var errors = await validator.ValidateClusterAsync(cluster);
+
+            Assert.Equal(1, errors.Count);
+            Assert.Equal("Invalid header encoding 'base64'.", errors[0].Message);
+        }
+#endif
     }
 }

--- a/test/ReverseProxy.Tests/Service/Management/ProxyConfigManagerTests.cs
+++ b/test/ReverseProxy.Tests/Service/Management/ProxyConfigManagerTests.cs
@@ -164,7 +164,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
                     MaxConnectionsPerServer = 10,
                     ClientCertificate = clientCertificate,
 #if NET
-                    RequestHeaderEncoding = Encoding.UTF8
+                    RequestHeaderEncoding = Encoding.UTF8.WebName
 #endif
                 }
             };
@@ -191,7 +191,7 @@ namespace Yarp.ReverseProxy.Service.Management.Tests
             Assert.Equal(10, clusterModel.Config.HttpClient.MaxConnectionsPerServer);
             Assert.Same(clientCertificate, clusterModel.Config.HttpClient.ClientCertificate);
 #if NET
-            Assert.Equal(Encoding.UTF8, clusterModel.Config.HttpClient.RequestHeaderEncoding);
+            Assert.Equal(Encoding.UTF8.WebName, clusterModel.Config.HttpClient.RequestHeaderEncoding);
 #endif
 
             var handler = Proxy.Tests.ProxyHttpClientFactoryTests.GetHandler(clusterModel.HttpClient);

--- a/test/ReverseProxy.Tests/Service/Proxy/Infrastructure/ProxyHttpClientFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/Infrastructure/ProxyHttpClientFactoryTests.cs
@@ -149,7 +149,7 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
             var factory = new ProxyHttpClientFactory(Mock<ILogger<ProxyHttpClientFactory>>().Object);
             var options = new HttpClientConfig
             {
-                RequestHeaderEncoding = Encoding.Latin1
+                RequestHeaderEncoding = Encoding.Latin1.WebName
             };
             var client = factory.CreateClient(new ProxyHttpClientContext { NewConfig = options });
 
@@ -176,7 +176,7 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
                 MaxConnectionsPerServer = 10,
                 ActivityContextHeaders = ActivityContextHeaders.CorrelationContext,
 #if NET
-                RequestHeaderEncoding = Encoding.Latin1,
+                RequestHeaderEncoding = Encoding.Latin1.WebName,
 #endif
             };
             var newOptions = oldOptions with { }; // Clone
@@ -442,7 +442,7 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
                         ClientCertificate = null,
                         MaxConnectionsPerServer = 10,
                         ActivityContextHeaders = ActivityContextHeaders.None,
-                        RequestHeaderEncoding = Encoding.UTF8,
+                        RequestHeaderEncoding = Encoding.UTF8.WebName,
                     },
                 },
                 new object[] {
@@ -453,7 +453,7 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
                         ClientCertificate = null,
                         MaxConnectionsPerServer = 10,
                         ActivityContextHeaders = ActivityContextHeaders.None,
-                        RequestHeaderEncoding = Encoding.UTF8,
+                        RequestHeaderEncoding = Encoding.UTF8.WebName,
                     },
                     new HttpClientConfig
                     {
@@ -462,7 +462,7 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
                         ClientCertificate = null,
                         MaxConnectionsPerServer = 10,
                         ActivityContextHeaders = ActivityContextHeaders.None,
-                        RequestHeaderEncoding = Encoding.Latin1,
+                        RequestHeaderEncoding = Encoding.Latin1.WebName,
                     },
                 }
 #endif


### PR DESCRIPTION
Contributes to #352

We have multiple providers that use System.Text.Json to serialize the config model across processes. The Encoding type doesn't serialize, so I've changed the config model to flow the encoding by name and resolve it to an instance later.
