### PR TITLE
Don't drop content-specific headers on requests without a body

### DIFF
--- a/src/ReverseProxy/Service/Proxy/EmptyHttpContent.cs
+++ b/src/ReverseProxy/Service/Proxy/EmptyHttpContent.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Yarp.ReverseProxy.Service.Proxy
+{
+    internal sealed class EmptyHttpContent : HttpContent
+    {
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) => Task.CompletedTask;
+
+#if NET
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken) => Task.CompletedTask;
+#endif
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return true;
+        }
+    }
+}

--- a/src/ReverseProxy/Utilities/RequestUtilities.cs
+++ b/src/ReverseProxy/Utilities/RequestUtilities.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
@@ -147,6 +148,13 @@ namespace Yarp.ReverseProxy.Utilities
                     Debug.Assert(added.GetValueOrDefault(), $"A header was dropped; {headerName}: {string.Join(", ", headerValues)}");
                 }
             }
+
+#if DEBUG
+            if (request.Content is EmptyHttpContent content && content.Headers.TryGetValues(HeaderNames.ContentLength, out var contentLength))
+            {
+                Debug.Assert(contentLength.Single() == "0", "An actual content should have been set");
+            }
+#endif
         }
     }
 }

--- a/src/ReverseProxy/Utilities/RequestUtilities.cs
+++ b/src/ReverseProxy/Utilities/RequestUtilities.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
+using Yarp.ReverseProxy.Service.Proxy;
 
 namespace Yarp.ReverseProxy.Utilities
 {
@@ -36,7 +38,7 @@ namespace Yarp.ReverseProxy.Utilities
             return _headersToExclude.Contains(headerName);
         }
 
-        private static readonly HashSet<string> _headersToExclude = new(StringComparer.OrdinalIgnoreCase)
+        private static readonly HashSet<string> _headersToExclude = new(14, StringComparer.OrdinalIgnoreCase)
         {
             HeaderNames.Connection,
             HeaderNames.TransferEncoding,
@@ -57,6 +59,23 @@ namespace Yarp.ReverseProxy.Utilities
             "Alt-Svc",
 #endif
 
+        };
+
+        // Headers marked as HttpHeaderType.Content in
+        // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Http/src/System/Net/Http/Headers/KnownHeaders.cs
+        private static readonly HashSet<string> _contentHeaders = new(11, StringComparer.OrdinalIgnoreCase)
+        {
+            HeaderNames.Allow,
+            HeaderNames.ContentDisposition,
+            HeaderNames.ContentEncoding,
+            HeaderNames.ContentLanguage,
+            HeaderNames.ContentLength,
+            HeaderNames.ContentLocation,
+            HeaderNames.ContentMD5,
+            HeaderNames.ContentRange,
+            HeaderNames.ContentType,
+            HeaderNames.Expires,
+            HeaderNames.LastModified
         };
 
         /// <summary>
@@ -85,6 +104,8 @@ namespace Yarp.ReverseProxy.Utilities
         // HttpRequestMessage.Headers and HttpRequestMessage.Content.Headers.
         // We don't really care where the proxied headers appear among those 2,
         // as long as they appear in one (and only one, otherwise they would be duplicated).
+        // Some headers may only appear on HttpContentHeaders, in which case we inject
+        // an EmptyHttpContent - dummy 0-length container only used for headers.
         internal static void AddHeader(HttpRequestMessage request, string headerName, StringValues value)
         {
             // HttpClient wrongly uses comma (",") instead of semi-colon (";") as a separator for Cookie headers.
@@ -101,10 +122,14 @@ namespace Yarp.ReverseProxy.Utilities
                 string headerValue = value;
                 if (!request.Headers.TryAddWithoutValidation(headerName, headerValue))
                 {
+                    if (request.Content is null && _contentHeaders.Contains(headerName))
+                    {
+                        request.Content = new EmptyHttpContent();
+                    }
+
                     var added = request.Content?.Headers.TryAddWithoutValidation(headerName, headerValue);
-                    // TODO: Log. Today this assert fails for a POST request with Content-Length: 0 header which is valid.
-                    // https://github.com/microsoft/reverse-proxy/issues/618
-                    // Debug.Assert(added.GetValueOrDefault(), $"A header was dropped; {headerName}: {headerValue}");
+                    // TODO: Log
+                    Debug.Assert(added.GetValueOrDefault(), $"A header was dropped; {headerName}: {headerValue}");
                 }
             }
             else
@@ -112,10 +137,14 @@ namespace Yarp.ReverseProxy.Utilities
                 string[] headerValues = value;
                 if (!request.Headers.TryAddWithoutValidation(headerName, headerValues))
                 {
+                    if (request.Content is null && _contentHeaders.Contains(headerName))
+                    {
+                        request.Content = new EmptyHttpContent();
+                    }
+
                     var added = request.Content?.Headers.TryAddWithoutValidation(headerName, headerValues);
-                    // TODO: Log. Today this assert fails for a POST request with Content-Length: 0 header which is valid.
-                    // https://github.com/microsoft/reverse-proxy/issues/618
-                    // Debug.Assert(added.GetValueOrDefault(), $"A header was dropped; {headerName}: {string.Join(", ", headerValues)}");
+                    // TODO: Log
+                    Debug.Assert(added.GetValueOrDefault(), $"A header was dropped; {headerName}: {string.Join(", ", headerValues)}");
                 }
             }
         }

--- a/test/ReverseProxy.Tests/Service/Proxy/HttpProxyTests.cs
+++ b/test/ReverseProxy.Tests/Service/Proxy/HttpProxyTests.cs
@@ -495,7 +495,7 @@ namespace Yarp.ReverseProxy.Service.Proxy.Tests
                     if (headers.Any())
                     {
                         Assert.NotNull(request.Content);
-                        Assert.Equal("EmptyHttpContent", request.Content.GetType().Name);
+                        Assert.IsType<EmptyHttpContent>(request.Content);
                         Assert.Empty(await request.Content.ReadAsByteArrayAsync());
 
                         foreach (var (key, value) in headers)


### PR DESCRIPTION
Fixes #618

Headers defined as `HttpHeaderType.Content` in [KnownHeaders.cs](https://github.com/dotnet/runtime/blob/c90debb5dc8ee85840bbef1a44b8502ab169f47b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/KnownHeaders.cs#L28-L61) may only be present in the `HttpContentHeaders` collection.
To avoid dropping such headers when there is no request body (e.g. `Content-Length` is 0), we inject a dummy 0-length content object to hold the headers.