### PR TITLE
Using options.HasFlag

### DIFF
--- a/src/ReverseProxy/Utilities/TlsFrameHelper.cs
+++ b/src/ReverseProxy/Utilities/TlsFrameHelper.cs
@@ -107,7 +107,7 @@ namespace Yarp.ReverseProxy.Utilities.Tls
             ApplicationProtocol = 0x2,
             Versions = 0x4,
             CipherSuites = 0x8,
-            All = 0x15,
+            All = 15,
         }
 
         [Flags]

--- a/src/ReverseProxy/Utilities/TlsFrameHelper.cs
+++ b/src/ReverseProxy/Utilities/TlsFrameHelper.cs
@@ -492,7 +492,7 @@ namespace Yarp.ReverseProxy.Utilities.Tls
 
                 ReadOnlySpan<byte> extensionData = extensions.Slice(0, extensionLength);
 
-                if (extensionType == ExtensionType.ServerName && (options.HasFlag(ProcessingOptions.ServerName)))
+                if (extensionType == ExtensionType.ServerName && options.HasFlag(ProcessingOptions.ServerName))
                 {
                     if (!TryGetSniFromServerNameList(extensionData, out string? sni))
                     {
@@ -501,7 +501,7 @@ namespace Yarp.ReverseProxy.Utilities.Tls
 
                     info.TargetName = sni!;
                 }
-                else if (extensionType == ExtensionType.SupportedVersions && (options.HasFlag(ProcessingOptions.Versions)))
+                else if (extensionType == ExtensionType.SupportedVersions && options.HasFlag(ProcessingOptions.Versions))
                 {
                     if (!TryGetSupportedVersionsFromExtension(extensionData, out SslProtocols versions))
                     {
@@ -510,7 +510,7 @@ namespace Yarp.ReverseProxy.Utilities.Tls
 
                     info.SupportedVersions |= versions;
                 }
-                else if (extensionType == ExtensionType.ApplicationProtocols && (options.HasFlag(ProcessingOptions.ApplicationProtocol)))
+                else if (extensionType == ExtensionType.ApplicationProtocols && options.HasFlag(ProcessingOptions.ApplicationProtocol))
                 {
                     if (!TryGetApplicationProtocolsFromExtension(extensionData, out ApplicationProtocolInfo alpn))
                     {

--- a/src/ReverseProxy/Utilities/TlsFrameHelper.cs
+++ b/src/ReverseProxy/Utilities/TlsFrameHelper.cs
@@ -510,7 +510,7 @@ namespace Yarp.ReverseProxy.Utilities.Tls
 
                     info.SupportedVersions |= versions;
                 }
-                else if (extensionType == ExtensionType.ApplicationProtocols && (options.HasFlag(ProcessingOptions.ApplicationProtocol))
+                else if (extensionType == ExtensionType.ApplicationProtocols && options.HasFlag(ProcessingOptions.ApplicationProtocol))
                 {
                     if (!TryGetApplicationProtocolsFromExtension(extensionData, out ApplicationProtocolInfo alpn))
                     {

--- a/src/ReverseProxy/Utilities/TlsFrameHelper.cs
+++ b/src/ReverseProxy/Utilities/TlsFrameHelper.cs
@@ -103,11 +103,11 @@ namespace Yarp.ReverseProxy.Utilities.Tls
         [Flags]
         public enum ProcessingOptions
         {
-            All = 0,
             ServerName = 0x1,
             ApplicationProtocol = 0x2,
             Versions = 0x4,
             CipherSuites = 0x8,
+            All = 0x15,
         }
 
         [Flags]
@@ -510,7 +510,7 @@ namespace Yarp.ReverseProxy.Utilities.Tls
 
                     info.SupportedVersions |= versions;
                 }
-                else if (extensionType == ExtensionType.ApplicationProtocols && options.HasFlag(ProcessingOptions.ApplicationProtocol))
+                else if (extensionType == ExtensionType.ApplicationProtocols && (options.HasFlag(ProcessingOptions.ApplicationProtocol))
                 {
                     if (!TryGetApplicationProtocolsFromExtension(extensionData, out ApplicationProtocolInfo alpn))
                     {

--- a/src/ReverseProxy/Utilities/TlsFrameHelper.cs
+++ b/src/ReverseProxy/Utilities/TlsFrameHelper.cs
@@ -406,7 +406,7 @@ namespace Yarp.ReverseProxy.Utilities.Tls
             // Skip SessionID (max size 32 => size fits in 1 byte)
             p = SkipOpaqueType1(p);
 
-            if (options == ProcessingOptions.All || (options & ProcessingOptions.CipherSuites) == ProcessingOptions.CipherSuites)
+            if (options.HasFlag(ProcessingOptions.CipherSuites))
             {
                 TryGetCipherSuites(p, ref info);
             }
@@ -492,8 +492,7 @@ namespace Yarp.ReverseProxy.Utilities.Tls
 
                 ReadOnlySpan<byte> extensionData = extensions.Slice(0, extensionLength);
 
-                if (extensionType == ExtensionType.ServerName && (options == ProcessingOptions.All ||
-                   (options & ProcessingOptions.ServerName) == ProcessingOptions.ServerName))
+                if (extensionType == ExtensionType.ServerName && (options.HasFlag(ProcessingOptions.ServerName)))
                 {
                     if (!TryGetSniFromServerNameList(extensionData, out string? sni))
                     {
@@ -502,8 +501,7 @@ namespace Yarp.ReverseProxy.Utilities.Tls
 
                     info.TargetName = sni!;
                 }
-                else if (extensionType == ExtensionType.SupportedVersions && (options == ProcessingOptions.All ||
-                          (options & ProcessingOptions.Versions) == ProcessingOptions.Versions))
+                else if (extensionType == ExtensionType.SupportedVersions && (options.HasFlag(ProcessingOptions.Versions)))
                 {
                     if (!TryGetSupportedVersionsFromExtension(extensionData, out SslProtocols versions))
                     {
@@ -512,8 +510,7 @@ namespace Yarp.ReverseProxy.Utilities.Tls
 
                     info.SupportedVersions |= versions;
                 }
-                else if (extensionType == ExtensionType.ApplicationProtocols && (options == ProcessingOptions.All ||
-                          (options & ProcessingOptions.ApplicationProtocol) == ProcessingOptions.ApplicationProtocol))
+                else if (extensionType == ExtensionType.ApplicationProtocols && (options.HasFlag(ProcessingOptions.ApplicationProtocol)))
                 {
                     if (!TryGetApplicationProtocolsFromExtension(extensionData, out ApplicationProtocolInfo alpn))
                     {

--- a/src/ReverseProxy/Utilities/TlsFrameHelper.cs
+++ b/src/ReverseProxy/Utilities/TlsFrameHelper.cs
@@ -107,7 +107,7 @@ namespace Yarp.ReverseProxy.Utilities.Tls
             ApplicationProtocol = 0x2,
             Versions = 0x4,
             CipherSuites = 0x8,
-            All = 15,
+            All = 0x7FFFFFFF,
         }
 
         [Flags]


### PR DESCRIPTION
as mentioned in https://github.com/microsoft/reverse-proxy/pull/1026#discussion_r640079973 used options.HasFlag.
also corrected `ProcessingOptions.All` to `0x7FFFFFFF`
fixes https://github.com/microsoft/reverse-proxy/pull/1026