### PR TITLE
Set default User-Agent for active health check requests

### DIFF
--- a/src/ReverseProxy/Service/HealthChecks/ActiveHealthCheckMonitor.cs
+++ b/src/ReverseProxy/Service/HealthChecks/ActiveHealthCheckMonitor.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Yarp.ReverseProxy.Abstractions;
 using Yarp.ReverseProxy.RuntimeModel;
 using Yarp.ReverseProxy.Service.Management;
 using Yarp.ReverseProxy.Utilities;
@@ -13,6 +12,7 @@ using System.Net.Http;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Net.Http.Headers;
 
 namespace Yarp.ReverseProxy.Service.HealthChecks
 {
@@ -127,6 +127,11 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                         var request = _probingRequestFactory.CreateRequest(clusterModel, destination.Model);
 
                         Log.SendingHealthProbeToEndpointOfDestination(_logger, request.RequestUri, destination.DestinationId, cluster.ClusterId);
+
+                        if (!request.Headers.Contains(HeaderNames.UserAgent))
+                        {
+                            request.Headers.Add(HeaderNames.UserAgent, "YARP Active Health Check Monitor");
+                        }
 
                         probeTasks.Add((clusterModel.HttpClient.SendAsync(request, cts.Token), cts));
                     }

--- a/src/ReverseProxy/Service/HealthChecks/ActiveHealthCheckMonitor.cs
+++ b/src/ReverseProxy/Service/HealthChecks/ActiveHealthCheckMonitor.cs
@@ -13,11 +13,15 @@ using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Net.Http.Headers;
+using System.Reflection;
 
 namespace Yarp.ReverseProxy.Service.HealthChecks
 {
     internal partial class ActiveHealthCheckMonitor : IActiveHealthCheckMonitor, IClusterChangeListener, IDisposable
     {
+        private static readonly string _version = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
+        private static readonly string _defaultUserAgent = $"YARP/{_version.Split('+')[0]} (Active Health Check Monitor)";
+
         private readonly ActiveHealthCheckMonitorOptions _monitorOptions;
         private readonly IDictionary<string, IActiveHealthCheckPolicy> _policies;
         private readonly IProbingRequestFactory _probingRequestFactory;
@@ -130,7 +134,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
 
                         if (!request.Headers.Contains(HeaderNames.UserAgent))
                         {
-                            request.Headers.Add(HeaderNames.UserAgent, "YARP Active Health Check Monitor");
+                            request.Headers.Add(HeaderNames.UserAgent, _defaultUserAgent);
                         }
 
                         probeTasks.Add((clusterModel.HttpClient.SendAsync(request, cts.Token), cts));

--- a/src/ReverseProxy/Service/HealthChecks/ActiveHealthCheckMonitor.cs
+++ b/src/ReverseProxy/Service/HealthChecks/ActiveHealthCheckMonitor.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Yarp.ReverseProxy.Abstractions;
 using Yarp.ReverseProxy.RuntimeModel;
 using Yarp.ReverseProxy.Service.Management;
 using Yarp.ReverseProxy.Utilities;
@@ -12,16 +13,11 @@ using System.Net.Http;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Net.Http.Headers;
-using System.Reflection;
 
 namespace Yarp.ReverseProxy.Service.HealthChecks
 {
     internal partial class ActiveHealthCheckMonitor : IActiveHealthCheckMonitor, IClusterChangeListener, IDisposable
     {
-        private static readonly string _version = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
-        private static readonly string _defaultUserAgent = $"YARP/{_version.Split('+')[0]} (Active Health Check Monitor)";
-
         private readonly ActiveHealthCheckMonitorOptions _monitorOptions;
         private readonly IDictionary<string, IActiveHealthCheckPolicy> _policies;
         private readonly IProbingRequestFactory _probingRequestFactory;
@@ -131,11 +127,6 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
                         var request = _probingRequestFactory.CreateRequest(clusterModel, destination.Model);
 
                         Log.SendingHealthProbeToEndpointOfDestination(_logger, request.RequestUri, destination.DestinationId, cluster.ClusterId);
-
-                        if (!request.Headers.Contains(HeaderNames.UserAgent))
-                        {
-                            request.Headers.Add(HeaderNames.UserAgent, _defaultUserAgent);
-                        }
 
                         probeTasks.Add((clusterModel.HttpClient.SendAsync(request, cts.Token), cts));
                     }

--- a/src/ReverseProxy/Service/HealthChecks/DefaultProbingRequestFactory.cs
+++ b/src/ReverseProxy/Service/HealthChecks/DefaultProbingRequestFactory.cs
@@ -3,26 +3,36 @@
 
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.Net.Http.Headers;
 using Yarp.ReverseProxy.RuntimeModel;
 
 namespace Yarp.ReverseProxy.Service.HealthChecks
 {
     internal sealed class DefaultProbingRequestFactory : IProbingRequestFactory
     {
+        private static readonly string? _version = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        private static readonly string _defaultUserAgent = $"YARP{(string.IsNullOrEmpty(_version) ? "" : $"/{_version.Split('+')[0]}")} (Active Health Check Monitor)";
+
         public HttpRequestMessage CreateRequest(ClusterModel cluster, DestinationModel destination)
         {
             var probeAddress = !string.IsNullOrEmpty(destination.Config.Health) ? destination.Config.Health : destination.Config.Address;
             var probePath = cluster.Config.HealthCheck?.Active?.Path;
             UriHelper.FromAbsolute(probeAddress, out var destinationScheme, out var destinationHost, out var destinationPathBase, out _, out _);
             var probeUri = UriHelper.BuildAbsolute(destinationScheme, destinationHost, destinationPathBase, probePath, default);
-            return new HttpRequestMessage(HttpMethod.Get, probeUri)
+
+            var request = new HttpRequestMessage(HttpMethod.Get, probeUri)
             {
                 Version = cluster.Config.HttpRequest?.Version ?? HttpVersion.Version20,
 #if NET
                 VersionPolicy = cluster.Config.HttpRequest?.VersionPolicy ?? HttpVersionPolicy.RequestVersionOrLower
 #endif
             };
+
+            request.Headers.Add(HeaderNames.UserAgent, _defaultUserAgent);
+
+            return request;
         }
     }
 }

--- a/test/ReverseProxy.Tests/Service/HealthChecks/ActiveHealthCheckMonitorTests.cs
+++ b/test/ReverseProxy.Tests/Service/HealthChecks/ActiveHealthCheckMonitorTests.cs
@@ -69,7 +69,7 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             requestFactory.Setup(p => p.CreateRequest(It.IsAny<ClusterModel>(), It.IsAny<DestinationModel>()))
                 .Returns((ClusterModel cluster, DestinationModel destination) =>
                 {
-                    var request = new DefaultProbingRequestFactory().CreateRequest(cluster, destination);
+                    var request = new HttpRequestMessage(HttpMethod.Get, "https://localhost:20000/cluster/api/health/");
                     request.Headers.UserAgent.ParseAdd("FooBar/9001");
                     return request;
                 });
@@ -78,11 +78,11 @@ namespace Yarp.ReverseProxy.Service.HealthChecks
             var monitor = new ActiveHealthCheckMonitor(options, new[] { policy.Object }, requestFactory.Object, new Mock<ITimerFactory>().Object, GetLogger());
 
             var httpClient = GetHttpClient();
-            var cluster = GetClusterInfo("cluster", "policy", true, httpClient.Object);
+            var cluster = GetClusterInfo("cluster", "policy", true, httpClient.Object, destinationCount: 1);
 
             await monitor.CheckHealthAsync(new[] { cluster });
 
-            VerifySentProbeAndResult(cluster, httpClient, policy, new[] { ("https://localhost:20000/cluster/api/health/", 1), ("https://localhost:20001/cluster/api/health/", 1) }, userAgent: @"^FooBar\/9001$");
+            VerifySentProbeAndResult(cluster, httpClient, policy, new[] { ("https://localhost:20000/cluster/api/health/", 1) }, userAgent: @"^FooBar\/9001$");
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #991

Since the user can specify a custom `IProbingRequestFactory`, they can already set a custom `User-Agent` for active health check requests.

Added a test to ensure we don't break that scenario - we only add the default value if one is not already provided.

Currently: `YARP Active Health Check Monitor`