### PR TITLE
Remove Forwarded header when X-Forwarded transforms added and vice versa

### DIFF
--- a/src/ReverseProxy/Transforms/Builder/TransformHelpers.cs
+++ b/src/ReverseProxy/Transforms/Builder/TransformHelpers.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Yarp.ReverseProxy.Utilities;
 
 namespace Yarp.ReverseProxy.Transforms.Builder
 {
@@ -22,6 +23,19 @@ namespace Yarp.ReverseProxy.Transforms.Builder
             {
                 throw new InvalidOperationException("The transform contains more parameters than expected: " + string.Join(';', rawTransform.Keys));
             }
+        }
+
+        internal static void RemoveAllXForwardedHeaders(TransformBuilderContext context, string prefix)
+        {
+            context.AddXForwardedFor(prefix + ForwardedTransformFactory.ForKey, ForwardedTransformActions.Remove);
+            context.AddXForwardedPrefix(prefix + ForwardedTransformFactory.PrefixKey, ForwardedTransformActions.Remove);
+            context.AddXForwardedHost(prefix + ForwardedTransformFactory.HostKey, ForwardedTransformActions.Remove);
+            context.AddXForwardedProto(prefix + ForwardedTransformFactory.ProtoKey, ForwardedTransformActions.Remove);
+        }
+
+        internal static void RemoveForwadedHeader(TransformBuilderContext context, IRandomFactory randomFactory)
+        {
+            context.RequestTransforms.Add(new RequestHeaderForwardedTransform(randomFactory, NodeFormat.Random, NodeFormat.Random, false, false, ForwardedTransformActions.Remove));
         }
     }
 }

--- a/src/ReverseProxy/Transforms/Builder/TransformHelpers.cs
+++ b/src/ReverseProxy/Transforms/Builder/TransformHelpers.cs
@@ -33,9 +33,9 @@ namespace Yarp.ReverseProxy.Transforms.Builder
             context.AddXForwardedProto(prefix + ForwardedTransformFactory.ProtoKey, ForwardedTransformActions.Remove);
         }
 
-        internal static void RemoveForwadedHeader(TransformBuilderContext context, IRandomFactory randomFactory)
+        internal static void RemoveForwadedHeader(TransformBuilderContext context)
         {
-            context.RequestTransforms.Add(new RequestHeaderForwardedTransform(randomFactory, NodeFormat.Random, NodeFormat.Random, false, false, ForwardedTransformActions.Remove));
+            context.RequestTransforms.Add(RequestHeaderForwardedTransform.RemoveTransform);
         }
     }
 }

--- a/src/ReverseProxy/Transforms/ForwardedTransformExtensions.cs
+++ b/src/ReverseProxy/Transforms/ForwardedTransformExtensions.cs
@@ -119,6 +119,10 @@ namespace Yarp.ReverseProxy.Transforms
             context.AddXForwardedPrefix(action: action);
             context.AddXForwardedHost(action: action);
             context.AddXForwardedProto(action: action);
+
+            // Remove the Forwarded header when an X-Forwarded transform is enabled
+            var random = context.Services.GetRequiredService<IRandomFactory>();
+            TransformHelpers.RemoveForwadedHeader(context, random);
             return context;
         }
 
@@ -186,6 +190,9 @@ namespace Yarp.ReverseProxy.Transforms
                 var random = context.Services.GetRequiredService<IRandomFactory>();
                 context.RequestTransforms.Add(new RequestHeaderForwardedTransform(random,
                     forFormat, byFormat, useHost, useProto, action));
+
+                // Remove the X-Forwarded headers when an Forwarded transform is enabled
+                TransformHelpers.RemoveAllXForwardedHeaders(context, ForwardedTransformFactory.DefaultXForwardedPrefix);
             }
             return context;
         }

--- a/src/ReverseProxy/Transforms/ForwardedTransformExtensions.cs
+++ b/src/ReverseProxy/Transforms/ForwardedTransformExtensions.cs
@@ -121,8 +121,7 @@ namespace Yarp.ReverseProxy.Transforms
             context.AddXForwardedProto(action: action);
 
             // Remove the Forwarded header when an X-Forwarded transform is enabled
