### PR TITLE
Fix race in ActiveHealthCheckMonitorTests

### DIFF
--- a/test/ReverseProxy.Tests/Health/ActiveHealthCheckMonitorTests.cs
+++ b/test/ReverseProxy.Tests/Health/ActiveHealthCheckMonitorTests.cs
@@ -491,16 +491,22 @@ namespace Yarp.ReverseProxy.Health.Tests
         {
             var policy = new Mock<IActiveHealthCheckPolicy>();
             policy.SetupGet(p => p.Name).Returns("policy0");
-            var options = Options.Create(new ActiveHealthCheckMonitorOptions { DefaultInterval = TimeSpan.FromSeconds(60), DefaultTimeout = TimeSpan.FromSeconds(1) });
+            var options = Options.Create(new ActiveHealthCheckMonitorOptions { DefaultInterval = TimeSpan.FromSeconds(60), DefaultTimeout = TimeSpan.FromMilliseconds(1) });
             var clusters = new List<ClusterState>();
             var monitor = new ActiveHealthCheckMonitor(options, new[] { policy.Object }, new DefaultProbingRequestFactory(), new Mock<ITimerFactory>().Object, GetLogger());
 
-            var tcs0 = new TaskCompletionSource<HttpResponseMessage>();
+            var assertsCompletedMre = new ManualResetEventSlim(false);
+
+            var tcs0 = new TaskCompletionSource<HttpResponseMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
             var httpClient0 = GetHttpClient(tcs0.Task);
             var cluster0 = GetClusterInfo("cluster0", "policy0", true, httpClient0.Object, destinationCount: 1);
             clusters.Add(cluster0);
-            var tcs1 = new TaskCompletionSource<HttpResponseMessage>();
-            var httpClient1 = GetHttpClient(tcs1.Task, () => tcs1.SetCanceled());
+            var tcs1 = new TaskCompletionSource<HttpResponseMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var httpClient1 = GetHttpClient(tcs1.Task, () =>
+            {
+                assertsCompletedMre.Wait();
+                tcs1.SetCanceled();
+            });
             var cluster1 = GetClusterInfo("cluster1", "policy0", true, httpClient1.Object, destinationCount: 1);
             clusters.Add(cluster1);
 
@@ -515,6 +521,8 @@ namespace Yarp.ReverseProxy.Health.Tests
 
             Assert.False(healthCheckTask.IsCompleted);
             Assert.False(monitor.InitialProbeCompleted);
+
+            assertsCompletedMre.Set();
 
             // Never set result to the second destination for it to time out.
 


### PR DESCRIPTION
The test is checking that the initial health probe will finish even if some of the request time out.
There is a race here where the timeout may happen (and the task finishes) before any of our asserts are run.

The following asserts may fail because of the race:
https://github.com/MihaZupan/reverse-proxy/blob/5fb636c0ab26005548710895f673dcdd5f987229/test/ReverseProxy.Tests/Health/ActiveHealthCheckMonitorTests.cs#L516-L517

This happened a few times in CI on main:
https://github.com/microsoft/reverse-proxy/runs/3426104789
https://github.com/microsoft/reverse-proxy/runs/2797519908