### PR TITLE
Mark the ServiceFabric package as non-shipping

### DIFF
--- a/src/ReverseProxy.ServiceFabric/Yarp.ReverseProxy.ServiceFabric.csproj
+++ b/src/ReverseProxy.ServiceFabric/Yarp.ReverseProxy.ServiceFabric.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Yarp.ReverseProxy.ServiceFabric</RootNamespace>
+    <IsPackable>$('System.TeamProject') != 'internal'</IsPackable>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 


### PR DESCRIPTION
We don't plan to ship the SF package with 1.0 so I've marked it as non-packable like we did for k8. We'll revisit post-1.0.

Downside: We won't ship any more previews of this package in the meantime.

Alternatives:
- Continue to ship previews and only disable this for the final 1.0 release.
- Categorize packages such that the ones we do want for 1.0 get a final release and the others stay on previews (how?).

Thoughts?