### PR TITLE
Implement header allow lists

### DIFF
--- a/docs/docfx/articles/transforms.md
+++ b/docs/docfx/articles/transforms.md
@@ -462,6 +462,39 @@ AnotherHeader: AnotherValue
 
 This removes the named header.
 
+### RequestHeadersAllowed
+
+| Key | Value | Required |
+|-----|-------|----------|
+| RequestHeadersAllowed | A semicolon separated list of allowed header names. | yes |
+
+Config:
+```JSON
+{
+  "RequestHeadersAllowed": "Header1;header2"
+}
+```
+Code:
+```csharp
+routeConfig = routeConfig.WithTransformRequestHeadersAllowed("Header1", "header2");
+```
+```C#
+transformBuilderContext.AddRequestHeadersAllowed("Header1", "header2");
+```
+
+YARP copies most request headers to the proxy request by default (see [RequestHeadersCopy](#RequestHeadersCopy)). Some security models only allow specific headers to be proxied. This transform disables RequestHeadersCopy and only copies the given headers. Other transforms that modify or append to existing headers may be affected if not included in the allow list.
+
+Note that there are some headers YARP does not copy by default since they are connection specific or otherwise security sensitive (e.g. `Connection`, `Alt-Svc`). Putting those header names in the allow list will bypass that restriction but is strongly discouraged as it may negatively affect the functionality of the proxy or cause security vulnerabilities.
+
+Example:
+```
+Header1: value1
+Header2: value2
+AnotherHeader: AnotherValue
+```
+
+Only header1 and header2 are copied to the proxy request.
+
 ### X-Forwarded
 
 | Key | Value | Default | Required |
@@ -710,6 +743,39 @@ This removes the named header.
 
 `When` specifies if the response header should be included for successful responses or for all responses. Any response with a status code less than 400 is considered a success.
 
+### ResponseHeadersAllowed
+
+| Key | Value | Required |
+|-----|-------|----------|
+| ResponseHeadersAllowed | A semicolon separated list of allowed header names. | yes |
+
+Config:
+```JSON
+{
+  "ResponseHeadersAllowed": "Header1;header2"
+}
+```
+Code:
+```csharp
+routeConfig = routeConfig.WithTransformResponseHeadersAllowed("Header1", "header2");
+```
+```C#
+transformBuilderContext.AddResponseHeadersAllowed("Header1", "header2");
+```
+
+YARP copies most response headers from the proxy response by default (see [ResponseHeadersCopy](#ResponseHeadersCopy)). Some security models only allow specific headers to be proxied. This transform disables ResponseHeadersCopy and only copies the given headers. Other transforms that modify or append to existing headers may be affected if not included in the allow list.
+
+Note that there are some headers YARP does not copy by default since they are connection specific or otherwise security sensitive (e.g. `Connection`, `Alt-Svc`). Putting those header names in the allow list will bypass that restriction but is strongly discouraged as it may negatively affect the functionality of the proxy or cause security vulnerabilities.
+
+Example:
+```
+Header1: value1
+Header2: value2
+AnotherHeader: AnotherValue
+```
+
+Only header1 and header2 are copied from the proxy response.
+
 ### ResponseTrailersCopy
 
 | Key | Value | Default | Required |
@@ -792,6 +858,39 @@ AnotherHeader: another-value
 This removes the named trailing header.
 
 ResponseTrailerRemove follows the same structure and guidance as ResponseHeaderRemove.
+
+### ResponseTrailersAllowed
+
+| Key | Value | Required |
+|-----|-------|----------|
+| ResponseTrailersAllowed | A semicolon separated list of allowed header names. | yes |
+
+Config:
+```JSON
+{
+  "ResponseTrailersAllowed": "Header1;header2"
+}
+```
+Code:
+```csharp
+routeConfig = routeConfig.WithTransformResponseTrailersAllowed("Header1", "header2");
+```
+```C#
+transformBuilderContext.AddResponseTrailersAllowed("Header1", "header2");
+```
+
+YARP copies most response trailers from the proxy response by default (see [ResponseTrailersCopy](#ResponseTrailersCopy)). Some security models only allow specific headers to be proxied. This transform disables ResponseTrailersCopy and only copies the given headers. Other transforms that modify or append to existing headers may be affected if not included in the allow list.
+
+Note that there are some headers YARP does not copy by default since they are connection specific or otherwise security sensitive (e.g. `Connection`, `Alt-Svc`). Putting those header names in the allow list will bypass that restriction but is strongly discouraged as it may negatively affect the functionality of the proxy or cause security vulnerabilities.
+
+Example:
+```
+Header1: value1
+Header2: value2
+AnotherHeader: AnotherValue
+```
+
+Only header1 and header2 are copied from the proxy response.
 
 ## Extensibility
 

--- a/src/ReverseProxy/Transforms/RequestHeadersAllowedTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeadersAllowedTransform.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Primitives;
 namespace Yarp.ReverseProxy.Transforms
 {
     /// <summary>
-    /// Removes a request header.
+    /// Copies only allowed request headers.
     /// </summary>
     public class RequestHeadersAllowedTransform : RequestTransform
     {

--- a/src/ReverseProxy/Transforms/RequestHeadersAllowedTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeadersAllowedTransform.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Primitives;
+
+namespace Yarp.ReverseProxy.Transforms
+{
+    /// <summary>
+    /// Removes a request header.
+    /// </summary>
+    public class RequestHeadersAllowedTransform : RequestTransform
+    {
+        public RequestHeadersAllowedTransform(string[] allowedHeaders)
+        {
+            if (allowedHeaders is null)
+            {
+                throw new ArgumentNullException(nameof(allowedHeaders));
+            }
+
+            AllowedHeaders = allowedHeaders;
+            AllowedHeadersSet = new HashSet<string>(allowedHeaders, StringComparer.OrdinalIgnoreCase);
+        }
+
+        internal string[] AllowedHeaders { get; }
+
+        private HashSet<string> AllowedHeadersSet { get; }
+
+        /// <inheritdoc/>
+        public override ValueTask ApplyAsync(RequestTransformContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            Debug.Assert(!context.HeadersCopied);
+
+            foreach (var header in context.HttpContext.Request.Headers)
+            {
+                var headerName = header.Key;
+                var headerValue = header.Value;
+                if (!StringValues.IsNullOrEmpty(headerValue)
+                    && AllowedHeadersSet.Contains(headerName))
+                {
+                    AddHeader(context, headerName, headerValue);
+                }
+            }
+
+            context.HeadersCopied = true;
+
+            return default;
+        }
+    }
+}

--- a/src/ReverseProxy/Transforms/RequestHeadersTransformExtensions.cs
+++ b/src/ReverseProxy/Transforms/RequestHeadersTransformExtensions.cs
@@ -58,6 +58,18 @@ namespace Yarp.ReverseProxy.Transforms
         }
 
         /// <summary>
+        /// Clones the route and adds the transform which will only copy the allowed request headers. Other transforms
+        /// that modify or append to existing headers may be affected if not included in the allow list.
+        /// </summary>
+        public static RouteConfig WithTransformRequestHeadersAllowed(this RouteConfig route, params string[] allowedHeaders)
+        {
+            return route.WithTransform(transform =>
+            {
+                transform[RequestHeadersTransformFactory.RequestHeadersAllowedKey] = string.Join(';', allowedHeaders);
+            });
+        }
+
+        /// <summary>
         /// Adds the transform which will append or set the request header.
         /// </summary>
         public static TransformBuilderContext AddRequestHeader(this TransformBuilderContext context, string headerName, string value, bool append = true)
@@ -72,6 +84,17 @@ namespace Yarp.ReverseProxy.Transforms
         public static TransformBuilderContext AddRequestHeaderRemove(this TransformBuilderContext context, string headerName)
         {
             context.RequestTransforms.Add(new RequestHeaderRemoveTransform(headerName));
+            return context;
+        }
+
+        /// <summary>
+        /// Adds the transform which will only copy the allowed request headers. Other transforms
+        /// that modify or append to existing headers may be affected if not included in the allow list.
+        /// </summary>
+        public static TransformBuilderContext AddRequestHeadersAllowed(this TransformBuilderContext context, params string[] allowedHeaders)
+        {
+            context.CopyRequestHeaders = false;
+            context.RequestTransforms.Add(new RequestHeadersAllowedTransform(allowedHeaders));
             return context;
         }
 

--- a/src/ReverseProxy/Transforms/RequestHeadersTransformFactory.cs
+++ b/src/ReverseProxy/Transforms/RequestHeadersTransformFactory.cs
@@ -13,6 +13,7 @@ namespace Yarp.ReverseProxy.Transforms
         internal static readonly string RequestHeaderOriginalHostKey = "RequestHeaderOriginalHost";
         internal static readonly string RequestHeaderKey = "RequestHeader";
         internal static readonly string RequestHeaderRemoveKey = "RequestHeaderRemove";
+        internal static readonly string RequestHeadersAllowedKey = "RequestHeadersAllowed";
         internal static readonly string AppendKey = "Append";
         internal static readonly string SetKey = "Set";
 
@@ -43,6 +44,10 @@ namespace Yarp.ReverseProxy.Transforms
                 }
             }
             else if (transformValues.TryGetValue(RequestHeaderRemoveKey, out var _))
+            {
+                TransformHelpers.TryCheckTooManyParameters(context, transformValues, expected: 1);
+            }
+            else if (transformValues.TryGetValue(RequestHeadersAllowedKey, out var _))
             {
                 TransformHelpers.TryCheckTooManyParameters(context, transformValues, expected: 1);
             }
@@ -86,6 +91,16 @@ namespace Yarp.ReverseProxy.Transforms
             {
                 TransformHelpers.CheckTooManyParameters(transformValues, expected: 1);
                 context.AddRequestHeaderRemove(removeHeaderName);
+            }
+            else if (transformValues.TryGetValue(RequestHeadersAllowedKey, out var allowedHeaders))
+            {
+                TransformHelpers.CheckTooManyParameters(transformValues, expected: 1);
+                var headersList = allowedHeaders.Split(';', options: StringSplitOptions.RemoveEmptyEntries
+#if NET
+                    | StringSplitOptions.TrimEntries
+#endif
+                    );
+                context.AddRequestHeadersAllowed(headersList);
             }
             else
             {

--- a/src/ReverseProxy/Transforms/ResponseHeadersAllowedTransform.cs
+++ b/src/ReverseProxy/Transforms/ResponseHeadersAllowedTransform.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+
+namespace Yarp.ReverseProxy.Transforms
+{
+    /// <summary>
+    /// Removes a request header.
+    /// </summary>
+    public class ResponseHeadersAllowedTransform : ResponseTransform
+    {
+        public ResponseHeadersAllowedTransform(string[] allowedHeaders)
+        {
+            if (allowedHeaders is null)
+            {
+                throw new ArgumentNullException(nameof(allowedHeaders));
+            }
+
+            AllowedHeaders = allowedHeaders;
+            AllowedHeadersSet = new HashSet<string>(allowedHeaders, StringComparer.OrdinalIgnoreCase);
+        }
+
+        internal string[] AllowedHeaders { get; }
+
+        private HashSet<string> AllowedHeadersSet { get; }
+
+        /// <inheritdoc/>
+        public override ValueTask ApplyAsync(ResponseTransformContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            Debug.Assert(!context.HeadersCopied);
+
+            // See https://github.com/microsoft/reverse-proxy/blob/51d797986b1fea03500a1ad173d13a1176fb5552/src/ReverseProxy/Forwarder/HttpTransformer.cs#L67-L77
+            var responseHeaders = context.HttpContext.Response.Headers;
+            CopyResponseHeaders(context.ProxyResponse.Headers, responseHeaders);
+            if (context.ProxyResponse.Content != null)
+            {
+                CopyResponseHeaders(context.ProxyResponse.Content.Headers, responseHeaders);
+            }
+
+            context.HeadersCopied = true;
+
+            return default;
+        }
+
+        // See https://github.com/microsoft/reverse-proxy/blob/51d797986b1fea03500a1ad173d13a1176fb5552/src/ReverseProxy/Forwarder/HttpTransformer.cs#L102-L115
+        private void CopyResponseHeaders(HttpHeaders source, IHeaderDictionary destination)
+        {
+            foreach (var header in source)
+            {
+                var headerName = header.Key;
+                if (AllowedHeadersSet.Contains(headerName))
+                {
+                    Debug.Assert(header.Value is string[]);
+                    destination.Append(headerName, header.Value as string[] ?? header.Value.ToArray());
+                }
+            }
+        }
+    }
+}

--- a/src/ReverseProxy/Transforms/ResponseTrailersAllowedTransform.cs
+++ b/src/ReverseProxy/Transforms/ResponseTrailersAllowedTransform.cs
@@ -8,16 +8,17 @@ using System.Linq;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Primitives;
 
 namespace Yarp.ReverseProxy.Transforms
 {
     /// <summary>
-    /// Copies only allowed response headers.
+    /// Copies only allowed response trailers.
     /// </summary>
-    public class ResponseHeadersAllowedTransform : ResponseTransform
+    public class ResponseTrailersAllowedTransform : ResponseTrailersTransform
     {
-        public ResponseHeadersAllowedTransform(string[] allowedHeaders)
+        public ResponseTrailersAllowedTransform(string[] allowedHeaders)
         {
             if (allowedHeaders is null)
             {
@@ -33,7 +34,7 @@ namespace Yarp.ReverseProxy.Transforms
         private HashSet<string> AllowedHeadersSet { get; }
 
         /// <inheritdoc/>
-        public override ValueTask ApplyAsync(ResponseTransformContext context)
+        public override ValueTask ApplyAsync(ResponseTrailersTransformContext context)
         {
             if (context is null)
             {
@@ -42,12 +43,15 @@ namespace Yarp.ReverseProxy.Transforms
 
             Debug.Assert(!context.HeadersCopied);
 
-            // See https://github.com/microsoft/reverse-proxy/blob/51d797986b1fea03500a1ad173d13a1176fb5552/src/ReverseProxy/Forwarder/HttpTransformer.cs#L67-L77
-            var responseHeaders = context.HttpContext.Response.Headers;
-            CopyResponseHeaders(context.ProxyResponse.Headers, responseHeaders);
-            if (context.ProxyResponse.Content != null)
+            // See https://github.com/microsoft/reverse-proxy/blob/51d797986b1fea03500a1ad173d13a1176fb5552/src/ReverseProxy/Forwarder/HttpTransformer.cs#L85-L99
+            // NOTE: Deliberately not using `context.Response.SupportsTrailers()`, `context.Response.AppendTrailer(...)`
+            // because they lookup `IHttpResponseTrailersFeature` for every call. Here we do it just once instead.
+            var responseTrailersFeature = context.HttpContext.Features.Get<IHttpResponseTrailersFeature>();
+            var outgoingTrailers = responseTrailersFeature?.Trailers;
+            if (outgoingTrailers != null && !outgoingTrailers.IsReadOnly)
             {
-                CopyResponseHeaders(context.ProxyResponse.Content.Headers, responseHeaders);
+                // Note that trailers, if any, should already have been declared in Proxy's response
+                CopyResponseHeaders(context.ProxyResponse.TrailingHeaders, outgoingTrailers);
             }
 
             context.HeadersCopied = true;

--- a/src/ReverseProxy/Transforms/ResponseTransformExtensions.cs
+++ b/src/ReverseProxy/Transforms/ResponseTransformExtensions.cs
@@ -62,6 +62,18 @@ namespace Yarp.ReverseProxy.Transforms
         }
 
         /// <summary>
+        /// Clones the route and adds the transform which will only copy the allowed response headers. Other transforms
+        /// that modify or append to existing headers may be affected if not included in the allow list.
+        /// </summary>
+        public static RouteConfig WithTransformResponseHeadersAllowed(this RouteConfig route, params string[] allowedHeaders)
+        {
+            return route.WithTransform(transform =>
+            {
+                transform[ResponseTransformFactory.ResponseHeadersAllowedKey] = string.Join(';', allowedHeaders);
+            });
+        }
+
+        /// <summary>
         /// Adds the transform which will append or set the response header.
         /// </summary>
         public static TransformBuilderContext AddResponseHeader(this TransformBuilderContext context, string headerName, string value, bool append = true, bool always = false)
@@ -76,6 +88,17 @@ namespace Yarp.ReverseProxy.Transforms
         public static TransformBuilderContext AddResponseHeaderRemove(this TransformBuilderContext context, string headerName, bool always = false)
         {
             context.ResponseTransforms.Add(new ResponseHeaderRemoveTransform(headerName, always));
+            return context;
+        }
+
+        /// <summary>
+        /// Adds the transform which will only copy the allowed response headers. Other transforms
+        /// that modify or append to existing headers may be affected if not included in the allow list.
+        /// </summary>
+        public static TransformBuilderContext AddResponseHeadersAllowed(this TransformBuilderContext context, params string[] allowedHeaders)
+        {
+            context.CopyResponseHeaders = false;
+            context.ResponseTransforms.Add(new ResponseHeadersAllowedTransform(allowedHeaders));
             return context;
         }
 

--- a/src/ReverseProxy/Transforms/ResponseTransformExtensions.cs
+++ b/src/ReverseProxy/Transforms/ResponseTransformExtensions.cs
@@ -147,5 +147,28 @@ namespace Yarp.ReverseProxy.Transforms
                 transform[ResponseTransformFactory.WhenKey] = when;
             });
         }
+
+        /// <summary>
+        /// Clones the route and adds the transform which will only copy the allowed response trailers. Other transforms
+        /// that modify or append to existing trailers may be affected if not included in the allow list.
+        /// </summary>
+        public static RouteConfig WithTransformResponseTrailersAllowed(this RouteConfig route, params string[] allowedHeaders)
+        {
+            return route.WithTransform(transform =>
+            {
+                transform[ResponseTransformFactory.ResponseTrailersAllowedKey] = string.Join(';', allowedHeaders);
+            });
+        }
+
+        /// <summary>
+        /// Adds the transform which will only copy the allowed response trailers. Other transforms
+        /// that modify or append to existing trailers may be affected if not included in the allow list.
+        /// </summary>
+        public static TransformBuilderContext AddResponseTrailersAllowed(this TransformBuilderContext context, params string[] allowedHeaders)
+        {
+            context.CopyResponseTrailers = false;
+            context.ResponseTrailersTransforms.Add(new ResponseTrailersAllowedTransform(allowedHeaders));
+            return context;
+        }
     }
 }

--- a/src/ReverseProxy/Transforms/ResponseTransformFactory.cs
+++ b/src/ReverseProxy/Transforms/ResponseTransformFactory.cs
@@ -16,6 +16,7 @@ namespace Yarp.ReverseProxy.Transforms
         internal static readonly string ResponseHeaderRemoveKey = "ResponseHeaderRemove";
         internal static readonly string ResponseTrailerRemoveKey = "ResponseTrailerRemove";
         internal static readonly string ResponseHeadersAllowedKey = "ResponseHeadersAllowed";
+        internal static readonly string ResponseTrailersAllowedKey = "ResponseTrailersAllowed";
         internal static readonly string WhenKey = "When";
         internal static readonly string AlwaysValue = "Always";
         internal static readonly string SuccessValue = "Success";
@@ -111,6 +112,10 @@ namespace Yarp.ReverseProxy.Transforms
                 }
             }
             else if (transformValues.TryGetValue(ResponseHeadersAllowedKey, out var _))
+            {
+                TransformHelpers.TryCheckTooManyParameters(context, transformValues, expected: 1);
+            }
+            else if (transformValues.TryGetValue(ResponseTrailersAllowedKey, out var _))
             {
                 TransformHelpers.TryCheckTooManyParameters(context, transformValues, expected: 1);
             }
@@ -225,6 +230,16 @@ namespace Yarp.ReverseProxy.Transforms
 #endif
                     );
                 context.AddResponseHeadersAllowed(headersList);
+            }
+            else if (transformValues.TryGetValue(ResponseTrailersAllowedKey, out var allowedTrailers))
+            {
+                TransformHelpers.CheckTooManyParameters(transformValues, expected: 1);
+                var headersList = allowedTrailers.Split(';', options: StringSplitOptions.RemoveEmptyEntries
+#if NET
+                    | StringSplitOptions.TrimEntries
+#endif
+                    );
+                context.AddResponseTrailersAllowed(headersList);
             }
             else
             {

--- a/src/ReverseProxy/Transforms/ResponseTransformFactory.cs
+++ b/src/ReverseProxy/Transforms/ResponseTransformFactory.cs
@@ -15,6 +15,7 @@ namespace Yarp.ReverseProxy.Transforms
         internal static readonly string ResponseTrailerKey = "ResponseTrailer";
         internal static readonly string ResponseHeaderRemoveKey = "ResponseHeaderRemove";
         internal static readonly string ResponseTrailerRemoveKey = "ResponseTrailerRemove";
+        internal static readonly string ResponseHeadersAllowedKey = "ResponseHeadersAllowed";
         internal static readonly string WhenKey = "When";
         internal static readonly string AlwaysValue = "Always";
         internal static readonly string SuccessValue = "Success";
@@ -109,6 +110,10 @@ namespace Yarp.ReverseProxy.Transforms
                     TransformHelpers.TryCheckTooManyParameters(context, transformValues, expected: 1);
                 }
             }
+            else if (transformValues.TryGetValue(ResponseHeadersAllowedKey, out var _))
+            {
+                TransformHelpers.TryCheckTooManyParameters(context, transformValues, expected: 1);
+            }
             else
             {
                 return false;
@@ -181,7 +186,7 @@ namespace Yarp.ReverseProxy.Transforms
                     throw new ArgumentException($"Unexpected parameters for ResponseTrailer: {string.Join(';', transformValues.Keys)}. Expected 'Set' or 'Append'");
                 }
             }
