### PR TITLE
Improve EntityActionScheduler reliability

### DIFF
--- a/src/ReverseProxy/Utilities/ConcurrentDictionaryExtensions.cs
+++ b/src/ReverseProxy/Utilities/ConcurrentDictionaryExtensions.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace Yarp.ReverseProxy.Utilities
+{
+    internal static class ConcurrentDictionaryExtensions
+    {
+        public static bool Contains<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> dictionary, KeyValuePair<TKey, TValue> item)
+            where TKey : notnull
+        {
+            return ((ICollection<KeyValuePair<TKey, TValue>>)dictionary).Contains(item);
+        }
+
+#if !NET
+        public static bool TryRemove<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> dictionary, KeyValuePair<TKey, TValue> item)
+            where TKey : notnull
+        {
+            return ((ICollection<KeyValuePair<TKey, TValue>>)dictionary).Remove(item);
+        }
+#endif
+    }
+}

--- a/test/ReverseProxy.Tests/Health/EntityActionSchedulerTests.cs
+++ b/test/ReverseProxy.Tests/Health/EntityActionSchedulerTests.cs
@@ -198,7 +198,7 @@ namespace Yarp.ReverseProxy.Health.Tests
         }
 
         [Fact]
-        public void ChangePeriod_TimerStartedPeriodChangedAfterFirstCall_PeriodChangedBeforeNextCall()
+        public void ChangePeriod_TimerStartedPeriodChangedAfterFirstCall_PeriodChangedAfterNextCall()
         {
             var entity = new Entity { Id = "entity0" };
             Entity lastInvokedEntity = null;
@@ -213,10 +213,14 @@ namespace Yarp.ReverseProxy.Health.Tests
             timerFactory.VerifyTimer(0, Period0);
 
             timerFactory.FireTimer(0);
+            timerFactory.VerifyTimer(0, Period0);
+            Assert.Same(entity, lastInvokedEntity);
 
             var newPeriod = TimeSpan.FromMilliseconds(Period1);
             scheduler.ChangePeriod(entity, newPeriod);
+            timerFactory.VerifyTimer(0, Period0);
 
+            timerFactory.FireTimer(0);
             timerFactory.VerifyTimer(0, Period1);
             Assert.Same(entity, lastInvokedEntity);
         }


### PR DESCRIPTION
The scheduler has a few issues right now:

- Changing the period or removing+adding an entry for the same key while the callback is (or is about to be) run will result in the callback firing multiple times. The callbacks will keep rescheduling themselves even if the entry has since been removed (it was only checking the key was in the dictionary)
- Updating the period of a timer on a frequency higher than that of the period would result in the callback never firing
  - Changed the entry so that updating the period does not call `Change` on the timer (which is racy). Instead, the timer is only rescheduled during the callback. This means that a period change will only take place after the timer fires - it is a slight change in behavior, but one that should not matter for YARP.
- Calls to `ScheduleEntity` or `ChangePeriod` after calling dispose (or in a race) could keep the scheduler and all its state rooted forever (the callback passed to the timer contained a captured reference to the scheduler) - this could result in random memory leaks if the app was recycling the state without restarting (likely not common with YARP)
  - Changed the implementation so that the timer callback does not capture state, and a weak reference to the scheduler is kept by entries instead
- The timers it creates will capture the user's `ExecutionContext`, keeping random `AsyncLocal`s alive
  - Added EC suppression when creating the timer
- An exception thrown by the callback would not be cought while executing on the ThreadPool (not currently an issue since none of our callbacks will throw)