### PR TITLE
Remove the Content-Length header

### DIFF
--- a/test/ReverseProxy.FunctionalTests/HeaderTests.cs
+++ b/test/ReverseProxy.FunctionalTests/HeaderTests.cs
@@ -387,5 +387,83 @@ namespace Yarp.ReverseProxy
             }
         }
 #endif
+
+        [Fact]
+        public async Task ContentLengthAndTransferEncoding_ContentLengthRemoved()
+        {
+            var proxyTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var test = new TestEnvironment(
+                context =>
+                {
+                    try
+                    {
+                        Assert.Null(context.Request.ContentLength);
+                        Assert.Equal("chunked", context.Request.Headers[HeaderNames.TransferEncoding]);
+                        appTcs.SetResult(0);
+                    }
+                    catch (Exception ex)
+                    {
+                        appTcs.SetException(ex);
+                    }
+                    return Task.CompletedTask;
+                },
+                proxyBuilder => { },
+                proxyApp =>
+                {
+                    proxyApp.Use(async (context, next) =>
+                    {
+                        try
+                        {
+                            Assert.Equal(11, context.Request.ContentLength);
+                            Assert.Equal("chunked", context.Request.Headers[HeaderNames.TransferEncoding]);
+                            proxyTcs.SetResult(0);
+                        }
+                        catch (Exception ex)
+                        {
+                            proxyTcs.SetException(ex);
+                        }
+
+                        await next();
+                    });
+                },
+                proxyProtocol: HttpProtocols.Http1);
+
+            await test.Invoke(async proxyUri =>
+            {
+                var proxyHostUri = new Uri(proxyUri);
+
+                using var tcpClient = new TcpClient(proxyHostUri.Host, proxyHostUri.Port);
+                await using var stream = tcpClient.GetStream();
+                await stream.WriteAsync(Encoding.ASCII.GetBytes("GET / HTTP/1.1\r\n"));
+                await stream.WriteAsync(Encoding.ASCII.GetBytes($"Host: {proxyHostUri.Host}:{proxyHostUri.Port}\r\n"));
+                await stream.WriteAsync(Encoding.ASCII.GetBytes($"Content-Length: 11\r\n"));
+                await stream.WriteAsync(Encoding.ASCII.GetBytes($"Transfer-Encoding: chunked\r\n"));
+                await stream.WriteAsync(Encoding.ASCII.GetBytes($"Connection: close\r\n"));
+                await stream.WriteAsync(Encoding.ASCII.GetBytes("\r\n"));
+                await stream.WriteAsync(Encoding.ASCII.GetBytes($"b\r\n"));
+                await stream.WriteAsync(Encoding.ASCII.GetBytes($"Hello World\r\n"));
+                await stream.WriteAsync(Encoding.ASCII.GetBytes($"0\r\n"));
+                await stream.WriteAsync(Encoding.ASCII.GetBytes($"\r\n"));
+                var buffer = new byte[4096];
+                var responseBuilder = new StringBuilder();
+                while (true)
+                {
+                    var count = await stream.ReadAsync(buffer);
+                    if (count == 0)
+                    {
+                        break;
+                    }
+                    responseBuilder.Append(Encoding.ASCII.GetString(buffer, 0, count));
+                }
+                var response = responseBuilder.ToString();
+
+                await proxyTcs.Task;
+                await appTcs.Task;
+
+                Assert.StartsWith("HTTP/1.1 200 OK", response);
+            });
+        }
     }
 }

