### PR TITLE
Remove TE header from proxied requests

### DIFF
--- a/src/ReverseProxy/Proxy/RequestUtilities.cs
+++ b/src/ReverseProxy/Proxy/RequestUtilities.cs
@@ -72,6 +72,7 @@ namespace Yarp.ReverseProxy.Proxy
             "Security-Scheme",
             "ALPN",
             "Close",
+            HeaderNames.TE,
 #if NET
             HeaderNames.AltSvc,
 #else

--- a/test/ReverseProxy.Tests/Proxy/HttpProxyTests.cs
+++ b/test/ReverseProxy.Tests/Proxy/HttpProxyTests.cs
@@ -1898,6 +1898,7 @@ namespace Yarp.ReverseProxy.Proxy.Tests
                 "Security-Scheme: value",
                 "ALPN: value",
                 "Close: value",
+                "TE: value",
 #if NET
                 "AltSvc: value",
 #endif


### PR DESCRIPTION
TE header only applies to the immediate connection, so it should be removed from proxied requests.

Fixes #969 