### PR TITLE
Enable nullable on TelemetryConsumption

### DIFF
--- a/src/ReverseProxy.TelemetryConsumption/EventListenerService.cs
+++ b/src/ReverseProxy.TelemetryConsumption/EventListenerService.cs
@@ -17,10 +17,10 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
         protected abstract string EventSourceName { get; }
 
         protected readonly ILogger<TService> Logger;
-        protected readonly TMetricsConsumer[] MetricsConsumers;
-        protected readonly TTelemetryConsumer[] TelemetryConsumers;
+        protected readonly TMetricsConsumer[]? MetricsConsumers;
+        protected readonly TTelemetryConsumer[]? TelemetryConsumers;
 
-        private EventSource _eventSource;
+        private EventSource? _eventSource;
         private readonly object _syncObject = new();
         private readonly bool _initialized;
 
@@ -54,9 +54,9 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
 
             lock (_syncObject)
             {
-                if (_eventSource is not null)
+                if (_eventSource is EventSource eventSource)
                 {
-                    EnableEventSource();
+                    EnableEventSource(eventSource);
                 }
 
                 _initialized = true;
@@ -74,13 +74,13 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                     if (_initialized)
                     {
                         // Ctor already finished - enable the EventSource here
-                        EnableEventSource();
+                        EnableEventSource(eventSource);
                     }
                 }
             }
         }
 
-        private void EnableEventSource()
+        private void EnableEventSource(EventSource eventSource)
         {
             var enableEvents = TelemetryConsumers is not null;
             var enableMetrics = MetricsConsumers is not null;
@@ -91,10 +91,9 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
             }
 
             var eventLevel = enableEvents ? EventLevel.Verbose : EventLevel.Critical;
-            var arguments = enableMetrics ? new Dictionary<string, string> { { "EventCounterIntervalSec", MetricsOptions.Interval.TotalSeconds.ToString() } } : null;
+            var arguments = enableMetrics ? new Dictionary<string, string?> { { "EventCounterIntervalSec", MetricsOptions.Interval.TotalSeconds.ToString() } } : null;
 
-            EnableEvents(_eventSource, eventLevel, EventKeywords.None, arguments);
-            _eventSource = null;
+            EnableEvents(eventSource, eventLevel, EventKeywords.None, arguments);
         }
 
         public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/src/ReverseProxy.TelemetryConsumption/Http/HttpEventListenerService.cs