-            var random = context.Services.GetRequiredService<IRandomFactory>();
-            TransformHelpers.RemoveForwadedHeader(context, random);
+            TransformHelpers.RemoveForwadedHeader(context);
             return context;
         }
 

--- a/src/ReverseProxy/Transforms/ForwardedTransformFactory.cs
+++ b/src/ReverseProxy/Transforms/ForwardedTransformFactory.cs
@@ -175,6 +175,13 @@ namespace Yarp.ReverseProxy.Transforms
                 context.AddXForwardedPrefix(prefix + PrefixKey, xPrefixAction);
                 context.AddXForwardedHost(prefix + HostKey, xHostAction);
                 context.AddXForwardedProto(prefix + ProtoKey, xProtoAction);
+
+                if (xForAction != ForwardedTransformActions.Off || xPrefixAction != ForwardedTransformActions.Off
+                    || xHostAction != ForwardedTransformActions.Off || xProtoAction != ForwardedTransformActions.Off)
+                {
+                    //Remove the Forwarded header when an X-Forwarded transform is enabled
+                    context.RequestTransforms.Add(new RequestHeaderForwardedTransform(_randomFactory, NodeFormat.Random, NodeFormat.Random, false, false, ForwardedTransformActions.Remove));
+                }
             }
             else if (transformValues.TryGetValue(ForwardedKey, out var forwardedHeader))
             {
@@ -242,6 +249,13 @@ namespace Yarp.ReverseProxy.Transforms
                 {
                     // Not using the extension to avoid resolving the random factory each time.
                     context.RequestTransforms.Add(new RequestHeaderForwardedTransform(_randomFactory, forFormat, byFormat, useHost, useProto, headerAction));
+
+                    //Remove the X-Forwarded headers when an Forwarded transform is enabled
+                    var prefix = "X-Forwarded-";
+                    context.AddXForwardedFor(prefix + ForKey, ForwardedTransformActions.Remove);
+                    context.AddXForwardedPrefix(prefix + PrefixKey, ForwardedTransformActions.Remove);
+                    context.AddXForwardedHost(prefix + HostKey, ForwardedTransformActions.Remove);
+                    context.AddXForwardedProto(prefix + ProtoKey, ForwardedTransformActions.Remove);
                 }
             }
             else if (transformValues.TryGetValue(ClientCertKey, out var clientCertHeader))

--- a/src/ReverseProxy/Transforms/ForwardedTransformFactory.cs
+++ b/src/ReverseProxy/Transforms/ForwardedTransformFactory.cs
@@ -181,7 +181,7 @@ namespace Yarp.ReverseProxy.Transforms
                     || xHostAction != ForwardedTransformActions.Off || xProtoAction != ForwardedTransformActions.Off)
                 {
                     // Remove the Forwarded header when an X-Forwarded transform is enabled
-                    TransformHelpers.RemoveForwadedHeader(context, _randomFactory);
+                    TransformHelpers.RemoveForwadedHeader(context);
                 }
             }
             else if (transformValues.TryGetValue(ForwardedKey, out var forwardedHeader))

