### PR TITLE
Removed invalid/unneeded using statements

### DIFF
--- a/docs/docfx/articles/config-providers.md
+++ b/docs/docfx/articles/config-providers.md
@@ -62,9 +62,7 @@ The following is an example `IProxyConfigProvider` that has routes and clusters 
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.Extensions.Primitives;
-using Yarp.ReverseProxy.Abstractions;
 using Yarp.ReverseProxy.Configuration;
-using Yarp.ReverseProxy.Service;
 
 namespace Microsoft.Extensions.DependencyInjection
 {


### PR DESCRIPTION
I copy and pasted the same code into the test project and found the two using statements are no longer needed and/or valid.