### PR TITLE
Only TE:trailers is allowed when proxying from 1.1 to 2 request version

### DIFF
--- a/src/ReverseProxy/Service/Proxy/HttpTransformer.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpTransformer.cs
@@ -43,7 +43,7 @@ namespace Yarp.ReverseProxy.Service.Proxy
                 var headerName = header.Key;
                 var headerValue = header.Value;
                 if (StringValues.IsNullOrEmpty(headerValue)
-                    || RequestUtilities.ShouldSkipRequestHeader(headerName))
+                    || RequestUtilities.ShouldSkipRequestHeader(headerName, httpContext, proxyRequest))
                 {
                     continue;
                 }

--- a/src/ReverseProxy/Service/Proxy/HttpTransformer.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpTransformer.cs
@@ -43,7 +43,7 @@ namespace Yarp.ReverseProxy.Service.Proxy
                 var headerName = header.Key;
                 var headerValue = header.Value;
                 if (StringValues.IsNullOrEmpty(headerValue)
-                    || RequestUtilities.ShouldSkipRequestHeader(headerName, httpContext, proxyRequest))
+                    || RequestUtilities.ShouldSkipRequestHeader(headerName, headerValue, httpContext, proxyRequest))
                 {
                     continue;
                 }

--- a/src/ReverseProxy/Service/Proxy/HttpTransformer.cs
+++ b/src/ReverseProxy/Service/Proxy/HttpTransformer.cs
@@ -43,7 +43,7 @@ namespace Yarp.ReverseProxy.Service.Proxy
                 var headerName = header.Key;
                 var headerValue = header.Value;
                 if (StringValues.IsNullOrEmpty(headerValue)
-                    || RequestUtilities.ShouldSkipRequestHeader(headerName, headerValue, httpContext, proxyRequest))
+                    || RequestUtilities.ShouldSkipRequestHeader(headerName, headerValue, proxyRequest.Version))
                 {
                     continue;
                 }

--- a/src/ReverseProxy/Utilities/ProtocolHelper.cs
+++ b/src/ReverseProxy/Utilities/ProtocolHelper.cs
@@ -20,6 +20,17 @@ namespace Yarp.ReverseProxy
 
         internal const string GrpcContentType = "application/grpc";
 
+        public static bool IsHttp11(string protocol)
+        {
+#if NET
+            return Microsoft.AspNetCore.Http.HttpProtocol.IsHttp11(protocol);
+#elif NETCOREAPP3_1
+            return StringComparer.OrdinalIgnoreCase.Equals("HTTP/1.1", protocol);
+#else
+#error A target framework was added to the project and needs to be added to this condition.
+#endif
+        }
+
         public static bool IsHttp2(string protocol)
         {
 #if NET

--- a/src/ReverseProxy/Utilities/RequestUtilities.cs
+++ b/src/ReverseProxy/Utilities/RequestUtilities.cs
@@ -27,7 +27,7 @@ namespace Yarp.ReverseProxy.Utilities
 
             if (headerName.Equals(HeaderNames.TE, StringComparison.OrdinalIgnoreCase)
                 && ProtocolHelper.IsHttp11(httpContext.Request.Protocol)
-                && proxyRequest.Version == ProtocolHelper.Http11Version
+                && proxyRequest.Version == ProtocolHelper.Http2Version
                 && httpContext.Request.Headers.TryGetValue(HeaderNames.TE, out var teValues))
             {
                 var containsTrailers = false;
@@ -40,10 +40,10 @@ namespace Yarp.ReverseProxy.Utilities
                     else
                     {
                         // Unexpected TE header's value found.
-                        return false;
+                        return true;
                     }
                 }
-                return containsTrailers;
+                return !containsTrailers;
             }
 
             // Filter out HTTP/2 pseudo headers like ":method" and ":path", those go into other fields.

--- a/src/ReverseProxy/Utilities/RequestUtilities.cs
+++ b/src/ReverseProxy/Utilities/RequestUtilities.cs
@@ -18,7 +18,7 @@ namespace Yarp.ReverseProxy.Utilities
     /// </summary>
     public static class RequestUtilities
     {
-        internal static bool ShouldSkipRequestHeader(string headerName, StringValues headerValue, HttpContext httpContext, HttpRequestMessage proxyRequest)
+        internal static bool ShouldSkipRequestHeader(string headerName, StringValues headerValue, Version destinationProtocol)
         {
             if (_headersToExclude.Contains(headerName))
             {
@@ -26,8 +26,7 @@ namespace Yarp.ReverseProxy.Utilities
             }
 
             if (headerName.Equals(HeaderNames.TE, StringComparison.OrdinalIgnoreCase)
-                && ProtocolHelper.IsHttp11(httpContext.Request.Protocol)
-                && proxyRequest.Version == ProtocolHelper.Http2Version)
+                && destinationProtocol == ProtocolHelper.Http2Version)
             {
                 return headerValue.Count != 1 || !string.Equals(headerValue[0], "trailers", StringComparison.OrdinalIgnoreCase);
             }

--- a/src/ReverseProxy/Utilities/RequestUtilities.cs
+++ b/src/ReverseProxy/Utilities/RequestUtilities.cs
@@ -18,7 +18,7 @@ namespace Yarp.ReverseProxy.Utilities
     /// </summary>
     public static class RequestUtilities
     {
-        internal static bool ShouldSkipRequestHeader(string headerName, HttpContext httpContext, HttpRequestMessage proxyRequest)
+        internal static bool ShouldSkipRequestHeader(string headerName, StringValues headerValue, HttpContext httpContext, HttpRequestMessage proxyRequest)
         {
             if (_headersToExclude.Contains(headerName))
             {
@@ -27,23 +27,9 @@ namespace Yarp.ReverseProxy.Utilities
 
             if (headerName.Equals(HeaderNames.TE, StringComparison.OrdinalIgnoreCase)
                 && ProtocolHelper.IsHttp11(httpContext.Request.Protocol)
-                && proxyRequest.Version == ProtocolHelper.Http2Version
-                && httpContext.Request.Headers.TryGetValue(HeaderNames.TE, out var teValues))
+                && proxyRequest.Version == ProtocolHelper.Http2Version)
             {
-                var containsTrailers = false;
-                foreach (var value in teValues)
-                {
-                    if (string.Equals(value, "trailers", StringComparison.OrdinalIgnoreCase))
-                    {
-                        containsTrailers = true;
-                    }
-                    else
-                    {
-                        // Unexpected TE header's value found.
-                        return true;
-                    }
-                }
-                return !containsTrailers;
+                return headerValue.Count != 1 || !string.Equals(headerValue[0], "trailers", StringComparison.OrdinalIgnoreCase);
             }
 
             // Filter out HTTP/2 pseudo headers like ":method" and ":path", those go into other fields.


### PR DESCRIPTION
If the incoming to proxy request has the protocol "HTTP/1.1" and contains the `TE` header whereas the outgoing to downstream request has the protocol "HTTP/2", then `TE` header is proxied only if it has the single `trailers` value, otherwise it's removed.

Fixes #969