--- a/src/ReverseProxy/Transforms/RequestHeaderForwardedTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderForwardedTransform.cs
@@ -16,6 +16,9 @@ namespace Yarp.ReverseProxy.Transforms
     /// </summary>
     public class RequestHeaderForwardedTransform : RequestTransform
     {
+        internal static readonly RequestHeaderForwardedTransform RemoveTransform =
+            new RequestHeaderForwardedTransform(new NullRandomFactory(), NodeFormat.Random, NodeFormat.Random, false, false, ForwardedTransformActions.Remove);
+
         private static readonly string ForwardedHeaderName = "Forwarded";
         // obfnode = "_" 1*( ALPHA / DIGIT / "." / "_" / "-")
         private static readonly string ObfChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-";

--- a/src/ReverseProxy/Utilities/NullRandomFactory.cs
+++ b/src/ReverseProxy/Utilities/NullRandomFactory.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Yarp.ReverseProxy.Utilities
+{
+    internal class NullRandomFactory : IRandomFactory
+    {
+        public Random CreateRandomInstance()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/ReverseProxy.Tests/Transforms/Builder/TransformBuilderTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/Builder/TransformBuilderTests.cs
@@ -163,7 +163,7 @@ namespace Yarp.ReverseProxy.Transforms.Builder.Tests
             var factory1 = new TestTransformFactory("1");
             var factory2 = new TestTransformFactory("2");
             var factory3 = new TestTransformFactory("3");
-            var builder = new TransformBuilder(GetServiceProviderWithRandom(),
+            var builder = new TransformBuilder(new ServiceCollection().BuildServiceProvider(),
                 new[] { factory1, factory2, factory3 }, Array.Empty<ITransformProvider>());
 
             var route = new RouteConfig().WithTransform(transform =>
@@ -190,7 +190,7 @@ namespace Yarp.ReverseProxy.Transforms.Builder.Tests
             var provider1 = new TestTransformProvider();
             var provider2 = new TestTransformProvider();
             var provider3 = new TestTransformProvider();
-            var builder = new TransformBuilder(GetServiceProviderWithRandom(),
+            var builder = new TransformBuilder(new ServiceCollection().BuildServiceProvider(),
                 Array.Empty<ITransformFactory>(), new[] { provider1, provider2, provider3 });
 
             var route = new RouteConfig();
@@ -415,16 +415,10 @@ namespace Yarp.ReverseProxy.Transforms.Builder.Tests
         private static TransformBuilder CreateTransformBuilder()
         {
             var serviceCollection = new ServiceCollection();
-            serviceCollection.AddSingleton(new Moq.Mock<IRandomFactory>().Object);
             serviceCollection.AddLogging();
             serviceCollection.AddReverseProxy();
-            var services = serviceCollection.BuildServiceProvider();
+            using var services = serviceCollection.BuildServiceProvider();
             return (TransformBuilder)services.GetRequiredService<ITransformBuilder>();
-        }
-
-        private ServiceProvider GetServiceProviderWithRandom()
-        {
-            return new ServiceCollection().AddSingleton(new Moq.Mock<IRandomFactory>().Object).BuildServiceProvider();
         }
 
         private class TestTransformFactory : ITransformFactory

--- a/test/ReverseProxy.Tests/Transforms/Builder/TransformBuilderTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/Builder/TransformBuilderTests.cs
@@ -393,7 +393,14 @@ namespace Yarp.ReverseProxy.Transforms.Builder.Tests
             Assert.Empty(errors);
 
             var results = transformBuilder.BuildInternal(route, new ClusterConfig());
-            var transform = Assert.Single(results.RequestTransforms);
+            Assert.Equal(5, results.RequestTransforms.Count);
+            Assert.All(
+                results.RequestTransforms.Skip(1).Select(t => (dynamic)t),
+                t => {
+                    Assert.StartsWith("X-Forwarded-", t.HeaderName);
+                    Assert.Equal(ForwardedTransformActions.Remove, t.TransformAction);
+                });
+            var transform = results.RequestTransforms[0];
             var forwardedTransform = Assert.IsType<RequestHeaderForwardedTransform>(transform);
             Assert.True(forwardedTransform.ProtoEnabled);
         }

--- a/test/ReverseProxy.Tests/Transforms/ForwardedTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/ForwardedTransformExtensionsTests.cs
@@ -175,7 +175,14 @@ namespace Yarp.ReverseProxy.Transforms.Tests
 
             if (byFormat != NodeFormat.None|| forFormat != NodeFormat.None || useHost || useProto)
             {
-                var transform = Assert.Single(builderContext.RequestTransforms);
+                Assert.Equal(5, builderContext.RequestTransforms.Count);
+                Assert.All(
+                    builderContext.RequestTransforms.Skip(1).Select(t => (dynamic) t),
+                    t => {
+                        Assert.StartsWith("X-Forwarded-", t.HeaderName);
+                        Assert.Equal(ForwardedTransformActions.Remove, t.TransformAction);
+                    });
+                var transform = builderContext.RequestTransforms[0];
                 var requestHeaderForwardedTransform = Assert.IsType<RequestHeaderForwardedTransform>(transform);
                 Assert.Equal(action, requestHeaderForwardedTransform.TransformAction);
                 Assert.Equal(useHost, requestHeaderForwardedTransform.HostEnabled);


### PR DESCRIPTION
If X-Forwarded-* transforms are enabled by any way (default or manually), a transform removing Forwarded header is added automatically. On the opposite, if Forwarded transform is added, the transforms removing all X-Forwarded-* headers are added automatically.

Fixes #1070