### PR TITLE
Add json serialization tests

### DIFF
--- a/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/ClusterTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/ClusterDiscovery/Contract/ClusterTests.cs
@@ -3,9 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Net.Http;
 using System.Security.Authentication;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Xunit;
 using Yarp.ReverseProxy.Service.LoadBalancing;
 using Yarp.ReverseProxy.Service.Proxy;
@@ -314,6 +317,149 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
             var equals = config1.Equals(null);
 
             Assert.False(equals);
+        }
+
+        [Fact]
+        public void Cluster_CanBeJsonSerialized()
+        {
+            var cluster1 = new ClusterConfig
+            {
+                ClusterId = "cluster1",
+                LoadBalancingPolicy = LoadBalancingPolicies.Random,
+                SessionAffinity = new SessionAffinityConfig
+                {
+                    Enabled = true,
+                    FailurePolicy = "Return503Error",
+                    Mode = "Cookie",
+                    AffinityKeyName = "key1",
+                    Cookie = new SessionAffinityCookieConfig
+                    {
+                        Domain = "domain",
+                        Expiration = TimeSpan.FromDays(1),
+                        HttpOnly = true,
+                        IsEssential = true,
+                        MaxAge = TimeSpan.FromHours(1),
+                        Path = "/",
+                        SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Unspecified,
+                        SecurePolicy = Microsoft.AspNetCore.Http.CookieSecurePolicy.None
+                    }
+                },
+                HealthCheck = new HealthCheckConfig
+                {
+                    Passive = new PassiveHealthCheckConfig
+                    {
+                        Enabled = true,
+                        Policy = "FailureRate",
+                        ReactivationPeriod = TimeSpan.FromMinutes(5)
+                    },
+                    Active = new ActiveHealthCheckConfig
+                    {
+                        Enabled = true,
+                        Interval = TimeSpan.FromSeconds(4),
+                        Timeout = TimeSpan.FromSeconds(6),
+                        Policy = "Any5xxResponse",
+                        Path = "healthCheckPath"
+                    }
+                },
+                HttpClient = new HttpClientConfig
+                {
+#if NET
+                    EnableMultipleHttp2Connections = true,
+#endif
+                    SslProtocols = SslProtocols.Tls11 | SslProtocols.Tls12,
+                    MaxConnectionsPerServer = 10,
+                    DangerousAcceptAnyServerCertificate = true,
+                    ActivityContextHeaders = ActivityContextHeaders.CorrelationContext,
+                    WebProxy = new WebProxyConfig
+                    {
+                        Address = new Uri("http://proxy"),
+                        BypassOnLocal = false,
+                        UseDefaultCredentials = false,
+                    }
+                },
+                HttpRequest = new RequestProxyConfig
+                {
+                    Timeout = TimeSpan.FromSeconds(60),
+                    Version = Version.Parse("1.0"),
+#if NET
+                    VersionPolicy = HttpVersionPolicy.RequestVersionExact,
+#endif
+                },
+                Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
+                {
+                    {
+                        "destinationA",
+                        new DestinationConfig
+                        {
+                            Address = "https://localhost:10000/destA",
+                            Health = "https://localhost:20000/destA",
+                            Metadata = new Dictionary<string, string> { { "destA-K1", "destA-V1" }, { "destA-K2", "destA-V2" } }
+                        }
+                    },
+                    {
+                        "destinationB",
+                        new DestinationConfig
+                        {
+                            Address = "https://localhost:10000/destB",
+                            Health = "https://localhost:20000/destB",
+                            Metadata = new Dictionary<string, string> { { "destB-K1", "destB-V1" }, { "destB-K2", "destB-V2" } }
+                        }
+                    }
+                },
+                Metadata = new Dictionary<string, string> { { "cluster1-K1", "cluster1-V1" }, { "cluster1-K2", "cluster1-V2" } }
+            };
+
+            var options = new JsonSerializerOptions
+            {
+#if !NET6_0_OR_GREATER
+                Converters =
+                {
+                    // TimeSpans https://github.com/dotnet/runtime/issues/29932
+                    new TimeSpanConverter(),
+                    // Version https://github.com/dotnet/runtime/pull/41384
+                    new VersionConverter()
+                }
+#endif
+            };
+            var json = JsonSerializer.Serialize(cluster1, options);
+            var cluster2 = JsonSerializer.Deserialize<ClusterConfig>(json, options);
+
+            Assert.Equal(cluster1.Destinations, cluster2.Destinations);
+            Assert.Equal(cluster1.HealthCheck.Active, cluster2.HealthCheck.Active);
+            Assert.Equal(cluster1.HealthCheck.Passive, cluster2.HealthCheck.Passive);
+            Assert.Equal(cluster1.HealthCheck, cluster2.HealthCheck);
+            Assert.Equal(cluster1.HttpClient, cluster2.HttpClient);
+            Assert.Equal(cluster1.HttpRequest, cluster2.HttpRequest);
+            Assert.Equal(cluster1.Metadata, cluster2.Metadata);
+            Assert.Equal(cluster1.SessionAffinity, cluster2.SessionAffinity);
+            Assert.Equal(cluster1, cluster2);
+        }
+
+        public class TimeSpanConverter : JsonConverter<TimeSpan>
+        {
+            public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                return TimeSpan.Parse(reader.GetString(), CultureInfo.InvariantCulture);
+            }
+
+            public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options)
+            {
+                writer.WriteStringValue(value.ToString(format: null, CultureInfo.InvariantCulture));
+            }
+        }
+
+        public class VersionConverter : JsonConverter<Version>
+        {
+            public override Version Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                var versionString = reader.GetString();
+                return Version.Parse(versionString);
+            }
+
+            public override void Write(Utf8JsonWriter writer, Version value, JsonSerializerOptions options)
+            {
+                writer.WriteStringValue(value.ToString());
+            }
         }
     }
 }

