### PR TITLE
Use the max of reactivation and detection periods for reactivation delay

### DIFF
--- a/src/ReverseProxy/Health/TransportFailureRateHealthPolicy.cs
+++ b/src/ReverseProxy/Health/TransportFailureRateHealthPolicy.cs
@@ -49,6 +49,7 @@ namespace Yarp.ReverseProxy.Health
             var error = context.Features.Get<IForwarderErrorFeature>();
             var newHealth = EvaluateProxiedRequest(cluster, destination, error != null);
             var clusterReactivationPeriod = cluster.Model.Config.HealthCheck?.Passive?.ReactivationPeriod ?? _defaultReactivationPeriod;
+            // Avoid reactivating until the history has expired so that it does not affect future health assessments.
             var reactivationPeriod = clusterReactivationPeriod >= _policyOptions.DetectionWindowSize ? clusterReactivationPeriod : _policyOptions.DetectionWindowSize;
             _healthUpdater.SetPassive(cluster, destination, newHealth, reactivationPeriod);
         }

--- a/src/ReverseProxy/Health/TransportFailureRateHealthPolicy.cs
+++ b/src/ReverseProxy/Health/TransportFailureRateHealthPolicy.cs
@@ -64,7 +64,12 @@ namespace Yarp.ReverseProxy.Health
                     (long)_policyOptions.DetectionWindowSize.TotalMilliseconds,
                     _policyOptions.MinimalTotalCountThreshold,
                     failed);
-                return failureRate < rateLimit ? DestinationHealth.Healthy : DestinationHealth.Unhealthy;
+                var newHealthState =  failureRate < rateLimit ? DestinationHealth.Healthy : DestinationHealth.Unhealthy;
+                if (newHealthState == DestinationHealth.Unhealthy)
+                {
+                    history.Clear();
+                }
+                return newHealthState;
             }
         }
 
@@ -118,6 +123,16 @@ namespace Yarp.ReverseProxy.Health
                 }
 
                 return _totalCount < totalCountThreshold || _totalCount == 0 ? 0.0 : _failedCount / _totalCount;
+            }
+
+            public void Clear()
+            {
+                _records.Clear();
+                _failedCount = 0;
+                _totalCount = 0;
+                _nextRecordCreatedAt = 0;
+                _nextRecordTotalCount = 0;
+                _nextRecordFailedCount = 0;
             }
 
             private readonly struct HistoryRecord


### PR DESCRIPTION
When `TransportFailureRatePolicy` is configured with ReactivationPeriod < DetectionWindowSize, an unhealthy destination sent for cool down and then reactivated can be marked as unhealthy on the first request right after reactivation even if such a request completed successfully.

To avoid that issue, we will use the max of reactivation and detection periods for the reactivation delay.

Fixes #1082