### PR TITLE
Add WebSockets telemetry

### DIFF
--- a/samples/ReverseProxy.Metrics.Sample/Startup.cs
+++ b/samples/ReverseProxy.Metrics.Sample/Startup.cs
@@ -44,6 +44,8 @@ namespace Yarp.Sample
             // Registration of a consumer to events for HttpClient telemetry
             // Note: this depends on changes implemented in .NET 5
             services.AddTelemetryConsumer<HttpClientTelemetryConsumer>();
+
+            services.AddTelemetryConsumer<WebSocketsTelemetryConsumer>();
         }
 
         /// <summary>
@@ -54,6 +56,9 @@ namespace Yarp.Sample
             // Custom middleware that collects and reports the proxy metrics
             // Placed at the beginning so it is the first and last thing run for each request
             app.UsePerRequestMetricCollection();
+
+            // Middleware used to intercept the WebSocket connection and collect telemetry exposed to WebSocketsTelemetryConsumer
+            app.UseWebSocketsTelemetry();
 
             app.UseRouting();
             app.UseEndpoints(endpoints =>

--- a/samples/ReverseProxy.Metrics.Sample/WebSocketsTelemetryConsumer.cs
+++ b/samples/ReverseProxy.Metrics.Sample/WebSocketsTelemetryConsumer.cs
@@ -1,0 +1,21 @@
+using System;
+using Microsoft.Extensions.Logging;
+using Yarp.Telemetry.Consumption;
+
+namespace Yarp.Sample
+{
+    public sealed class WebSocketsTelemetryConsumer : IWebSocketsTelemetryConsumer
+    {
+        private readonly ILogger<WebSocketsTelemetryConsumer> _logger;
+
+        public WebSocketsTelemetryConsumer(ILogger<WebSocketsTelemetryConsumer> logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public void OnWebSocketClosed(DateTime timestamp, DateTime establishedTime, WebSocketCloseReason closeReason, long messagesRead, long messagesWritten)
+        {
+            _logger.LogInformation($"WebSocket connection closed ({closeReason}) after reading {messagesRead} and writing {messagesWritten} messages over {(timestamp - establishedTime).TotalSeconds:N2} seconds.");
+        }
+    }
+}

--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -576,7 +576,7 @@ namespace Yarp.ReverseProxy.Forwarder
                 var (secondResult, secondException) = await secondTask;
                 if (secondResult != StreamCopyResult.Success)
                 {
-                    error = ReportResult(context, requestFinishedFirst, secondResult, secondException!);
+                    error = ReportResult(context, !requestFinishedFirst, secondResult, secondException!);
                 }
                 else
                 {

--- a/src/ReverseProxy/Utilities/DelegatingStream.cs
+++ b/src/ReverseProxy/Utilities/DelegatingStream.cs
@@ -1,5 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Diagnostics;
@@ -7,8 +7,9 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Yarp.Tests.Common
+namespace Yarp.ReverseProxy.Utilities
 {
+    // Taken from https://github.com/dotnet/runtime/blob/00f37bc13b4edbba1afca9e98d74432a94f5192f/src/libraries/Common/src/System/IO/DelegatingStream.cs
     // Forwards all calls to an inner stream except where overridden in a derived class.
     internal abstract class DelegatingStream : Stream
     {
@@ -113,9 +114,9 @@ namespace Yarp.Tests.Common
             return _innerStream.ReadAsync(buffer, cancellationToken);
         }
 
-        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
         {
-            return _innerStream.BeginRead(buffer, offset, count, callback, state);
+            return _innerStream.BeginRead(buffer, offset, count, callback!, state);
         }
 
         public override int EndRead(IAsyncResult asyncResult)
@@ -167,9 +168,9 @@ namespace Yarp.Tests.Common
             return _innerStream.WriteAsync(buffer, cancellationToken);
         }
 
-        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
         {
-            return _innerStream.BeginWrite(buffer, offset, count, callback, state);
+            return _innerStream.BeginWrite(buffer, offset, count, callback!, state);
         }
 
         public override void EndWrite(IAsyncResult asyncResult)

--- a/src/ReverseProxy/WebSocketsTelemetry/WebSocketCloseReason.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/WebSocketCloseReason.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Yarp.ReverseProxy.WebSocketsTelemetry
+{
+    internal enum WebSocketCloseReason : int
+    {
+        Unknown,
+        ClientGracefulClose,
+        ServerGracefulClose,
+        ClientDisconnect,
+        ServerDisconnect,
+    }
+}

--- a/src/ReverseProxy/WebSocketsTelemetry/WebSocketsParser.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/WebSocketsParser.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+
+namespace Yarp.ReverseProxy.WebSocketsTelemetry
+{
+    internal unsafe struct WebSocketsParser
+    {
+        private const int MaskLength = 4;
+        private const int MinHeaderSize = 2;
+        private const int MaxHeaderSize = MinHeaderSize + MaskLength + sizeof(ulong);
+
+        private fixed byte _leftoverBuffer[MaxHeaderSize - 1];
+        private readonly byte _minHeaderSize;
+        private byte _leftover;
+        private ulong _bytesToSkip;
+
+        public long MessageCount { get; private set; }
+
+        public DateTime? CloseTime { get; private set; }
+
+        public WebSocketsParser(bool isServer)
+        {
+            _minHeaderSize = (byte)(MinHeaderSize + (isServer ? MaskLength : 0));
+            _leftover = 0;
+            _bytesToSkip = 0;
+            MessageCount = 0;
+            CloseTime = null;
+        }
+
+        // The WebSocket Protocol: https://datatracker.ietf.org/doc/html/rfc6455#section-5.2
+        //  0                   1                   2                   3
+        //  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+        // +-+-+-+-+-------+-+-------------+-------------------------------+
+        // |F|R|R|R| opcode|M| Payload len |    Extended payload length    |
+        // |I|S|S|S|  (4)  |A|     (7)     |             (16/64)           |
+        // |N|V|V|V|       |S|             |   (if payload len==126/127)   |
+        // | |1|2|3|       |K|             |                               |
+        // +-+-+-+-+-------+-+-------------+ - - - - - - - - - - - - - - - +
+        // |     Extended payload length continued, if payload len == 127  |
+        // + - - - - - - - - - - - - - - - +-------------------------------+
+        // |                               |Masking-key, if MASK set to 1  |
+        // +-------------------------------+-------------------------------+
+        // | Masking-key (continued)       |          Payload Data         |
+        // +-------------------------------- - - - - - - - - - - - - - - - +
+        // :                     Payload Data continued ...                :
+        // +---------------------------------------------------------------+
+        //
+        // The header can be 2-10 bytes long, followed by a 4 byte mask if the message was sent by the client.
+        // We have to read the first 2 bytes to know how long the frame header will be.
+        // Since the buffer may not contain the full frame, we make use of a leftoverBuffer
+        // where we store leftover bytes that don't represent a complete frame header.
+        // On the next call to Consume, we interpret the leftover bytes as the beginning of the frame.
+        // As we are not interested in the actual payload data, we skip over (payload length + mask length) bytes after each header.
+        public void Consume(ReadOnlySpan<byte> buffer)
+        {
+            int leftover = _leftover;
+            var bytesToSkip = _bytesToSkip;
+
+            while (true)
+            {
+                var toSkip = Math.Min(bytesToSkip, (ulong)buffer.Length);
+                buffer = buffer.Slice((int)toSkip);
+                bytesToSkip -= toSkip;
+
+                var available = leftover + buffer.Length;
+                int headerSize = _minHeaderSize;
+
+                if (available < headerSize)
+                {
+                    break;
+                }
+
+                var length = (leftover > 1 ? _leftoverBuffer[1] : buffer[1 - leftover]) & 0x7FUL;
+
+                if (length > 125)
+                {
+                    // The actual length will be encoded in 2 or 8 bytes, based on whether the length was 126 or 127
+                    var lengthBytes = 2 << (((int)length & 1) << 1);
+                    headerSize += lengthBytes;
+                    Debug.Assert(leftover < headerSize);
+
+                    if (available < headerSize)
+                    {
+                        break;
+                    }
+
+                    lengthBytes += MinHeaderSize;
+
+                    length = 0;
+                    for (var i = MinHeaderSize; i < lengthBytes; i++)
+                    {
+                        length <<= 8;
+                        length |= i < leftover ? _leftoverBuffer[i] : buffer[i - leftover];
+                    }
+                }
+
+                Debug.Assert(leftover < headerSize);
+                bytesToSkip = length;
+
+                int header = leftover > 0 ? _leftoverBuffer[0] : buffer[0];
+
+                if ((header & 0xF) == 0x8) // CLOSE
+                {
+                    CloseTime ??= DateTime.UtcNow;
+                }
+                else if ((header & 0x80) != 0) // FIN
+                {
+                    MessageCount++;
+                }
+
+                // Advance the buffer by the number of bytes read for the header,
+                // accounting for any bytes we may have read from the leftoverBuffer
+                buffer = buffer.Slice(headerSize - leftover);
+                leftover = 0;
+            }
+
+            Debug.Assert(bytesToSkip == 0 || buffer.Length == 0);
+            _bytesToSkip = bytesToSkip;
+
+            Debug.Assert(leftover + buffer.Length < MaxHeaderSize);
+            for (var i = 0; i < buffer.Length; i++, leftover++)
+            {
+                _leftoverBuffer[leftover] = buffer[i];
+            }
+
+            _leftover = (byte)leftover;
+        }
+    }
+}

--- a/src/ReverseProxy/WebSocketsTelemetry/WebSocketsParser.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/WebSocketsParser.cs
@@ -22,7 +22,7 @@ namespace Yarp.ReverseProxy.WebSocketsTelemetry
 
         public long MessageCount { get; private set; }
 
-        public DateTime? CloseTime => _closeTime == 0 ? null : new DateTime(_closeTime);
+        public DateTime? CloseTime => _closeTime == 0 ? null : new DateTime(_closeTime, DateTimeKind.Utc);
 
         public WebSocketsParser(IClock clock, bool isServer)
         {

--- a/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetry.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetry.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.Tracing;
+
+namespace Yarp.ReverseProxy.WebSocketsTelemetry
+{
+    [EventSource(Name = "Yarp.ReverseProxy.WebSockets")]
+    internal sealed class WebSocketsTelemetry : EventSource
+    {
+        public static readonly WebSocketsTelemetry Log = new();
+
+        [Event(1, Level = EventLevel.Informational)]
+        public void WebSocketClosed(long establishedTime, WebSocketCloseReason closeReason, long messagesRead, long messagesWritten)
+        {
+            if (IsEnabled(EventLevel.Informational, EventKeywords.All))
+            {
+                WriteEvent(eventId: 1, establishedTime, closeReason, messagesRead, messagesWritten);
+            }
+        }
+    }
+}

--- a/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetryExtensions.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetryExtensions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Yarp.ReverseProxy.WebSocketsTelemetry;
+
+namespace Microsoft.AspNetCore.Builder
+{
+    /// <summary>
+    /// <see cref="IApplicationBuilder"/> extension methods to add the <see cref="WebSocketsTelemetryMiddleware"/>.
+    /// </summary>
+    public static class WebSocketsTelemetryExtensions
+    {
+        /// <summary>
+        /// Adds a <see cref="WebSocketsTelemetryMiddleware"/> to the request pipeline.
+        /// Must be added before <see cref="WebSockets.WebSocketMiddleware"/>.
+        /// </summary>
+        public static IApplicationBuilder UseWebSocketsTelemetry(this IApplicationBuilder app)
+        {
+            return app.UseMiddleware<WebSocketsTelemetryMiddleware>();
+        }
+    }
+}

--- a/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetryMiddleware.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetryMiddleware.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Yarp.ReverseProxy.WebSocketsTelemetry
+{
+    internal sealed class WebSocketsTelemetryMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public WebSocketsTelemetryMiddleware(RequestDelegate next)
+        {
+            _next = next ?? throw new ArgumentNullException(nameof(next));
+        }
+
+        public Task Invoke(HttpContext context)
+        {
+            if (WebSocketsTelemetry.Log.IsEnabled())
+            {
+                if (context.Features.Get<IHttpUpgradeFeature>() is { IsUpgradableRequest: true } upgradeFeature)
+                {
+                    return InvokeAsyncCore(context, upgradeFeature, _next);
+                }
+            }
+
+            return _next(context);
+        }
+
+        private static async Task InvokeAsyncCore(HttpContext context, IHttpUpgradeFeature upgradeFeature, RequestDelegate next)
+        {
+            var upgradeWrapper = new HttpUpgradeFeatureWrapper(upgradeFeature);
+            context.Features.Set<IHttpUpgradeFeature>(upgradeWrapper);
+
+            try
+            {
+                await next(context);
+            }
+            finally
+            {
+                if (upgradeWrapper.TelemetryStream is { } telemetryStream)
+                {
+                    WebSocketsTelemetry.Log.WebSocketClosed(
+                        telemetryStream.EstablishedTime.Ticks,
+                        telemetryStream.GetCloseReason(context),
+                        telemetryStream.MessagesRead,
+                        telemetryStream.MessagesWritten);
+                }
+
+                context.Features.Set(upgradeFeature);
+            }
+        }
+
+        private sealed class HttpUpgradeFeatureWrapper : IHttpUpgradeFeature
+        {
+            private readonly IHttpUpgradeFeature _upgradeFeature;
+
+            public WebSocketsTelemetryStream? TelemetryStream { get; private set; }
+
+            public bool IsUpgradableRequest => _upgradeFeature.IsUpgradableRequest;
+
+            public HttpUpgradeFeatureWrapper(IHttpUpgradeFeature upgradeFeature)
+            {
+                _upgradeFeature = upgradeFeature ?? throw new ArgumentNullException(nameof(upgradeFeature));
+            }
+
+            public async Task<Stream> UpgradeAsync()
+            {
+                Debug.Assert(TelemetryStream is null);
+                var opaqueTransport = await _upgradeFeature.UpgradeAsync();
+                TelemetryStream = new WebSocketsTelemetryStream(opaqueTransport);
+                return TelemetryStream;
+            }
+        }
+    }
+}

--- a/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetryMiddleware.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetryMiddleware.cs
@@ -7,34 +7,37 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Yarp.ReverseProxy.Utilities;
 
 namespace Yarp.ReverseProxy.WebSocketsTelemetry
 {
     internal sealed class WebSocketsTelemetryMiddleware
     {
         private readonly RequestDelegate _next;
+        private readonly IClock _clock;
 
-        public WebSocketsTelemetryMiddleware(RequestDelegate next)
+        public WebSocketsTelemetryMiddleware(RequestDelegate next, IClock clock)
         {
             _next = next ?? throw new ArgumentNullException(nameof(next));
+            _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         }
 
-        public Task Invoke(HttpContext context)
+        public Task InvokeAsync(HttpContext context)
         {
             if (WebSocketsTelemetry.Log.IsEnabled())
             {
                 if (context.Features.Get<IHttpUpgradeFeature>() is { IsUpgradableRequest: true } upgradeFeature)
                 {
-                    return InvokeAsyncCore(context, upgradeFeature, _next);
+                    var upgradeWrapper = new HttpUpgradeFeatureWrapper(_clock, upgradeFeature);
+                    return InvokeAsyncCore(context, upgradeWrapper, _next);
                 }
             }
 
             return _next(context);
         }
 
-        private static async Task InvokeAsyncCore(HttpContext context, IHttpUpgradeFeature upgradeFeature, RequestDelegate next)
+        private static async Task InvokeAsyncCore(HttpContext context, HttpUpgradeFeatureWrapper upgradeWrapper, RequestDelegate next)
         {
-            var upgradeWrapper = new HttpUpgradeFeatureWrapper(upgradeFeature);
             context.Features.Set<IHttpUpgradeFeature>(upgradeWrapper);
 
             try
@@ -52,28 +55,31 @@ namespace Yarp.ReverseProxy.WebSocketsTelemetry
                         telemetryStream.MessagesWritten);
                 }
 
-                context.Features.Set(upgradeFeature);
+                context.Features.Set(upgradeWrapper.InnerUpgradeFeature);
             }
         }
 
         private sealed class HttpUpgradeFeatureWrapper : IHttpUpgradeFeature
         {
-            private readonly IHttpUpgradeFeature _upgradeFeature;
+            private readonly IClock _clock;
+
+            public IHttpUpgradeFeature InnerUpgradeFeature { get; private set; }
 
             public WebSocketsTelemetryStream? TelemetryStream { get; private set; }
 
-            public bool IsUpgradableRequest => _upgradeFeature.IsUpgradableRequest;
+            public bool IsUpgradableRequest => InnerUpgradeFeature.IsUpgradableRequest;
 
-            public HttpUpgradeFeatureWrapper(IHttpUpgradeFeature upgradeFeature)
+            public HttpUpgradeFeatureWrapper(IClock clock, IHttpUpgradeFeature upgradeFeature)
             {
-                _upgradeFeature = upgradeFeature ?? throw new ArgumentNullException(nameof(upgradeFeature));
+                _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+                InnerUpgradeFeature = upgradeFeature ?? throw new ArgumentNullException(nameof(upgradeFeature));
             }
 
             public async Task<Stream> UpgradeAsync()
             {
                 Debug.Assert(TelemetryStream is null);
-                var opaqueTransport = await _upgradeFeature.UpgradeAsync();
-                TelemetryStream = new WebSocketsTelemetryStream(opaqueTransport);
+                var opaqueTransport = await InnerUpgradeFeature.UpgradeAsync();
+                TelemetryStream = new WebSocketsTelemetryStream(_clock, opaqueTransport);
                 return TelemetryStream;
             }
         }

--- a/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetryStream.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetryStream.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Yarp.ReverseProxy.Forwarder;
+using Yarp.ReverseProxy.Utilities;
+
+namespace Yarp.ReverseProxy.WebSocketsTelemetry
+{
+    internal sealed class WebSocketsTelemetryStream : DelegatingStream
+    {
+        private WebSocketsParser _readParser, _writeParser;
+
+        public DateTime EstablishedTime { get; }
+        public long MessagesRead => _readParser.MessageCount;
+        public long MessagesWritten => _writeParser.MessageCount;
+
+        public WebSocketsTelemetryStream(Stream innerStream)
+            : base(innerStream)
+        {
+            EstablishedTime = DateTime.UtcNow;
+            _readParser = new WebSocketsParser(isServer: true);
+            _writeParser = new WebSocketsParser(isServer: false);
+        }
+
+        public WebSocketCloseReason GetCloseReason(HttpContext context)
+        {
+            var clientCloseTime = _readParser.CloseTime;
+            var serverCloseTime = _writeParser.CloseTime;
+
+            // Mutual, graceful WebSocket close. We report whichever one we saw first.
+            if (clientCloseTime.HasValue && serverCloseTime.HasValue)
+            {
+                return clientCloseTime.Value < serverCloseTime.Value ? WebSocketCloseReason.ClientGracefulClose : WebSocketCloseReason.ServerGracefulClose;
+            }
+
+            // One side sent a WebSocket close, but we never saw a response from the other side
+            // It is possible an error occurred, but we saw a graceful close first, so that is the intiator
+            if (clientCloseTime.HasValue)
+            {
+                return WebSocketCloseReason.ClientGracefulClose;
+            }
+            if (serverCloseTime.HasValue)
+            {
+                return WebSocketCloseReason.ServerGracefulClose;
+            }
+
+            return context.Features.Get<IForwarderErrorFeature>()?.Error switch
+            {
+                // Either side disconnected without sending a WebSocket close
+                ForwarderError.UpgradeRequestClient         => WebSocketCloseReason.ClientDisconnect,
+                ForwarderError.UpgradeRequestCanceled       => WebSocketCloseReason.ClientDisconnect,
+                ForwarderError.UpgradeResponseClient        => WebSocketCloseReason.ClientDisconnect,
+                ForwarderError.UpgradeResponseCanceled      => WebSocketCloseReason.ClientDisconnect,
+                ForwarderError.UpgradeRequestDestination    => WebSocketCloseReason.ServerDisconnect,
+                ForwarderError.UpgradeResponseDestination   => WebSocketCloseReason.ServerDisconnect,
+
+                // Both sides gracefully closed the underlying connection without sending a WebSocket close
+                // Neither side is doing what we recognize as WebSockets ¯\_(ツ)_/¯
+                null => WebSocketCloseReason.Unknown,
+
+                // We are not expecting any other error from HttpForwarder after a successful connection upgrade
+                // Technically, a user could overwrite the IForwarderErrorFeature, in which case we don't know what's going on
+                _ => WebSocketCloseReason.Unknown
+            };
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            var readTask = base.ReadAsync(buffer, cancellationToken);
+
+            if (readTask.IsCompletedSuccessfully)
+            {
+                var read = readTask.GetAwaiter().GetResult();
+                _readParser.Consume(buffer.Span.Slice(0, read));
+                return new ValueTask<int>(read);
+            }
+            else
+            {
+                return Core(buffer, readTask);
+            }
+
+            async ValueTask<int> Core(Memory<byte> buffer, ValueTask<int> readTask)
+            {
+                var read = await readTask;
+                _readParser.Consume(buffer.Span.Slice(0, read));
+                return read;
+            }
+        }
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            _writeParser.Consume(buffer.Span);
+            return base.WriteAsync(buffer, cancellationToken);
+        }
+    }
+}

--- a/src/TelemetryConsumption/WebSockets/IWebSocketsTelemetryConsumer.cs
+++ b/src/TelemetryConsumption/WebSockets/IWebSocketsTelemetryConsumer.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Yarp.Telemetry.Consumption
+{
+    /// <summary>
+    /// A consumer of Yarp.ReverseProxy.WebSockets EventSource events.
+    /// </summary>
+    public interface IWebSocketsTelemetryConsumer
+    {
+        /// <summary>
+        /// Called when a WebSockets connection is closed.
+        /// </summary>
+        /// <param name="timestamp">Timestamp when the event was fired.</param>
+        /// <param name="establishedTime">Timestamp when the connection upgrade completed.</param>
+        /// <param name="closeReason">The reason the WebSocket connection closed.</param>
+        /// <param name="messagesRead">Messages read by the destination server.</param>
+        /// <param name="messagesWritten">Messages sent by the destination server.</param>
+        void OnWebSocketClosed(DateTime timestamp, DateTime establishedTime, WebSocketCloseReason closeReason, long messagesRead, long messagesWritten);
+    }
+}

--- a/src/TelemetryConsumption/WebSockets/WebSocketCloseReason.cs
+++ b/src/TelemetryConsumption/WebSockets/WebSocketCloseReason.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Yarp.Telemetry.Consumption
+{
+    /// <summary>
+    /// The reason the WebSocket connection closed.
+    /// </summary>
+    public enum WebSocketCloseReason : int
+    {
+        Unknown,
+        ClientGracefulClose,
+        ServerGracefulClose,
+        ClientDisconnect,
+        ServerDisconnect,
+    }
+}

--- a/src/TelemetryConsumption/WebSockets/WebSocketsEventListenerService.cs
+++ b/src/TelemetryConsumption/WebSockets/WebSocketsEventListenerService.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using Microsoft.Extensions.Logging;
+
+namespace Yarp.Telemetry.Consumption
+{
+    internal interface IWebSocketsMetricsConsumer { }
+
+    internal sealed class WebSocketsEventListenerService : EventListenerService<WebSocketsEventListenerService, IWebSocketsTelemetryConsumer, IWebSocketsMetricsConsumer>
+    {
+        protected override string EventSourceName => "Yarp.ReverseProxy.WebSockets";
+
+        public WebSocketsEventListenerService(ILogger<WebSocketsEventListenerService> logger, IEnumerable<IWebSocketsTelemetryConsumer> telemetryConsumers, IEnumerable<IWebSocketsMetricsConsumer> metricsConsumers)
+            : base(logger, telemetryConsumers, metricsConsumers)
+        { }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            const int MinEventId = 1;
+            const int MaxEventId = 1;
+
+            if (eventData.EventId < MinEventId || eventData.EventId > MaxEventId)
+            {
+                return;
+            }
+
+            if (TelemetryConsumers is null)
+            {
+                return;
+            }
+
+#pragma warning disable IDE0007 // Use implicit type
+            // Explicit type here to drop the object? signature of payload elements
+            ReadOnlyCollection<object> payload = eventData.Payload!;
+#pragma warning restore IDE0007 // Use implicit type
+
+            switch (eventData.EventId)
+            {
+                case 1:
+                    Debug.Assert(eventData.EventName == "WebSocketClosed" && payload.Count == 4);
+                    {
+                        var establishedTime = new DateTime((long)payload[0]);
+                        var closeReason = (WebSocketCloseReason)payload[1];
+                        var messagesRead = (long)payload[2];
+                        var messagesWritten = (long)payload[3];
+                        foreach (var consumer in TelemetryConsumers)
+                        {
+                            consumer.OnWebSocketClosed(eventData.TimeStamp, establishedTime, closeReason, messagesRead, messagesWritten);
+                        }
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/test/ReverseProxy.FunctionalTests/HeaderTests.cs
+++ b/test/ReverseProxy.FunctionalTests/HeaderTests.cs
@@ -340,6 +340,7 @@ namespace Yarp.ReverseProxy
             Exception unhandledError = null;
 
             using var proxy = TestEnvironment.CreateProxy(HttpProtocols.Http1, false, false, encoding, "cluster1", $"http://{tcpListener.LocalEndpoint}",
+                proxyServices => { },
                 proxyBuilder => { },
                 proxyApp =>
                 {

--- a/test/ReverseProxy.FunctionalTests/WebSocketTests.cs
+++ b/test/ReverseProxy.FunctionalTests/WebSocketTests.cs
@@ -165,6 +165,7 @@ namespace Yarp.ReverseProxy
                         builder.Map("/post", Post);
                     });
                 },
+                proxyServices => { },
                 proxyBuilder => { },
                 proxyApp =>
                 {

--- a/test/ReverseProxy.FunctionalTests/WebSocketsTelemetryTests.cs
+++ b/test/ReverseProxy.FunctionalTests/WebSocketsTelemetryTests.cs
@@ -1,0 +1,308 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Net.Http;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Yarp.ReverseProxy.Common;
+using Yarp.Telemetry.Consumption;
+
+namespace Yarp.ReverseProxy
+{
+    public class WebSocketsTelemetryTests
+    {
+        [Fact]
+        public async Task NoWebSocketsUpgrade_NoTelemetryWritten()
+        {
+            var telemetry = await TestAsync(
+                async uri =>
+                {
+                    using var client = new HttpClient();
+                    await client.GetStringAsync(uri);
+                },
+                (context, webSocket) => throw new InvalidOperationException("Shouldn't be reached"));
+
+            Assert.Null(telemetry);
+        }
+
+        [Theory]
+        [InlineData(0, 0, 42)]
+        [InlineData(0, 1, 42)]
+        [InlineData(1, 0, 42)]
+        [InlineData(23, 29, 0)]
+        [InlineData(17, 19, 1)]
+        [InlineData(11, 13, 100)]
+        [InlineData(5, 7, 1_000)]
+        [InlineData(2, 3, 100_000)]
+        public async Task MessagesExchanged_CorrectNumberReported(int read, int written, int messageSize)
+        {
+            var startTime = DateTime.UtcNow;
+
+            var telemetry = await TestAsync(
+                async uri =>
+                {
+                    using var client = new ClientWebSocket();
+                    await client.ConnectAsync(uri, CancellationToken.None);
+                    var webSocket = new WebSocketAdapter(client);
+
+                    await Task.WhenAll(
+                        SendMessagesAndCloseAsync(webSocket, read, messageSize),
+                        ReceiveAllMessagesAsync(webSocket));
+                },
+                async (context, webSocket) =>
+                {
+                    await Task.WhenAll(
+                        SendMessagesAndCloseAsync(webSocket, written, messageSize),
+                        ReceiveAllMessagesAsync(webSocket));
+                });
+
+            Assert.NotNull(telemetry);
+            Assert.InRange(telemetry!.EstablishedTime, startTime, telemetry.Timestamp);
+            Assert.Contains(telemetry.CloseReason, new[] { WebSocketCloseReason.ClientGracefulClose, WebSocketCloseReason.ServerGracefulClose });
+            Assert.Equal(read, telemetry!.MessagesRead);
+            Assert.Equal(written, telemetry.MessagesWritten);
+        }
+
+        public enum Behavior
+        {
+            ClosesConnection                = 1,
+            SendsClose_WaitsForClose        = 2,
+            SendsClose_ClosesConnection     = 4 | ClosesConnection,
+            WaitsForClose_SendsClose        = 8,
+            WaitsForClose_ClosesConnection  = 16 | ClosesConnection,
+        }
+
+        [Theory]
+        // Both sides close the connection - race between which is noticed first
+        [InlineData(Behavior.ClosesConnection,                  Behavior.ClosesConnection,                  WebSocketCloseReason.Unknown, WebSocketCloseReason.ClientDisconnect, WebSocketCloseReason.ServerDisconnect)]
+        // One side sends a graceful close
+        [InlineData(Behavior.SendsClose_ClosesConnection,       Behavior.WaitsForClose_ClosesConnection,    WebSocketCloseReason.ClientGracefulClose)]
+        [InlineData(Behavior.SendsClose_WaitsForClose,          Behavior.WaitsForClose_ClosesConnection,    WebSocketCloseReason.ClientGracefulClose)]
+        [InlineData(Behavior.WaitsForClose_ClosesConnection,    Behavior.SendsClose_ClosesConnection,       WebSocketCloseReason.ServerGracefulClose)]
+        [InlineData(Behavior.WaitsForClose_ClosesConnection,    Behavior.SendsClose_WaitsForClose,          WebSocketCloseReason.ServerGracefulClose)]
+        // One side sends a graceful close while the other disconnects - race between which is noticed first
+        [InlineData(Behavior.SendsClose_WaitsForClose,          Behavior.ClosesConnection,                  WebSocketCloseReason.ClientGracefulClose, WebSocketCloseReason.ServerDisconnect)]
+        [InlineData(Behavior.SendsClose_ClosesConnection,       Behavior.ClosesConnection,                  WebSocketCloseReason.ClientGracefulClose, WebSocketCloseReason.ServerDisconnect)]
+        [InlineData(Behavior.ClosesConnection,                  Behavior.SendsClose_ClosesConnection,       WebSocketCloseReason.ServerGracefulClose, WebSocketCloseReason.ClientDisconnect)]
+        [InlineData(Behavior.ClosesConnection,                  Behavior.SendsClose_WaitsForClose,          WebSocketCloseReason.ServerGracefulClose, WebSocketCloseReason.ClientDisconnect)]
+        // One side closes the connection while the other is waiting for messages
+        [InlineData(Behavior.ClosesConnection,                  Behavior.WaitsForClose_SendsClose,          WebSocketCloseReason.ClientDisconnect)]
+        [InlineData(Behavior.ClosesConnection,                  Behavior.WaitsForClose_ClosesConnection,    WebSocketCloseReason.ClientDisconnect)]
+        [InlineData(Behavior.WaitsForClose_SendsClose,          Behavior.ClosesConnection,                  WebSocketCloseReason.ServerDisconnect)]
+        [InlineData(Behavior.WaitsForClose_ClosesConnection,    Behavior.ClosesConnection,                  WebSocketCloseReason.ServerDisconnect)]
+        // Graceful, mutual close - other side closes as a reaction to receiving close
+        [InlineData(Behavior.SendsClose_WaitsForClose,          Behavior.WaitsForClose_SendsClose,          WebSocketCloseReason.ClientGracefulClose)]
+        [InlineData(Behavior.SendsClose_ClosesConnection,       Behavior.WaitsForClose_SendsClose,          WebSocketCloseReason.ClientGracefulClose)]
+        [InlineData(Behavior.WaitsForClose_SendsClose,          Behavior.SendsClose_WaitsForClose,          WebSocketCloseReason.ServerGracefulClose)]
+        [InlineData(Behavior.WaitsForClose_SendsClose,          Behavior.SendsClose_ClosesConnection,       WebSocketCloseReason.ServerGracefulClose)]
+        // Graceful, mutual close - both sides close at the same time - race between which is noticed first
+        [InlineData(Behavior.SendsClose_WaitsForClose,          Behavior.SendsClose_WaitsForClose,          WebSocketCloseReason.ClientGracefulClose, WebSocketCloseReason.ServerGracefulClose)]
+        [InlineData(Behavior.SendsClose_WaitsForClose,          Behavior.SendsClose_ClosesConnection,       WebSocketCloseReason.ClientGracefulClose, WebSocketCloseReason.ServerGracefulClose)]
+        [InlineData(Behavior.SendsClose_ClosesConnection,       Behavior.SendsClose_WaitsForClose,          WebSocketCloseReason.ClientGracefulClose, WebSocketCloseReason.ServerGracefulClose)]
+        [InlineData(Behavior.SendsClose_ClosesConnection,       Behavior.SendsClose_ClosesConnection,       WebSocketCloseReason.ClientGracefulClose, WebSocketCloseReason.ServerGracefulClose)]
+        public async Task ConnectionClosed_BlameAttributedCorrectly(Behavior clientBehavior, Behavior serverBehavior, params WebSocketCloseReason[] expectedReasons)
+        {
+            var telemetry = await TestAsync(
+                async uri =>
+                {
+                    using var client = new ClientWebSocket();
+
+                    // Keep sending messages from the client in order to observe a server disconnect sooner
+                    client.Options.KeepAliveInterval = TimeSpan.FromMilliseconds(10);
+
+                    await client.ConnectAsync(uri, CancellationToken.None);
+                    var webSocket = new WebSocketAdapter(client);
+
+                    try
+                    {
+                        await ProcessAsync(webSocket, clientBehavior, client: client);
+                    }
+                    catch
+                    {
+                        Assert.True(serverBehavior.HasFlag(Behavior.ClosesConnection));
+                    }
+                },
+                async (context, webSocket) =>
+                {
+                    try
+                    {
+                        await ProcessAsync(webSocket, serverBehavior, context: context);
+                    }
+                    catch
+                    {
+                        Assert.True(clientBehavior.HasFlag(Behavior.ClosesConnection));
+                    }
+                });
+
+            Assert.NotNull(telemetry);
+            Assert.Contains(telemetry!.CloseReason, expectedReasons);
+
+            static async Task ProcessAsync(WebSocketAdapter webSocket, Behavior behavior, ClientWebSocket? client = null, HttpContext? context = null)
+            {
+                if (behavior == Behavior.SendsClose_WaitsForClose ||
+                    behavior == Behavior.SendsClose_ClosesConnection)
+                {
+                    await webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "Bye");
+                }
+
+                if (behavior == Behavior.SendsClose_WaitsForClose ||
+                    behavior == Behavior.WaitsForClose_SendsClose ||
+                    behavior == Behavior.WaitsForClose_ClosesConnection)
+                {
+                    await ReceiveAllMessagesAsync(webSocket);
+                }
+
+                if (behavior == Behavior.WaitsForClose_SendsClose)
+                {
+                    await webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "Bye");
+                }
+
+                if (behavior == Behavior.SendsClose_ClosesConnection ||
+                    behavior == Behavior.WaitsForClose_ClosesConnection ||
+                    behavior == Behavior.ClosesConnection)
+                {
+                    client?.Abort();
+
+                    if (context is not null)
+                    {
+                        await context.Response.Body.FlushAsync();
+                        context.Abort();
+                    }
+                }
+            }
+        }
+
+        private static async Task ReceiveAllMessagesAsync(WebSocketAdapter webSocket)
+        {
+            Memory<byte> buffer = new byte[1024];
+
+            while (true)
+            {
+                var result = await webSocket.ReceiveAsync(buffer);
+
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    break;
+                }
+            }
+        }
+
+        private static async Task SendMessagesAndCloseAsync(WebSocketAdapter webSocket, int messageCount, int messageSize)
+        {
+            var rng = new Random(42);
+            var buffer = new byte[1024];
+
+            for (var i = 0; i < messageCount; i++)
+            {
+                var remaining = messageSize;
+
+                while (remaining > 1)
+                {
+                    var chunkSize = Math.Min(buffer.Length, remaining - 1);
+                    remaining -= chunkSize;
+                    var chunk = buffer.AsMemory(0, chunkSize);
+                    rng.NextBytes(chunk.Span);
+                    await webSocket.SendAsync(chunk, WebSocketMessageType.Binary, endOfMessage: false);
+                }
+
+                await webSocket.SendAsync(buffer.AsMemory(0, remaining), WebSocketMessageType.Binary, endOfMessage: true);
+            }
+
+            await webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "Bye", CancellationToken.None);
+        }
+
+        private class WebSocketAdapter
+        {
+            private readonly ClientWebSocket? _client;
+            private readonly WebSocket? _server;
+
+            public WebSocketAdapter(ClientWebSocket? client = null, WebSocket? server = null)
+            {
+                Assert.True(client is null ^ server is null);
+                _client = client;
+                _server = server;
+            }
+
+            public ValueTask<ValueWebSocketReceiveResult> ReceiveAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                return _client is not null
+                    ? _client.ReceiveAsync(buffer, cancellationToken)
+                    : _server!.ReceiveAsync(buffer, cancellationToken);
+            }
+
+            public ValueTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken = default)
+            {
+                return _client is not null
+                    ? _client.SendAsync(buffer, messageType, endOfMessage, cancellationToken)
+                    : _server!.SendAsync(buffer, messageType, endOfMessage, cancellationToken);
+            }
+
+            public Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken = default)
+            {
+                return _client is not null
+                    ? _client.CloseOutputAsync(closeStatus, statusDescription, cancellationToken)
+                    : _server!.CloseOutputAsync(closeStatus, statusDescription, cancellationToken);
+            }
+        }
+
+        private static async Task<WebSocketsTelemetry?> TestAsync(Func<Uri, Task> requestDelegate, Func<HttpContext, WebSocketAdapter, Task> destinationDelegate)
+        {
+            var telemetryConsumer = new TelemetryConsumer();
+
+            var test = new TestEnvironment(
+                destinationServies => { },
+                destinationApp =>
+                {
+                    destinationApp.UseWebSockets();
+
+                    destinationApp.Run(async context =>
+                    {
+                        if (context.WebSockets.IsWebSocketRequest)
+                        {
+                            var webSocket = await context.WebSockets.AcceptWebSocketAsync();
+
+                            await destinationDelegate(context, new WebSocketAdapter(server: webSocket));
+                        }
+                    });
+                },
+                proxyBuilder =>
+                {
+                    proxyBuilder.Services.AddTelemetryConsumer(telemetryConsumer);
+                },
+                proxyApp =>
+                {
+                    proxyApp.UseWebSocketsTelemetry();
+                });
+
+            await test.Invoke(async uri =>
+            {
+                var webSocketsTarget = uri.Replace("https://", "wss://").Replace("http://", "ws://");
+                var webSocketsUri = new Uri(new Uri(webSocketsTarget, UriKind.Absolute), "websockets");
+
+                await requestDelegate(webSocketsUri);
+            });
+
+            return telemetryConsumer.Telemetry;
+        }
+
+        private record WebSocketsTelemetry(DateTime Timestamp, DateTime EstablishedTime, WebSocketCloseReason CloseReason, long MessagesRead, long MessagesWritten);
+
+        private class TelemetryConsumer : IWebSocketsTelemetryConsumer
+        {
+            public WebSocketsTelemetry? Telemetry { get; private set; }
+
+            public void OnWebSocketClosed(DateTime timestamp, DateTime establishedTime, WebSocketCloseReason closeReason, long messagesRead, long messagesWritten)
+            {
+                Telemetry = new WebSocketsTelemetry(timestamp, establishedTime, closeReason, messagesRead, messagesWritten);
+            }
+        }
+    }
+}