+++ b/src/ReverseProxy.TelemetryConsumption/Http/HttpEventListenerService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Net.Http;
@@ -12,7 +13,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
 {
     internal sealed class HttpEventListenerService : EventListenerService<HttpEventListenerService, IHttpTelemetryConsumer, IHttpMetricsConsumer>
     {
-        private HttpMetrics _previousMetrics;
+        private HttpMetrics? _previousMetrics;
         private HttpMetrics _currentMetrics = new();
         private int _eventCountersCount;
 
@@ -42,7 +43,10 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 return;
             }
 
-            var payload = eventData.Payload;
+#pragma warning disable IDE0007 // Use implicit type
+            // Explicit type here to drop the object? signature of payload elements
+            ReadOnlyCollection<object> payload = eventData.Payload!;
+#pragma warning restore IDE0007 // Use implicit type
 
             switch (eventData.EventId)
             {
@@ -182,8 +186,8 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 return;
             }
 
-            Debug.Assert(eventData.EventName == "EventCounters" && eventData.Payload.Count == 1);
-            var counters = (IDictionary<string, object>)eventData.Payload[0];
+            Debug.Assert(eventData.EventName == "EventCounters" && eventData.Payload!.Count == 1);
+            var counters = (IDictionary<string, object>)eventData.Payload[0]!;
 
             if (!counters.TryGetValue("Mean", out var valueObj))
             {

--- a/src/ReverseProxy.TelemetryConsumption/Kestrel/KestrelEventListenerService.cs
+++ b/src/ReverseProxy.TelemetryConsumption/Kestrel/KestrelEventListenerService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using Microsoft.Extensions.Logging;
@@ -16,7 +17,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
     internal sealed class KestrelEventListenerService : EventListenerService<KestrelEventListenerService, IKestrelTelemetryConsumer, IKestrelMetricsConsumer>
     {
 #if NET
-        private KestrelMetrics _previousMetrics;
+        private KestrelMetrics? _previousMetrics;
         private KestrelMetrics _currentMetrics = new();
         private int _eventCountersCount;
 #endif
@@ -49,7 +50,10 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 return;
             }
 
-            var payload = eventData.Payload;
+#pragma warning disable IDE0007 // Use implicit type
+            // Explicit type here to drop the object? signature of payload elements
+            ReadOnlyCollection<object> payload = eventData.Payload!;
+#pragma warning restore IDE0007 // Use implicit type
 
 #if NET
             switch (eventData.EventId)
@@ -122,8 +126,8 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 return;
             }
 
-            Debug.Assert(eventData.EventName == "EventCounters" && eventData.Payload.Count == 1);
-            var counters = (IDictionary<string, object>)eventData.Payload[0];
+            Debug.Assert(eventData.EventName == "EventCounters" && eventData.Payload!.Count == 1);
+            var counters = (IDictionary<string, object>)eventData.Payload[0]!;
 
             if (!counters.TryGetValue("Mean", out var valueObj))
             {

--- a/src/ReverseProxy.TelemetryConsumption/NameResolution/NameResolutionEventListenerService.cs
+++ b/src/ReverseProxy.TelemetryConsumption/NameResolution/NameResolutionEventListenerService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using Microsoft.Extensions.Logging;
@@ -11,7 +12,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
 {
     internal sealed class NameResolutionEventListenerService : EventListenerService<NameResolutionEventListenerService, INameResolutionTelemetryConsumer, INameResolutionMetricsConsumer>
     {
-        private NameResolutionMetrics _previousMetrics;
+        private NameResolutionMetrics? _previousMetrics;
         private NameResolutionMetrics _currentMetrics = new();
         private int _eventCountersCount;
 
@@ -41,7 +42,10 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 return;
             }
 
-            var payload = eventData.Payload;
+#pragma warning disable IDE0007 // Use implicit type
+            // Explicit type here to drop the object? signature of payload elements
+            ReadOnlyCollection<object> payload = eventData.Payload!;
+#pragma warning restore IDE0007 // Use implicit type
 
             switch (eventData.EventId)
             {
@@ -85,8 +89,8 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 return;
             }
 
-            Debug.Assert(eventData.EventName == "EventCounters" && eventData.Payload.Count == 1);
-            var counters = (IDictionary<string, object>)eventData.Payload[0];
+            Debug.Assert(eventData.EventName == "EventCounters" && eventData.Payload!.Count == 1);
+            var counters = (IDictionary<string, object>)eventData.Payload[0]!;
 
             if (!counters.TryGetValue("Mean", out var valueObj))
             {

--- a/src/ReverseProxy.TelemetryConsumption/NetSecurity/NetSecurityEventListenerService.cs
+++ b/src/ReverseProxy.TelemetryConsumption/NetSecurity/NetSecurityEventListenerService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Security.Authentication;
@@ -12,7 +13,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
 {
     internal sealed class NetSecurityEventListenerService : EventListenerService<NetSecurityEventListenerService, INetSecurityTelemetryConsumer, INetSecurityMetricsConsumer>
     {
-        private NetSecurityMetrics _previousMetrics;
+        private NetSecurityMetrics? _previousMetrics;
         private NetSecurityMetrics _currentMetrics = new();
         private int _eventCountersCount;
 
@@ -42,7 +43,10 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 return;
             }
 
-            var payload = eventData.Payload;
+#pragma warning disable IDE0007 // Use implicit type
+            // Explicit type here to drop the object? signature of payload elements
+            ReadOnlyCollection<object> payload = eventData.Payload!;
+#pragma warning restore IDE0007 // Use implicit type
 
             switch (eventData.EventId)
             {
@@ -91,8 +95,8 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 return;
             }
 
-            Debug.Assert(eventData.EventName == "EventCounters" && eventData.Payload.Count == 1);
-            var counters = (IDictionary<string, object>)eventData.Payload[0];
+            Debug.Assert(eventData.EventName == "EventCounters" && eventData.Payload!.Count == 1);
+            var counters = (IDictionary<string, object>)eventData.Payload[0]!;
 
             if (!counters.TryGetValue("Mean", out var valueObj))
             {

--- a/src/ReverseProxy.TelemetryConsumption/Proxy/ProxyEventListenerService.cs
+++ b/src/ReverseProxy.TelemetryConsumption/Proxy/ProxyEventListenerService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using Microsoft.Extensions.Logging;
@@ -12,7 +13,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
 {
     internal sealed class ProxyEventListenerService : EventListenerService<ProxyEventListenerService, IProxyTelemetryConsumer, IProxyMetricsConsumer>
     {
-        private ProxyMetrics _previousMetrics;
+        private ProxyMetrics? _previousMetrics;
         private ProxyMetrics _currentMetrics = new();
         private int _eventCountersCount;
 
@@ -42,7 +43,10 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 return;
             }
 
-            var payload = eventData.Payload;
+#pragma warning disable IDE0007 // Use implicit type
+            // Explicit type here to drop the object? signature of payload elements
+            ReadOnlyCollection<object> payload = eventData.Payload!;
+#pragma warning restore IDE0007 // Use implicit type
 
             switch (eventData.EventId)
             {
@@ -143,8 +147,8 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 return;
             }
 
-            Debug.Assert(eventData.EventName == "EventCounters" && eventData.Payload.Count == 1);
-            var counters = (IDictionary<string, object>)eventData.Payload[0];
+            Debug.Assert(eventData.EventName == "EventCounters" && eventData.Payload!.Count == 1);
+            var counters = (IDictionary<string, object>)eventData.Payload[0]!;
 
             if (!counters.TryGetValue("Mean", out var valueObj))
             {

--- a/src/ReverseProxy.TelemetryConsumption/Sockets/SocketsEventListenerService.cs
+++ b/src/ReverseProxy.TelemetryConsumption/Sockets/SocketsEventListenerService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Net.Sockets;
@@ -12,7 +13,7 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
 {
     internal sealed class SocketsEventListenerService : EventListenerService<SocketsEventListenerService, ISocketsTelemetryConsumer, ISocketsMetricsConsumer>
     {
-        private SocketsMetrics _previousMetrics;
+        private SocketsMetrics? _previousMetrics;
         private SocketsMetrics _currentMetrics = new();
         private int _eventCountersCount;
 
@@ -42,7 +43,10 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 return;
             }
 
-            var payload = eventData.Payload;
+#pragma warning disable IDE0007 // Use implicit type
+            // Explicit type here to drop the object? signature of payload elements
+            ReadOnlyCollection<object> payload = eventData.Payload!;
+#pragma warning restore IDE0007 // Use implicit type
 
             switch (eventData.EventId)
             {
@@ -88,8 +92,8 @@ namespace Yarp.ReverseProxy.Telemetry.Consumption
                 return;
             }
 
-            Debug.Assert(eventData.EventName == "EventCounters" && eventData.Payload.Count == 1);
-            var counters = (IDictionary<string, object>)eventData.Payload[0];
+            Debug.Assert(eventData.EventName == "EventCounters" && eventData.Payload!.Count == 1);
+            var counters = (IDictionary<string, object>)eventData.Payload[0]!;
 
             if (!counters.TryGetValue("Mean", out var valueObj))
             {

--- a/src/ReverseProxy.TelemetryConsumption/Yarp.ReverseProxy.Telemetry.Consumption.csproj
+++ b/src/ReverseProxy.TelemetryConsumption/Yarp.ReverseProxy.Telemetry.Consumption.csproj
@@ -6,6 +6,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Yarp.ReverseProxy.Telemetry.Consumption</RootNamespace>
     <LangVersion>9.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Public API stays the same (all non-null)

Contributes to #654