--- a/test/ReverseProxy.Tests/Abstractions/RouteDiscovery/Contract/ProxyRouteTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/RouteDiscovery/Contract/ProxyRouteTests.cs
@@ -129,7 +129,7 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
         }
 
         [Fact]
-        public void RouteConfig_CanBeJsonSerialzied()
+        public void RouteConfig_CanBeJsonSerialized()
         {
             var route1 = new RouteConfig()
             {

--- a/test/ReverseProxy.Tests/Abstractions/RouteDiscovery/Contract/ProxyRouteTests.cs
+++ b/test/ReverseProxy.Tests/Abstractions/RouteDiscovery/Contract/ProxyRouteTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Text.Json;
 using Xunit;
 
 namespace Yarp.ReverseProxy.Abstractions.Tests
@@ -125,6 +126,52 @@ namespace Yarp.ReverseProxy.Abstractions.Tests
         public void Equals_Null_False()
         {
             Assert.False(new RouteConfig().Equals(null));
+        }
+
+        [Fact]
+        public void RouteConfig_CanBeJsonSerialzied()
+        {
+            var route1 = new RouteConfig()
+            {
+                AuthorizationPolicy = "a",
+                ClusterId = "c",
+                CorsPolicy = "co",
+                Match = new RouteMatch()
+                {
+                    Headers = new[]
+                    {
+                        new RouteHeader()
+                        {
+                            Name = "Hi",
+                            Values = new[] { "v1", "v2" },
+                            IsCaseSensitive = true,
+                            Mode = HeaderMatchMode.HeaderPrefix,
+                        }
+                    },
+                    Hosts = new[] { "foo:90" },
+                    Methods = new[] { "GET", "POST" },
+                    Path = "/p",
+                },
+                Metadata = new Dictionary<string, string>()
+                {
+                    { "m", "m1" }
+                },
+                Transforms = new[]
+                {
+                    new Dictionary<string, string>
+                    {
+                        { "key", "value" },
+                        { "key1", "" }
+                    }
+                },
+                Order = 1,
+                RouteId = "R",
+            };
+
+            var json = JsonSerializer.Serialize(route1);
+            var route2 = JsonSerializer.Deserialize<RouteConfig>(json);
+
+            Assert.Equal(route1, route2);
         }
     }
 }


### PR DESCRIPTION
Fixes #352 By adding regression tests.

After #995 (Encoding) and #994 (X509Certificate) were resolved the only types left in the config model that can't be deserialized by default are TimeSpan and Version. These are both being fixed in .NET 6 and have easy workarounds so I'm content to leave them.

~~Marking as draft until I can include the new entries from #997 (Session Affinity cookies).~~