### PR TITLE
Remove cancellation token from IProxyConfigFilter

### DIFF
--- a/src/ReverseProxy/Configuration/IProxyConfigFilter.cs
+++ b/src/ReverseProxy/Configuration/IProxyConfigFilter.cs
@@ -15,13 +15,13 @@ namespace Yarp.ReverseProxy.Configuration
         /// Allows modification of a cluster configuration.
         /// </summary>
         /// <param name="cluster">The <see cref="ClusterConfig"/> instance to configure.</param>
-        ValueTask<ClusterConfig> ConfigureClusterAsync(ClusterConfig cluster, CancellationToken cancel);
+        ValueTask<ClusterConfig> ConfigureClusterAsync(ClusterConfig cluster);
 
         /// <summary>
         /// Allows modification of a route configuration.
         /// </summary>
         /// <param name="route">The <see cref="RouteConfig"/> instance to configure.</param>
         /// <param name="cluster">The <see cref="ClusterConfig"/> instance related to <see cref="RouteConfig"/>.</param>
-        ValueTask<RouteConfig> ConfigureRouteAsync(RouteConfig route, ClusterConfig? cluster, CancellationToken cancel);
+        ValueTask<RouteConfig> ConfigureRouteAsync(RouteConfig route, ClusterConfig? cluster);
     }
 }

--- a/src/ReverseProxy/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Management/ProxyConfigManager.cs
@@ -212,8 +212,8 @@ namespace Yarp.ReverseProxy.Management
         // Throws for validation failures
         private async Task<bool> ApplyConfigAsync(IProxyConfig config)
         {
-            var (configuredClusters, clusterErrors) = await VerifyClustersAsync(config.Clusters, cancellation: default);
-            var (configuredRoutes, routeErrors) = await VerifyRoutesAsync(config.Routes, configuredClusters, cancellation: default);
+            var (configuredClusters, clusterErrors) = await VerifyClustersAsync(config.Clusters);
+            var (configuredRoutes, routeErrors) = await VerifyRoutesAsync(config.Routes, configuredClusters);
 
             if (routeErrors.Count > 0 || clusterErrors.Count > 0)
             {
@@ -226,7 +226,7 @@ namespace Yarp.ReverseProxy.Management
             return routesChanged;
         }
 
-        private async Task<(IList<RouteConfig>, IList<Exception>)> VerifyRoutesAsync(IReadOnlyList<RouteConfig> routes, IReadOnlyDictionary<string, ClusterConfig> clusters, CancellationToken cancellation)
+        private async Task<(IList<RouteConfig>, IList<Exception>)> VerifyRoutesAsync(IReadOnlyList<RouteConfig> routes, IReadOnlyDictionary<string, ClusterConfig> clusters)
         {
             if (routes == null)
             {
@@ -259,7 +259,7 @@ namespace Yarp.ReverseProxy.Management
 
                         foreach (var filter in _filters)
                         {
-                            route = await filter.ConfigureRouteAsync(route, cluster, cancellation);
+                            route = await filter.ConfigureRouteAsync(route, cluster);
                         }
                     }
                 }
@@ -287,7 +287,7 @@ namespace Yarp.ReverseProxy.Management
             return (configuredRoutes, errors);
         }
 
