### PR TITLE
Fix small typo in configfiles.md

### DIFF
--- a/docs/docfx/articles/configfiles.md
+++ b/docs/docfx/articles/configfiles.md
@@ -110,7 +110,7 @@ For additional fields see [Cluster](xref:Yarp.ReverseProxy.Abstractions.Cluster)
       "allrouteprops" : {
         // matches /something/* and routes to "allclusterprops"
         "ClusterId": "allclusterprops", // Name of one of the clusters
-        "Order" : 100, // Lower numbers have higher precidence
+        "Order" : 100, // Lower numbers have higher precedence
         "Authorization Policy" : "Anonymous", // Name of the policy or "Default", "Anonymous"
         "CorsPolicy" : "Default", // Name of the CorsPolicy to apply to this route or "Default", "Disable"
         "Match": {


### PR DESCRIPTION
The comment:

> // Lower numbers have higher precidence

Should read:

> // Lower numbers have higher **precedence**