### PR TITLE
Pass EventSource name via attribute

### DIFF
--- a/src/ReverseProxy/Forwarder/ForwarderTelemetry.cs
+++ b/src/ReverseProxy/Forwarder/ForwarderTelemetry.cs
@@ -8,9 +8,10 @@ using System.Threading;
 
 namespace Yarp.ReverseProxy.Forwarder
 {
+    [EventSource(Name = "Yarp.ReverseProxy")]
     internal sealed class ForwarderTelemetry : EventSource
     {
-        public static readonly ForwarderTelemetry Log = new ForwarderTelemetry();
+        public static readonly ForwarderTelemetry Log = new();
 
         private IncrementingPollingCounter? _startedRequestsPerSecondCounter;
         private PollingCounter? _startedRequestsCounter;
@@ -20,10 +21,6 @@ namespace Yarp.ReverseProxy.Forwarder
         private long _startedRequests;
         private long _stoppedRequests;
         private long _failedRequests;
-
-        private ForwarderTelemetry()
-            : base("Yarp.ReverseProxy")
-        { }
 
         [Event(1, Level = EventLevel.Informational)]
         public void ForwarderStart(string destinationPrefix)


### PR DESCRIPTION
There is a very subtle difference between the two:
- The current version (passing the name in ctor) uses the public `EventSource` constructor, which sets the `EtwSelfDescribingEventFormat` option.
- The new version (attribute) uses the empty ctor, which is a protected one that sets `EtwManifestEventFormat` instead.

There are some subtle differences (for example bools are encoded with 1 vs 4 bytes).

This PR makes us consistent with what all other `EventSource`s do.

`dotnet trace` appears to have problems working with `EtwSelfDescribingEventFormat`, which can be observed as garbage data for events that include a bool.
![image](https://user-images.githubusercontent.com/25307628/121967314-fe115e80-cd24-11eb-8cff-bbde32b59573.png)

cc: @alnikola this is what you have been seeing in the past

Related to #1079


Opened an issue in diagnostics regarding `dotnet trace`: dotnet/diagnostics#2367