### PR TITLE
Fix Telemetry test for .NET 6.0

### DIFF
--- a/test/ReverseProxy.FunctionalTests/TelemetryConsumptionTests.cs
+++ b/test/ReverseProxy.FunctionalTests/TelemetryConsumptionTests.cs
@@ -112,6 +112,9 @@ namespace Yarp.ReverseProxy
                 "OnHandshakeStart",
                 "OnHandshakeStop",
                 "OnConnectionEstablished",
+#if NET6_0_OR_GREATER
+                "OnRequestLeftQueue",
+#endif
                 "OnRequestHeadersStart",
                 "OnRequestHeadersStop",
                 "OnResponseHeadersStart",
@@ -159,6 +162,9 @@ namespace Yarp.ReverseProxy
                 "OnConnectStart",
                 "OnConnectStop",
                 "OnConnectionEstablished",
+#if NET6_0_OR_GREATER
+                "OnRequestLeftQueue",
+#endif
                 "OnRequestHeadersStart",
                 "OnRequestHeadersStop",
                 "OnResponseHeadersStart",


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/53851 reworked the connection pooling logic, so now any time a request waits for a connection to be established, it will also log the `RequestLeftQueue` event.