-            else if (transformValues.TryGetValue(ResponseHeaderKey, out var removeResponseHeaderName))
+            else if (transformValues.TryGetValue(ResponseHeaderRemoveKey, out var removeResponseHeaderName))
             {
                 var always = false;
                 if (transformValues.TryGetValue(WhenKey, out var whenValue))
@@ -210,6 +215,16 @@ namespace Yarp.ReverseProxy.Transforms
                 }
 
                 context.AddResponseTrailerRemove(removeResponseTrailerName, always);
+            }
+            else if (transformValues.TryGetValue(ResponseHeadersAllowedKey, out var allowedHeaders))
+            {
+                TransformHelpers.CheckTooManyParameters(transformValues, expected: 1);
+                var headersList = allowedHeaders.Split(';', options: StringSplitOptions.RemoveEmptyEntries
+#if NET
+                    | StringSplitOptions.TrimEntries
+#endif
+                    );
+                context.AddResponseHeadersAllowed(headersList);
             }
             else
             {

--- a/test/ReverseProxy.Tests/Transforms/RequestHeadersAllowedTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/RequestHeadersAllowedTransformTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+
+namespace Yarp.ReverseProxy.Transforms.Tests
+{
+    public class RequestHeadersAllowedTransformTests
+    {
+        [Theory]
+        [InlineData("", 0)]
+        [InlineData("header1", 1)]
+        [InlineData("header1;header2", 2)]
+        [InlineData("header1;header2;header3", 3)]
+        [InlineData("header1;header2;header2;header3", 3)]
+        public async Task AllowedHeaders_Copied(string names, int expected)
+        {
+            var httpContext = new DefaultHttpContext();
+            var proxyRequest = new HttpRequestMessage();
+            httpContext.Request.Headers["header1"] = "value1";
+            httpContext.Request.Headers["header2"] = "value2";
+            httpContext.Request.Headers["header3"] = "value3";
+            httpContext.Request.Headers["header4"] = "value4";
+            httpContext.Request.Headers["header5"] = "value5";
+            httpContext.Request.Headers.ContentLength = 0;
+
+            var allowed = names.Split(';');
+            var transform = new RequestHeadersAllowedTransform(allowed);
+            var transformContext = new RequestTransformContext()
+            {
+                HttpContext = httpContext,
+                ProxyRequest = proxyRequest,
+                HeadersCopied = false,
+            };
+            await transform.ApplyAsync(transformContext);
+
+            Assert.True(transformContext.HeadersCopied);
+
+            Assert.Equal(expected, proxyRequest.Headers.Count());
+            foreach (var header in proxyRequest.Headers)
+            {
+                Assert.Contains(header.Key, allowed, StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        [Theory]
+        [InlineData("", 0)]
+        [InlineData("Allow", 1)]
+        [InlineData("content-disposition;header2", 1)]
+        [InlineData("content-length;content-Location;Content-Type", 3)]
+        [InlineData("Allow;Content-Disposition;Content-Encoding;Content-Language;Content-Location;Content-MD5;Content-Range;Content-Type;Expires;Last-Modified;Content-Length", 11)]
+        public async Task ContentHeaders_CopiedIfAllowed(string names, int expected)
+        {
+            var httpContext = new DefaultHttpContext();
+            var proxyRequest = new HttpRequestMessage();
+            httpContext.Request.Headers[HeaderNames.Allow] = "value1";
+            httpContext.Request.Headers[HeaderNames.ContentDisposition] = "value2";
+            httpContext.Request.Headers[HeaderNames.ContentEncoding] = "value3";
+            httpContext.Request.Headers[HeaderNames.ContentLanguage] = "value4";
+            httpContext.Request.Headers[HeaderNames.ContentLocation] = "value5";
+            httpContext.Request.Headers[HeaderNames.ContentMD5] = "value6";
+            httpContext.Request.Headers[HeaderNames.ContentRange] = "value7";
+            httpContext.Request.Headers[HeaderNames.ContentType] = "value8";
+            httpContext.Request.Headers[HeaderNames.Expires] = "value9";
+            httpContext.Request.Headers[HeaderNames.LastModified] = "value10";
+            httpContext.Request.Headers.ContentLength = 0;
+
+            var allowed = names.Split(';');
+            var transform = new RequestHeadersAllowedTransform(allowed);
+            var transformContext = new RequestTransformContext()
+            {
+                HttpContext = httpContext,
+                ProxyRequest = proxyRequest,
+                HeadersCopied = false,
+            };
+            await transform.ApplyAsync(transformContext);
+
+            Assert.True(transformContext.HeadersCopied);
+
+            Assert.Empty(proxyRequest.Headers);
+            var content = proxyRequest.Content;
+            if (expected == 0)
+            {
+                Assert.Null(content);
+                return;
+            }
+
+            Assert.Equal(expected, content.Headers.Count());
+            foreach (var header in content.Headers)
+            {
+                Assert.Contains(header.Key, allowed, StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        [Theory]
+        [InlineData("", 0)]
+        [InlineData("connection", 1)]
+        [InlineData("Transfer-Encoding;Keep-Alive", 2)]
+        // See https://github.com/microsoft/reverse-proxy/blob/51d797986b1fea03500a1ad173d13a1176fb5552/src/ReverseProxy/Forwarder/RequestUtilities.cs#L61-L83
+        public async Task RestrictedHeaders_CopiedIfAllowed(string names, int expected)
+        {
+            var httpContext = new DefaultHttpContext();
+            var proxyRequest = new HttpRequestMessage();
+            httpContext.Request.Headers[HeaderNames.Connection] = "value1";
+            httpContext.Request.Headers[HeaderNames.TransferEncoding] = "value2";
+            httpContext.Request.Headers[HeaderNames.KeepAlive] = "value3";
+
+            var allowed = names.Split(';');
+            var transform = new RequestHeadersAllowedTransform(allowed);
+            var transformContext = new RequestTransformContext()
+            {
+                HttpContext = httpContext,
+                ProxyRequest = proxyRequest,
+                HeadersCopied = false,
+            };
+            await transform.ApplyAsync(transformContext);
+
+            Assert.True(transformContext.HeadersCopied);
+
+            Assert.Equal(expected, proxyRequest.Headers.Count());
+            foreach (var header in proxyRequest.Headers)
+            {
+                Assert.Contains(header.Key, allowed, StringComparer.OrdinalIgnoreCase);
+            }
+        }
+    }
+}

--- a/test/ReverseProxy.Tests/Transforms/RequestHeadersTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/RequestHeadersTransformExtensionsTests.cs
@@ -66,12 +66,47 @@ namespace Yarp.ReverseProxy.Transforms.Tests
         }
 
         [Fact]
-        public void RemoveRequestHeader()
+        public void WithTransformRequestHeaderRemove()
         {
             var routeConfig = new RouteConfig();
             routeConfig = routeConfig.WithTransformRequestHeaderRemove("MyHeader");
 
-            ValidateAndBuild(routeConfig, _factory);   
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
+            var transform = Assert.Single(builderContext.RequestTransforms) as RequestHeaderRemoveTransform;
+            Assert.Equal("MyHeader", transform.HeaderName);
+        }
+
+        [Fact]
+        public void AddRequestHeaderRemove()
+        {
+            var builderContext = CreateBuilderContext();
+            builderContext.AddRequestHeaderRemove("MyHeader");
+
+            var transform = Assert.Single(builderContext.RequestTransforms) as RequestHeaderRemoveTransform;
+            Assert.Equal("MyHeader", transform.HeaderName);
+        }
+
+        [Fact]
+        public void WithTransformRequestHeadersAllowed()
+        {
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformRequestHeadersAllowed("header1", "Header2");
+
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
+            var transform = Assert.Single(builderContext.RequestTransforms) as RequestHeadersAllowedTransform;
+            Assert.Equal(new[] { "header1", "Header2" }, transform.AllowedHeaders);
+            Assert.False(builderContext.CopyRequestHeaders);
+        }
+
+        [Fact]
+        public void AddRequestHeadersAllowed()
+        {
+            var builderContext = CreateBuilderContext();
+            builderContext.AddRequestHeadersAllowed("header1", "Header2");
+
+            var transform = Assert.Single(builderContext.RequestTransforms) as RequestHeadersAllowedTransform;
+            Assert.Equal(new[] { "header1", "Header2" }, transform.AllowedHeaders);
+            Assert.False(builderContext.CopyRequestHeaders);
         }
 
         private static void ValidateRequestHeader(bool append, TransformBuilderContext builderContext)

--- a/test/ReverseProxy.Tests/Transforms/ResponseHeadersAllowedTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/ResponseHeadersAllowedTransformTests.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+
+namespace Yarp.ReverseProxy.Transforms.Tests
+{
+    public class ResponseHeadersAllowedTransformTests
+    {
+        [Theory]
+        [InlineData("", 0)]
+        [InlineData("header1", 1)]
+        [InlineData("header1;header2", 2)]
+        [InlineData("header1;header2;header3", 3)]
+        [InlineData("header1;header2;header2;header3", 3)]
+        public async Task AllowedHeaders_Copied(string names, int expected)
+        {
+            var httpContext = new DefaultHttpContext();
+            var proxyResponse = new HttpResponseMessage();
+            proxyResponse.Headers.TryAddWithoutValidation("header1", "value1");
+            proxyResponse.Headers.TryAddWithoutValidation("header2", "value2");
+            proxyResponse.Headers.TryAddWithoutValidation("header3", "value3");
+            proxyResponse.Headers.TryAddWithoutValidation("header4", "value4");
+            proxyResponse.Headers.TryAddWithoutValidation("header5", "value5");
+
+            var allowed = names.Split(';');
+            var transform = new ResponseHeadersAllowedTransform(allowed);
+            var transformContext = new ResponseTransformContext()
+            {
+                HttpContext = httpContext,
+                ProxyResponse = proxyResponse,
+                HeadersCopied = false,
+            };
+            await transform.ApplyAsync(transformContext);
+
+            Assert.True(transformContext.HeadersCopied);
+
+            Assert.Equal(expected, httpContext.Response.Headers.Count());
+            foreach (var header in httpContext.Response.Headers)
+            {
+                Assert.Contains(header.Key, allowed, StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        [Theory]
+        [InlineData("", 0)]
+        [InlineData("Allow", 1)]
+        [InlineData("content-disposition;header0", 2)]
+        [InlineData("content-length;content-Location;Content-Type", 3)]
+        [InlineData("Allow;Content-Disposition;Content-Encoding;Content-Language;Content-Location;Content-MD5;Content-Range;Content-Type;Expires;Last-Modified;Content-Length", 11)]
+        public async Task ContentHeaders_CopiedIfAllowed(string names, int expected)
+        {
+            var httpContext = new DefaultHttpContext();
+            var proxyResponse = new HttpResponseMessage();
+            proxyResponse.Content = new StringContent("");
+            proxyResponse.Content.Headers.TryAddWithoutValidation("header0", "value0");
+            proxyResponse.Content.Headers.TryAddWithoutValidation(HeaderNames.Allow, "value1");
+            proxyResponse.Content.Headers.TryAddWithoutValidation(HeaderNames.ContentDisposition,"value2");
+            proxyResponse.Content.Headers.TryAddWithoutValidation(HeaderNames.ContentEncoding, "value3");
+            proxyResponse.Content.Headers.TryAddWithoutValidation(HeaderNames.ContentLanguage, "value4");
+            proxyResponse.Content.Headers.TryAddWithoutValidation(HeaderNames.ContentLocation, "value5");
+            proxyResponse.Content.Headers.TryAddWithoutValidation(HeaderNames.ContentMD5, "value6");
+            proxyResponse.Content.Headers.TryAddWithoutValidation(HeaderNames.ContentRange, "value7");
+            proxyResponse.Content.Headers.TryAddWithoutValidation(HeaderNames.ContentType, "value8");
+            proxyResponse.Content.Headers.TryAddWithoutValidation(HeaderNames.Expires, "value9");
+            proxyResponse.Content.Headers.TryAddWithoutValidation(HeaderNames.LastModified, "value10");
+            proxyResponse.Content.Headers.TryAddWithoutValidation(HeaderNames.ContentLength, "0");
+
+            var allowed = names.Split(';');
+            var transform = new ResponseHeadersAllowedTransform(allowed);
+            var transformContext = new ResponseTransformContext()
+            {
+                HttpContext = httpContext,
+                ProxyResponse = proxyResponse,
+                HeadersCopied = false,
+            };
+            await transform.ApplyAsync(transformContext);
+
+            Assert.True(transformContext.HeadersCopied);
+
+            Assert.Equal(expected, httpContext.Response.Headers.Count());
+            foreach (var header in httpContext.Response.Headers)
+            {
+                Assert.Contains(header.Key, allowed, StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        [Theory]
+        [InlineData("", 0)]
+        [InlineData("connection", 1)]
+        [InlineData("Transfer-Encoding;Keep-Alive", 2)]
+        // See https://github.com/microsoft/reverse-proxy/blob/51d797986b1fea03500a1ad173d13a1176fb5552/src/ReverseProxy/Forwarder/RequestUtilities.cs#L61-L83
+        public async Task RestrictedHeaders_CopiedIfAllowed(string names, int expected)
+        {
+            var httpContext = new DefaultHttpContext();
+            var proxyResponse = new HttpResponseMessage();
+            proxyResponse.Headers.TryAddWithoutValidation(HeaderNames.Connection, "value1");
+            proxyResponse.Headers.TryAddWithoutValidation(HeaderNames.TransferEncoding, "value2");
+            proxyResponse.Headers.TryAddWithoutValidation(HeaderNames.KeepAlive, "value3");
+
+            var allowed = names.Split(';');
+            var transform = new ResponseHeadersAllowedTransform(allowed);
+            var transformContext = new ResponseTransformContext()
+            {
+                HttpContext = httpContext,
+                ProxyResponse = proxyResponse,
+                HeadersCopied = false,
+            };
+            await transform.ApplyAsync(transformContext);
+
+            Assert.True(transformContext.HeadersCopied);
+
+            Assert.Equal(expected, httpContext.Response.Headers.Count());
+            foreach (var header in httpContext.Response.Headers)
+            {
+                Assert.Contains(header.Key, allowed, StringComparer.OrdinalIgnoreCase);
+            }
+        }
+    }
+}

--- a/test/ReverseProxy.Tests/Transforms/ResponseTrailersAllowedTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/ResponseTrailersAllowedTransformTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+
+namespace Yarp.ReverseProxy.Transforms.Tests
+{
+    public class ResponseTrailersAllowedTransformTests
+    {
+        [Theory]
+        [InlineData("", 0)]
+        [InlineData("header1", 1)]
+        [InlineData("header1;header2", 2)]
+        [InlineData("header1;header2;header3", 3)]
+        [InlineData("header1;header2;header2;header3", 3)]
+        public async Task AllowedHeaders_Copied(string names, int expected)
+        {
+            var httpContext = new DefaultHttpContext();
+            var trailerFeature = new TestTrailersFeature();
+            httpContext.Features.Set<IHttpResponseTrailersFeature>(trailerFeature);
+            var proxyResponse = new HttpResponseMessage();
+            proxyResponse.TrailingHeaders.TryAddWithoutValidation("header1", "value1");
+            proxyResponse.TrailingHeaders.TryAddWithoutValidation("header2", "value2");
+            proxyResponse.TrailingHeaders.TryAddWithoutValidation("header3", "value3");
+            proxyResponse.TrailingHeaders.TryAddWithoutValidation("header4", "value4");
+            proxyResponse.TrailingHeaders.TryAddWithoutValidation("header5", "value5");
+
+            var allowed = names.Split(';');
+            var transform = new ResponseTrailersAllowedTransform(allowed);
+            var transformContext = new ResponseTrailersTransformContext()
+            {
+                HttpContext = httpContext,
+                ProxyResponse = proxyResponse,
+                HeadersCopied = false,
+            };
+            await transform.ApplyAsync(transformContext);
+
+            Assert.True(transformContext.HeadersCopied);
+
+            Assert.Equal(expected, trailerFeature.Trailers.Count());
+            foreach (var header in trailerFeature.Trailers)
+            {
+                Assert.Contains(header.Key, allowed, StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        [Theory]
+        [InlineData("", 0)]
+        [InlineData("connection", 1)]
+        [InlineData("Transfer-Encoding;Keep-Alive", 2)]
+        // See https://github.com/microsoft/reverse-proxy/blob/51d797986b1fea03500a1ad173d13a1176fb5552/src/ReverseProxy/Forwarder/RequestUtilities.cs#L61-L83
+        public async Task RestrictedHeaders_CopiedIfAllowed(string names, int expected)
+        {
+            var httpContext = new DefaultHttpContext();
+            var trailerFeature = new TestTrailersFeature();
+            httpContext.Features.Set<IHttpResponseTrailersFeature>(trailerFeature);
+            var proxyResponse = new HttpResponseMessage();
+            proxyResponse.TrailingHeaders.TryAddWithoutValidation(HeaderNames.Connection, "value1");
+            proxyResponse.TrailingHeaders.TryAddWithoutValidation(HeaderNames.TransferEncoding, "value2");
+            proxyResponse.TrailingHeaders.TryAddWithoutValidation(HeaderNames.KeepAlive, "value3");
+
+            var allowed = names.Split(';');
+            var transform = new ResponseTrailersAllowedTransform(allowed);
+            var transformContext = new ResponseTrailersTransformContext()
+            {
+                HttpContext = httpContext,
+                ProxyResponse = proxyResponse,
+                HeadersCopied = false,
+            };
+            await transform.ApplyAsync(transformContext);
+
+            Assert.True(transformContext.HeadersCopied);
+
+            Assert.Equal(expected, trailerFeature.Trailers.Count());
+            foreach (var header in trailerFeature.Trailers)
+            {
+                Assert.Contains(header.Key, allowed, StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        private class TestTrailersFeature : IHttpResponseTrailersFeature
+        {
+            public IHeaderDictionary Trailers { get; set; } = new HeaderDictionary();
+        }
+    }
+}

--- a/test/ReverseProxy.Tests/Transforms/ResponseTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/ResponseTransformExtensionsTests.cs
@@ -75,6 +75,50 @@ namespace Yarp.ReverseProxy.Transforms.Tests
             Assert.Equal(always, responseHeaderValueTransform.Always);
         }
 
+        [Fact]
+        public void WithTransformResponseHeaderRemove()
+        {
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformResponseHeaderRemove("MyHeader");
+
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
+            var transform = Assert.Single(builderContext.ResponseTransforms) as ResponseHeaderRemoveTransform;
+            Assert.Equal("MyHeader", transform.HeaderName);
+        }
+
+        [Fact]
+        public void AddResponseHeaderRemove()
+        {
+            var builderContext = CreateBuilderContext();
+            builderContext.AddResponseHeaderRemove("MyHeader");
+
+            var transform = Assert.Single(builderContext.ResponseTransforms) as ResponseHeaderRemoveTransform;
+            Assert.Equal("MyHeader", transform.HeaderName);
+        }
+
+        [Fact]
+        public void WithTransformResponseHeadersAllowed()
+        {
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformResponseHeadersAllowed("header1", "Header2");
+
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
+            var transform = Assert.Single(builderContext.ResponseTransforms) as ResponseHeadersAllowedTransform;
+            Assert.Equal(new[] { "header1", "Header2" }, transform.AllowedHeaders);
+            Assert.False(builderContext.CopyResponseHeaders);
+        }
+
+        [Fact]
+        public void AddResponseHeadersAllowed()
+        {
+            var builderContext = CreateBuilderContext();
+            builderContext.AddResponseHeadersAllowed("header1", "Header2");
+
+            var transform = Assert.Single(builderContext.ResponseTransforms) as ResponseHeadersAllowedTransform;
+            Assert.Equal(new[] { "header1", "Header2" }, transform.AllowedHeaders);
+            Assert.False(builderContext.CopyResponseHeaders);
+        }
+
         [Theory]
         [InlineData(false, false)]
         [InlineData(false, true)]

--- a/test/ReverseProxy.Tests/Transforms/ResponseTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/ResponseTransformExtensionsTests.cs
@@ -156,5 +156,49 @@ namespace Yarp.ReverseProxy.Transforms.Tests
             Assert.Equal(append, responseHeaderValueTransform.Append);
             Assert.Equal(always, responseHeaderValueTransform.Always);
         }
+
+        [Fact]
+        public void WithTransformResponseTrailerRemove()
+        {
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformResponseTrailerRemove("MyHeader");
+
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
+            var transform = Assert.Single(builderContext.ResponseTrailersTransforms) as ResponseTrailerRemoveTransform;
+            Assert.Equal("MyHeader", transform.HeaderName);
+        }
+
+        [Fact]
+        public void AddResponseTrailerRemove()
+        {
+            var builderContext = CreateBuilderContext();
+            builderContext.AddResponseTrailerRemove("MyHeader");
+
+            var transform = Assert.Single(builderContext.ResponseTrailersTransforms) as ResponseTrailerRemoveTransform;
+            Assert.Equal("MyHeader", transform.HeaderName);
+        }
+
+        [Fact]
+        public void WithTransformResponseTrailersAllowed()
+        {
+            var routeConfig = new RouteConfig();
+            routeConfig = routeConfig.WithTransformResponseTrailersAllowed("header1", "Header2");
+
+            var builderContext = ValidateAndBuild(routeConfig, _factory);
+            var transform = Assert.Single(builderContext.ResponseTrailersTransforms) as ResponseTrailersAllowedTransform;
+            Assert.Equal(new[] { "header1", "Header2" }, transform.AllowedHeaders);
+            Assert.False(builderContext.CopyResponseTrailers);
+        }
+
+        [Fact]
+        public void AddResponseTrailersAllowed()
+        {
+            var builderContext = CreateBuilderContext();
+            builderContext.AddResponseTrailersAllowed("header1", "Header2");
+
+            var transform = Assert.Single(builderContext.ResponseTrailersTransforms) as ResponseTrailersAllowedTransform;
+            Assert.Equal(new[] { "header1", "Header2" }, transform.AllowedHeaders);
+            Assert.False(builderContext.CopyResponseTrailers);
+        }
     }
 }


### PR DESCRIPTION
Fixes #1114. YARP copies request and response headers by default. A security conscious admin may want to only allow specific headers in or out. This PR implements allow lists for request headers, response headers and response trailers as per route transforms.

I also backfilled some tests for the Request/Response/Trailers Remove transforms and fixed a bug with ResponseHeaderRemove using the wrong key. (Fixes #1141)