### PR TITLE
Set ActivityContextHeaders default to CorrelationContext only

### DIFF
--- a/src/ReverseProxy/Forwarder/ForwarderHttpClientFactory.cs
+++ b/src/ReverseProxy/Forwarder/ForwarderHttpClientFactory.cs
@@ -128,7 +128,7 @@ namespace Yarp.ReverseProxy.Forwarder
         /// </summary>
         protected virtual HttpMessageHandler WrapHandler(ForwarderHttpClientContext context, HttpMessageHandler handler)
         {
-            var activityContextHeaders = context.NewConfig.ActivityContextHeaders.GetValueOrDefault(ActivityContextHeaders.BaggageAndCorrelationContext);
+            var activityContextHeaders = context.NewConfig.ActivityContextHeaders.GetValueOrDefault(ActivityContextHeaders.CorrelationContext);
             if (activityContextHeaders != ActivityContextHeaders.None)
             {
                 handler = new ActivityPropagationHandler(activityContextHeaders, handler);


### PR DESCRIPTION
Contributes to #708

This matches the default used by runtime
https://github.com/dotnet/runtime/blob/c83b6edc1c1f500565bc5d53cfd726463ce2f56b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DistributedContextPropagator.cs#L123
and will make the change smaller if/when we remove the `ActivityPropagationHandler` from YARP.