### PR TITLE
Allow empty headers

### DIFF
--- a/src/ReverseProxy/Forwarder/HttpTransformer.cs
+++ b/src/ReverseProxy/Forwarder/HttpTransformer.cs
@@ -41,8 +41,7 @@ namespace Yarp.ReverseProxy.Forwarder
             {
                 var headerName = header.Key;
                 var headerValue = header.Value;
-                if (StringValues.IsNullOrEmpty(headerValue)
-                    || RequestUtilities.ShouldSkipRequestHeader(headerName))
+                if (RequestUtilities.ShouldSkipRequestHeader(headerName))
                 {
                     continue;
                 }
@@ -110,7 +109,11 @@ namespace Yarp.ReverseProxy.Forwarder
                 }
 
                 Debug.Assert(header.Value is string[]);
-                destination.Append(headerName, header.Value as string[] ?? header.Value.ToArray());
+                var values = header.Value as string[] ?? header.Value.ToArray();
+                // We want to append to any prior values, if any.
+                // Not using Append here because it skips empty headers.
+                values = StringValues.Concat(destination[headerName], values);
+                destination[headerName] = values;
             }
         }
     }


### PR DESCRIPTION
Customers concerned with proxying requests as faithfully as possible have raised concerns about not proxying headers with empty values. It looks like empty header values are supported by Kestrel and HttpClient, it was YARP that was filtering them out.

Note I think the ASP.NET Core HttpSys and IIS servers filter out empty response headers, but that's not a blocker here.