-        private async Task<(IReadOnlyDictionary<string, ClusterConfig>, IList<Exception>)> VerifyClustersAsync(IReadOnlyList<ClusterConfig> clusters, CancellationToken cancellation)
+        private async Task<(IReadOnlyDictionary<string, ClusterConfig>, IList<Exception>)> VerifyClustersAsync(IReadOnlyList<ClusterConfig> clusters)
         {
             if (clusters == null)
             {
@@ -312,7 +312,7 @@ namespace Yarp.ReverseProxy.Management
 
                     foreach (var filter in _filters)
                     {
-                        cluster = await filter.ConfigureClusterAsync(cluster, cancellation);
+                        cluster = await filter.ConfigureClusterAsync(cluster);
                     }
 
                     var clusterErrors = await _configValidator.ValidateClusterAsync(cluster);

--- a/test/ReverseProxy.Tests/Management/ProxyConfigManagerTests.cs
+++ b/test/ReverseProxy.Tests/Management/ProxyConfigManagerTests.cs
@@ -360,12 +360,12 @@ namespace Yarp.ReverseProxy.Management.Tests
 
         private class FixRouteHostFilter : IProxyConfigFilter
         {
-            public ValueTask<ClusterConfig> ConfigureClusterAsync(ClusterConfig cluster, CancellationToken cancel)
+            public ValueTask<ClusterConfig> ConfigureClusterAsync(ClusterConfig cluster)
             {
                 return new ValueTask<ClusterConfig>(cluster);
             }
 
-            public ValueTask<RouteConfig> ConfigureRouteAsync(RouteConfig route, ClusterConfig cluster, CancellationToken cancel)
+            public ValueTask<RouteConfig> ConfigureRouteAsync(RouteConfig route, ClusterConfig cluster)
             {
                 return new ValueTask<RouteConfig>(route with
                 {
@@ -376,7 +376,7 @@ namespace Yarp.ReverseProxy.Management.Tests
 
         private class ClusterAndRouteFilter : IProxyConfigFilter
         {
-            public ValueTask<ClusterConfig> ConfigureClusterAsync(ClusterConfig cluster, CancellationToken cancel)
+            public ValueTask<ClusterConfig> ConfigureClusterAsync(ClusterConfig cluster)
             {
                 return new ValueTask<ClusterConfig>(cluster with
                 {
@@ -387,7 +387,7 @@ namespace Yarp.ReverseProxy.Management.Tests
                 });
             }
 
-            public ValueTask<RouteConfig> ConfigureRouteAsync(RouteConfig route, ClusterConfig cluster, CancellationToken cancel)
+            public ValueTask<RouteConfig> ConfigureRouteAsync(RouteConfig route, ClusterConfig cluster)
             {
                 string order;
                 if (cluster != null)
@@ -457,12 +457,12 @@ namespace Yarp.ReverseProxy.Management.Tests
 
         private class ClusterAndRouteThrows : IProxyConfigFilter
         {
-            public ValueTask<ClusterConfig> ConfigureClusterAsync(ClusterConfig cluster, CancellationToken cancel)
+            public ValueTask<ClusterConfig> ConfigureClusterAsync(ClusterConfig cluster)
             {
                 throw new NotFiniteNumberException("Test exception");
             }
 
-            public ValueTask<RouteConfig> ConfigureRouteAsync(RouteConfig route, ClusterConfig cluster, CancellationToken cancel)
+            public ValueTask<RouteConfig> ConfigureRouteAsync(RouteConfig route, ClusterConfig cluster)
             {
                 throw new NotFiniteNumberException("Test exception");
             }

--- a/testassets/ReverseProxy.Config/CustomConfigFilter.cs
+++ b/testassets/ReverseProxy.Config/CustomConfigFilter.cs
@@ -12,7 +12,7 @@ namespace Yarp.ReverseProxy.Sample
 {
     public class CustomConfigFilter : IProxyConfigFilter
     {
-        public ValueTask<ClusterConfig> ConfigureClusterAsync(ClusterConfig cluster, CancellationToken cancel)
+        public ValueTask<ClusterConfig> ConfigureClusterAsync(ClusterConfig cluster)
         {
             // How to use custom metadata to configure clusters
             if (cluster.Metadata?.TryGetValue("CustomHealth", out var customHealth) ?? false
@@ -53,7 +53,7 @@ namespace Yarp.ReverseProxy.Sample
             return new ValueTask<ClusterConfig>(cluster);
         }
 
-        public ValueTask<RouteConfig> ConfigureRouteAsync(RouteConfig route, ClusterConfig cluster, CancellationToken cancel)
+        public ValueTask<RouteConfig> ConfigureRouteAsync(RouteConfig route, ClusterConfig cluster)
         {
             // Do not let config based routes take priority over code based routes.
             // Lower numbers are higher priority. Code routes default to 0.


### PR DESCRIPTION
I think we could remove the `CancellationToken` from `IProxyConfigFilter` now. This would make sense before https://github.com/microsoft/reverse-proxy/commit/8841dac2a64b90a0eb6144f229885e832110bace with the present of `IReverseProxyConfigManager` but currently is always `CancellationToken.None`.

https://github.com/microsoft/reverse-proxy/blob/04e0afabf50eccc6e75d1029b2fed6c098bf8005/src/ReverseProxy/Management/ProxyConfigManager.cs#L215-L216