### PR TITLE
Update the patching instructions

### DIFF
--- a/docs/operations/BackportingToPreview.md
+++ b/docs/operations/BackportingToPreview.md
@@ -12,10 +12,9 @@ Backporting changes is very similar to a regular release. Changes are made on th
 - Package Artifacts from this build can be shared to validate the patch. Optionally, the artifacts from the [public pipeline](https://dev.azure.com/dnceng/public/_build?definitionId=807&view=branches) can be used
 - Continue iterating on the preview branch until satisfied with the validation of the change
 - [Release the build](https://github.com/microsoft/reverse-proxy/blob/main/docs/operations/Release.md#release-the-build) from the preview branch
-- Update the preview tag to the released commit
+- Create a new git tag for the released commit
 
   **While still on the preview branch:**
-  - `git tag -d v1.0.0-previewX` (delete the current tag)
-  - `git tag v1.0.0-previewX` (re-create the tag on the current commit)
-  - `git push upstream --tags --force` (force push the tag change to the upstream repo (**not your fork**))
-- Update the description of the [release](https://github.com/microsoft/reverse-proxy/releases) if necessary. The associated tag/commit will be automatically updated by the previous step.
+  - `git tag v1.0.0-previewX.build.d`
+  - `git push upstream --tags`
+- Create a new [release](https://github.com/microsoft/reverse-proxy/releases).


### PR DESCRIPTION
Clarifying some points in the patching instructions:
- A patch is a new release. Do not edit prior releases or delete prior tags.
- Use the full build number to identify patch releases.

E.g. Preview 12 was tagged as v1.0.0-preview12. The patch for preview12 was tagged as v1.0.0-preview12.21451.3.