--- a/test/ReverseProxy.Tests/Forwarder/HttpTransformerTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/HttpTransformerTests.cs
@@ -1,0 +1,155 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+
+namespace Yarp.ReverseProxy.Forwarder.Tests
+{
+    public class HttpTransformerTests
+    {
+        private static readonly string[] RestrictedHeaders = new[]
+        {
+            HeaderNames.TransferEncoding,
+            HeaderNames.KeepAlive,
+            HeaderNames.Upgrade,
+            "Proxy-Connection",
+            "Proxy-Authenticate",
+            "Proxy-Authentication-Info",
+            "Proxy-Authorization",
+            "Proxy-Features",
+            "Proxy-Instruction",
+            "Security-Scheme",
+            "ALPN",
+            "Close",
+            "HTTP2-Settings",
+            "Upgrade-Insecure-Requests",
+            HeaderNames.TE,
+#if NET
+            HeaderNames.AltSvc,
+#else
+            "Alt-Svc",
+#endif
+        };
+
+        [Fact]
+        public async Task TransformRequestAsync_RemovesRestrictedHeaders()
+        {
+            var transformer = HttpTransformer.Default;
+            var httpContext = new DefaultHttpContext();
+            var proxyRequest = new HttpRequestMessage();
+
+            foreach (var header in RestrictedHeaders)
+            {
+                httpContext.Request.Headers[header] = "value";
+            }
+
+            await transformer.TransformRequestAsync(httpContext, proxyRequest, "prefix");
+
+            foreach (var header in RestrictedHeaders)
+            {
+                Assert.False(proxyRequest.Headers.Contains(header));
+            }
+
+            Assert.Null(proxyRequest.Content);
+        }
+
+        [Fact]
+        public async Task TransformRequestAsync_ContentLengthAndTransferEncoding_ContentLengthRemoved()
+        {
+            var transformer = HttpTransformer.Default;
+            var httpContext = new DefaultHttpContext();
+            var proxyRequest = new HttpRequestMessage()
+            {
+                Content = new ByteArrayContent(Array.Empty<byte>())
+            };
+
+            httpContext.Request.Headers[HeaderNames.TransferEncoding] = "chUnked";
+            httpContext.Request.Headers[HeaderNames.ContentLength] = "10";
+
+            await transformer.TransformRequestAsync(httpContext, proxyRequest, "prefix");
+
+            Assert.False(proxyRequest.Content.Headers.TryGetValues(HeaderNames.ContentLength, out var _));
+            // Transfer-Encoding is on the restricted list and removed. HttpClient will re-add it if required.
+            Assert.False(proxyRequest.Headers.TryGetValues(HeaderNames.TransferEncoding, out var _));
+        }
+
+        [Fact]
+        public async Task TransformResponseAsync_RemovesRestrictedHeaders()
+        {
+            var transformer = HttpTransformer.Default;
+            var httpContext = new DefaultHttpContext();
+            var proxyResponse = new HttpResponseMessage()
+            {
+                Content = new ByteArrayContent(Array.Empty<byte>())
+            };
+
+            foreach (var header in RestrictedHeaders)
+            {
+                if (!proxyResponse.Headers.TryAddWithoutValidation(header,"value"))
+                {
+                    Assert.True(proxyResponse.Content.Headers.TryAddWithoutValidation(header, "value"));
+                }
+            }
+
+            await transformer.TransformResponseAsync(httpContext, proxyResponse);
+
+            foreach (var header in RestrictedHeaders)
+            {
+                Assert.False(httpContext.Response.Headers.ContainsKey(header));
+            }
+        }
+
+        [Fact]
+        public async Task TransformResponseAsync_ContentLengthAndTransferEncoding_ContentLengthRemoved()
+        {
+            var transformer = HttpTransformer.Default;
+            var httpContext = new DefaultHttpContext();
+            var proxyResponse = new HttpResponseMessage()
+            {
+                Content = new ByteArrayContent(new byte[10])
+            };
+
+            proxyResponse.Headers.TransferEncodingChunked = true;
+            Assert.Equal(10, proxyResponse.Content.Headers.ContentLength);
+
+            await transformer.TransformResponseAsync(httpContext, proxyResponse);
+
+            Assert.False(httpContext.Response.Headers.ContainsKey(HeaderNames.ContentLength));
+            // Transfer-Encoding is on the restricted list and removed. HttpClient will re-add it if required.
+            Assert.False(httpContext.Response.Headers.ContainsKey(HeaderNames.TransferEncoding));
+        }
+
+        [Fact]
+        public async Task TransformResponseTrailersAsync_RemovesRestrictedHeaders()
+        {
+            var transformer = HttpTransformer.Default;
+            var httpContext = new DefaultHttpContext();
+            var trailersFeature = new TestTrailersFeature();
+            httpContext.Features.Set<IHttpResponseTrailersFeature>(trailersFeature);
+            var proxyResponse = new HttpResponseMessage();
+
+            foreach (var header in RestrictedHeaders)
+            {
+                Assert.True(proxyResponse.TrailingHeaders.TryAddWithoutValidation(header, "value"));
+            }
+
+            await transformer.TransformResponseTrailersAsync(httpContext, proxyResponse);
+
+            foreach (var header in RestrictedHeaders)
+            {
+                Assert.False(trailersFeature.Trailers.ContainsKey(header));
+            }
+        }
+
+        private class TestTrailersFeature : IHttpResponseTrailersFeature
+        {
+            public IHeaderDictionary Trailers { get; set; } = new HeaderDictionary();
+        }
+    }
+}


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.3
```
       If a message is received with both a Transfer-Encoding and a
       Content-Length header field, the Transfer-Encoding overrides the
       Content-Length.  Such a message might indicate an attempt to
       perform request smuggling (Section 9.5) or response splitting
       (Section 9.4) and ought to be handled as an error.  A sender MUST
       remove the received Content-Length field prior to forwarding such
       a message downstream.
```

We've decided to remove the Content-Length header in this scenario as a precaution.