--- a/test/ReverseProxy.FunctionalTests/WebSocketsTelemetryTests.cs
+++ b/test/ReverseProxy.FunctionalTests/WebSocketsTelemetryTests.cs
@@ -165,9 +165,7 @@ namespace Yarp.ReverseProxy
                     await webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "Bye");
                 }
 
-                if (behavior == Behavior.SendsClose_ClosesConnection ||
-                    behavior == Behavior.WaitsForClose_ClosesConnection ||
-                    behavior == Behavior.ClosesConnection)
+                if (behavior.HasFlag(Behavior.ClosesConnection))
                 {
                     client?.Abort();
 
@@ -285,7 +283,7 @@ namespace Yarp.ReverseProxy
             await test.Invoke(async uri =>
             {
                 var webSocketsTarget = uri.Replace("https://", "wss://").Replace("http://", "ws://");
-                var webSocketsUri = new Uri(new Uri(webSocketsTarget, UriKind.Absolute), "websockets");
+                var webSocketsUri = new Uri(webSocketsTarget, UriKind.Absolute);
 
                 await requestDelegate(webSocketsUri);
             });

--- a/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
@@ -19,6 +19,7 @@ using Microsoft.Net.Http.Headers;
 using Moq;
 using Xunit;
 using Yarp.Tests.Common;
+using Yarp.ReverseProxy.Utilities;
 
 namespace Yarp.ReverseProxy.Forwarder.Tests
 {

--- a/test/ReverseProxy.Tests/WebSocketsTelemetry/WebSocketsParserTests.cs
+++ b/test/ReverseProxy.Tests/WebSocketsTelemetry/WebSocketsParserTests.cs
@@ -1,0 +1,230 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Text;
+using Xunit;
+using Yarp.ReverseProxy.Utilities;
+using Yarp.Tests.Common;
+
+namespace Yarp.ReverseProxy.WebSocketsTelemetry.Tests
+{
+    public abstract class WebSocketsParserTests
+    {
+        protected abstract bool IsServer { get; }
+
+        private int MaskSize => IsServer ? 4 : 0;
+
+        private WebSocketsParser CreateParser(IClock clock = null) => new(clock ?? new Clock(), IsServer);
+
+        private ReadOnlySpan<byte> GetHeader(int opcode, int length, bool endOfMessage = true)
+        {
+            var header = new byte[2 + MaskSize + (length < 126 ? 0 : (length < 65536 ? 2 : 8))];
+
+            Assert.InRange(opcode, 0, 15);
+            header[0] = (byte)opcode;
+
+            if (endOfMessage)
+            {
+                header[0] |= 0x80;
+            }
+
+            if (length < 126)
+            {
+                header[1] = (byte)length;
+            }
+            else
+            {
+                header[1] = (byte)(length < 65536 ? 126 : 127);
+                var i = header.Length - MaskSize - 1;
+                while (length != 0)
+                {
+                    header[i--] = (byte)(length % 256);
+                    length /= 256;
+                }
+            }
+
+            if (IsServer)
+            {
+                header[1] |= 0x80;
+            }
+
+            return header;
+        }
+
+        private ReadOnlySpan<byte> GetCloseFrame() => GetHeader(opcode: 8, length: 0);
+
+        private ReadOnlySpan<byte> GetPingFrame() => GetHeader(opcode: 9, length: 0);
+
+        private ReadOnlySpan<byte> GetPongFrame() => GetHeader(opcode: 10, length: 0);
+
+        private ReadOnlySpan<byte> GetTextMessageFrame(string message, bool continuation = false, bool endOfMessage = true)
+        {
+            var messageBytes = Encoding.UTF8.GetBytes(message);
+            var header = GetHeader(opcode: continuation ? 0 : 1, length: messageBytes.Length, endOfMessage);
+
+            var frame = new byte[header.Length + messageBytes.Length];
+            header.CopyTo(frame);
+            messageBytes.CopyTo(frame, header.Length);
+
+            return frame;
+        }
+
+        private ReadOnlySpan<byte> GetBinaryMessageFrame(ReadOnlySpan<byte> message, bool continuation = false, bool endOfMessage = true)
+        {
+            var header = GetHeader(opcode: continuation ? 0 : 2, length: message.Length, endOfMessage);
+
+            var frame = new byte[header.Length + message.Length];
+            header.CopyTo(frame);
+            message.CopyTo(frame.AsSpan(header.Length));
+
+            return frame;
+        }
+
+        [Fact]
+        public void CustomClockIsUsedForCloseTime()
+        {
+            var clock = new ManualClock(new TimeSpan(42));
+            var parser = CreateParser(clock);
+
+            Assert.Null(parser.CloseTime);
+
+            parser.Consume(GetCloseFrame());
+
+            Assert.NotNull(parser.CloseTime);
+            Assert.Equal(clock.GetUtcNow(), parser.CloseTime.Value);
+        }
+
+        [Fact]
+        public void MessagesAreCountedCorrectly()
+        {
+            var parser = CreateParser();
+
+            // Whole messages
+            parser.Consume(GetTextMessageFrame("Foo"));
+            Assert.Equal(1, parser.MessageCount);
+
+            parser.Consume(GetBinaryMessageFrame(new byte[] { 4, 2 }));
+            Assert.Equal(2, parser.MessageCount);
+
+
+            // Continuations
+            parser.Consume(GetTextMessageFrame("Hello, ", endOfMessage: false));
+            Assert.Equal(2, parser.MessageCount);
+
+            parser.Consume(GetTextMessageFrame("world", continuation: true, endOfMessage: false));
+            Assert.Equal(2, parser.MessageCount);
+
+            parser.Consume(GetTextMessageFrame("!", continuation: true, endOfMessage: true));
+            Assert.Equal(3, parser.MessageCount);
+
+            parser.Consume(GetBinaryMessageFrame(new byte[] { 4 }, endOfMessage: false));
+            Assert.Equal(3, parser.MessageCount);
+
+            parser.Consume(GetBinaryMessageFrame(new byte[] { 2 }, continuation: true, endOfMessage: true));
+            Assert.Equal(4, parser.MessageCount);
+
+
+            // Large messages
+            parser.Consume(GetTextMessageFrame(new string('a', 1_000)));
+            Assert.Equal(5, parser.MessageCount);
+
+            parser.Consume(GetTextMessageFrame(new string('b', 100_000)));
+            Assert.Equal(6, parser.MessageCount);
+
+            parser.Consume(GetBinaryMessageFrame(Encoding.UTF8.GetBytes(new string('c', 1_000))));
+            Assert.Equal(7, parser.MessageCount);
+
+            parser.Consume(GetBinaryMessageFrame(Encoding.UTF8.GetBytes(new string('d', 100_000))));
+            Assert.Equal(8, parser.MessageCount);
+
+
+            // Large messages with continuations
+            parser.Consume(GetTextMessageFrame(new string('a', 1_000), endOfMessage: false));
+            Assert.Equal(8, parser.MessageCount);
+
+            parser.Consume(GetTextMessageFrame(new string('b', 1_000), continuation: true, endOfMessage: true));
+            Assert.Equal(9, parser.MessageCount);
+
+            parser.Consume(GetBinaryMessageFrame(Encoding.UTF8.GetBytes(new string('c', 1_000)), endOfMessage: false));
+            Assert.Equal(9, parser.MessageCount);
+
+            parser.Consume(GetBinaryMessageFrame(Encoding.UTF8.GetBytes(new string('d', 1_000)), continuation: true, endOfMessage: true));
+            Assert.Equal(10, parser.MessageCount);
+
+
+            // Fragmented frames
+            parser.Consume(Array.Empty<byte>());
+            Assert.Equal(10, parser.MessageCount);
+
+            ConsumeInFragments(ref parser, GetBinaryMessageFrame(Encoding.UTF8.GetBytes(new string('a', 1_000))));
+            Assert.Equal(11, parser.MessageCount);
+
+            var ms = new MemoryStream();
+            for (var i = (int)parser.MessageCount; i < 500; i++)
+            {
+                // Control frames are not counted
+                if (i % 7 == 0)
+                {
+                    ms.Write(GetPingFrame());
+                }
+                if (i % 13 == 0)
+                {
+                    ms.Write(GetPongFrame());
+                }
+
+                switch (i % 4)
+                {
+                    case 0:
+                        ms.Write(GetTextMessageFrame(new string('a', i)));
+                        break;
+
+                    case 1:
+                        ms.Write(GetBinaryMessageFrame(Encoding.UTF8.GetBytes(new string('b', i))));
+                        break;
+
+                    case 2:
+                        ms.Write(GetTextMessageFrame(new string('a', i), endOfMessage: false));
+                        ms.Write(GetTextMessageFrame(new string('b', i), continuation: true, endOfMessage: false));
+                        ms.Write(GetTextMessageFrame(new string('c', i), continuation: true, endOfMessage: true));
+                        break;
+
+                    case 3:
+                        ms.Write(GetBinaryMessageFrame(Encoding.UTF8.GetBytes(new string('a', i)), endOfMessage: false));
+                        ms.Write(GetBinaryMessageFrame(Encoding.UTF8.GetBytes(new string('b', i)), continuation: true, endOfMessage: false));
+                        ms.Write(GetBinaryMessageFrame(Encoding.UTF8.GetBytes(new string('c', i)), continuation: true, endOfMessage: true));
+                        break;
+                }
+            }
+            ConsumeInFragments(ref parser, ms.ToArray());
+            Assert.Equal(500, parser.MessageCount);
+
+
+            // Close frame is not counted
+            parser.Consume(GetCloseFrame());
+            Assert.Equal(500, parser.MessageCount);
+
+            static void ConsumeInFragments(ref WebSocketsParser parser, ReadOnlySpan<byte> message)
+            {
+                var rng = new Random(42);
+                while (message.Length != 0)
+                {
+                    var fragmentLength = Math.Min(message.Length, rng.Next(0, 150));
+                    parser.Consume(message.Slice(0, fragmentLength));
+                    message = message.Slice(fragmentLength);
+                }
+            }
+        }
+    }
+
+    public sealed class WebSocketsParserTests_Client : WebSocketsParserTests
+    {
+        protected override bool IsServer => false;
+    }
+
+    public sealed class WebSocketsParserTests_Server : WebSocketsParserTests
+    {
+        protected override bool IsServer => true;
+    }
+}

--- a/test/Tests.Common/ManualClock.cs
+++ b/test/Tests.Common/ManualClock.cs
@@ -29,7 +29,7 @@ namespace Yarp.Tests.Common
         private TimeSpan _currentTime;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="VirtualMonotonicTimer" /> class.
+        /// Initializes a new instance of the <see cref="ManualClock" /> class.
         /// </summary>
         /// <param name="initialTime">Initial value for current time. Zero if not specified.</param>
         public ManualClock(TimeSpan? initialTime = null)
@@ -69,7 +69,7 @@ namespace Yarp.Tests.Common
             _currentTime = targetTime;
         }
 
-        public DateTimeOffset GetUtcNow() => DateTimeOffset.UtcNow;
+        public DateTimeOffset GetUtcNow() => new DateTime(_currentTime.Ticks, DateTimeKind.Utc);
 
         public TimeSpan GetStopwatchTime() => _currentTime;
 


### PR DESCRIPTION
Fixes #1209

I followed the approach outlined in #1209 of wrapping the upgrade feature and MITM the upgrade transport stream.

Public API is just the `UseWebSocketsTelemetry` extension method.
I fed the data to an `EventSource` event, but it could also alternatively be something like `IWebSocketsTelemetryFeature`.

I didn't know where to put the code so I made a `WebSocketsTelemetry` folder in the main project (all types are internal though).


ToDo: I will add tests when we're happy with the overall approach