### PR TITLE
Fix many docfx warnings

### DIFF
--- a/docs/docfx/articles/dests-health-checks.md
+++ b/docs/docfx/articles/dests-health-checks.md
@@ -233,7 +233,7 @@ var clusters = new[]
 ### Configuration
 Passive health check settings are specified on the cluster level in `Cluster/HealthCheck/Passive` section. Alternatively, they can be defined in code via the corresponding types in [Yarp.ReverseProxy.Configuration](xref:Yarp.ReverseProxy.Configuration) namespace mirroring the configuration contract.
 
-Passive health checks require the `PassiveHealthCheckMiddleware` added into the pipeline for them to work. The default `MapReverseProxy(this IEndpointRouteBuilder endpoints)` method does it automatically, but in case of a manual pipeline construction the [UsePassiveHealthChecks](xref:Microsoft.AspNetCore.Builder.ProxyMiddlewareAppBuilderExtensions) method must be called to add that middleware as shown in the example below.
+Passive health checks require the `PassiveHealthCheckMiddleware` added into the pipeline for them to work. The default `MapReverseProxy(this IEndpointRouteBuilder endpoints)` method does it automatically, but in case of a manual pipeline construction the [UsePassiveHealthChecks](xref:Microsoft.AspNetCore.Builder.AppBuilderHealthExtensions) method must be called to add that middleware as shown in the example below.
 
 ```C#
 endpoints.MapReverseProxy(proxyPipeline =>

--- a/docs/docfx/articles/grpc.md
+++ b/docs/docfx/articles/grpc.md
@@ -26,7 +26,7 @@ This shows configuring Kestrel to use HTTP/2 over http (non-TLS):
 
 ## Configure YARP's Outgoing Protocols
 
-YARP automatically negotiates HTTP/1.1 or HTTP/2 for outgoing proxy requests, but only for https (TLS). HTTP/2 over http (non-TLS) requires additional settings. Note outgoing protocols are independent of incoming ones. E.g. https can be used for the incoming connection and http for the outgoing one, this is called TLS termination. See [here](proxy-httpclient-config.md#httprequest) for configuration details.
+YARP automatically negotiates HTTP/1.1 or HTTP/2 for outgoing proxy requests, but only for https (TLS). HTTP/2 over http (non-TLS) requires additional settings. Note outgoing protocols are independent of incoming ones. E.g. https can be used for the incoming connection and http for the outgoing one, this is called TLS termination. See [here](http-client-config.md#httprequest) for configuration details.
 
 This shows configuring the outgoing proxy request to use HTTP/2 over http. Note the `VersionPolicy` settings requires .NET 5.0:
 ```json

--- a/docs/docfx/articles/header-routing.md
+++ b/docs/docfx/articles/header-routing.md
@@ -163,7 +163,7 @@ var routes = new[]
 
 ## Contract
 
-[RouteHeader](xref:RouteHeaderYarp.ReverseProxy.Configuration.RouteHeader) defines the code contract and is mapped from config.
+[RouteHeader](xref:Yarp.ReverseProxy.Configuration.RouteHeader) defines the code contract and is mapped from config.
 
 ### Name
 
@@ -175,7 +175,7 @@ A list of possible values to search for. The header must match at least one of t
 
 ### Mode
 
-[HeaderMatchMode](xref:RouteHeaderYarp.ReverseProxy.Configuration.HeaderMatchMode) specifies how to match the value(s) against the request header. The default is `ExactHeader`.
+[HeaderMatchMode](xref:Yarp.ReverseProxy.Configuration.HeaderMatchMode) specifies how to match the value(s) against the request header. The default is `ExactHeader`.
 - ExactHeader - The header must match in its entirety, subject to the value of `IsCaseSensitive`. Only single headers are supported. If there are multiple headers with the same name then the match fails.
 - HeaderPrefix - The header must match by prefix, subject to the value of `IsCaseSensitive`. Only single headers are supported. If there are multiple headers with the same name then the match fails.
 - Exists - The header must exist and contain any non-empty value.

--- a/docs/docfx/articles/http-client-config.md
+++ b/docs/docfx/articles/http-client-config.md
@@ -200,7 +200,7 @@ public void ConfigureServices(IServiceCollection services)
 ```
 
 ## Custom IForwarderHttpClientFactory
-If direct control of HTTP client construction is necessary, the default [IForwarderHttpClientFactory](xref:Yarp.ReverseProxy.Forwarder.IForwarderHttpClientFactory) can be replaced with a custom one. For some customizations you can derive from the default [ProxyHttpClientFactory](xref:Yarp.ReverseProxy.Service.Proxy.Infrastructure.ProxyHttpClientFactory) and override the methods that configure the client.
+If direct control of HTTP client construction is necessary, the default [IForwarderHttpClientFactory](xref:Yarp.ReverseProxy.Forwarder.IForwarderHttpClientFactory) can be replaced with a custom one. For some customizations you can derive from the default [ForwarderHttpClientFactory](xref:Yarp.ReverseProxy.Forwarder.ForwarderHttpClientFactory) and override the methods that configure the client.
 
 It's recommended that any custom factory set the following `SocketsHttpHandler` properties to the same values as the default factory does in order to preserve a correct reverse proxy behavior and avoid unnecessary overhead.
 

--- a/docs/docfx/articles/kubernetes-ingress.md
+++ b/docs/docfx/articles/kubernetes-ingress.md
@@ -34,7 +34,7 @@ docker push <REGISTRY_NAME>/yarp-controller:<TAG>
 
 where `REGISTRY_NAME` is the name of your docker registry and `TAG` is a tag for the image (for example 1.0.0).
 
-Then the first step will be to deploy the YARP ingress controller to the Kubernetes cluster. This can be done by navigating to [Kubernetes Ingress sample](../../../samples/KuberenetesIngress.Sample/Ingress)
+Then the first step will be to deploy the YARP ingress controller to the Kubernetes cluster. This can be done by navigating to Kubernetes Ingress sample `\samples\KuberenetesIngress.Sample\Ingress`
 and running (after modifying `ingress-controller.yaml` with the same `REGISTRY_NAME` and `TAG`):
 
 ```

--- a/docs/docfx/articles/middleware.md
+++ b/docs/docfx/articles/middleware.md
@@ -25,13 +25,13 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 } 
 ```
 
-The parmeterless [MapReverseProxy](xref:Microsoft.AspNetCore.Builder.ReverseProxyIEndpointRouteBuilderExtensions.MapReverseProxy) overload includes all standard proxy middleware for [session affinity](session-affinity.md), [load balancing](load-balancing.md), [passive health checks](dests-health-checks.md), and the final proxying of the request. Each of these check the configuration of the matched route, cluster, and destination and perform their task accordingly.
+The parmeterless `MapReverseProxy()` in [ReverseProxyIEndpointRouteBuilderExtensions](xref:Microsoft.AspNetCore.Builder.ReverseProxyIEndpointRouteBuilderExtensions) overload includes all standard proxy middleware for [session affinity](session-affinity.md), [load balancing](load-balancing.md), [passive health checks](dests-health-checks.md), and the final proxying of the request. Each of these check the configuration of the matched route, cluster, and destination and perform their task accordingly.
 
 ## Adding Middleware
 
 Middleware added to your application pipeline will see the request in different states of processing depending on where the middleware is added. Middleware added before `UseRouting` will see all requests and can manipulate them before any routing takes place. Middleware added between `UseRouting` and `UseEndpoints` can call `HttpContext.GetEndpoint()` to check which endpoint routing matched the request to (if any), and use any metadata that was associated with that endpoint. This is how [Authentication, Authorization](authn-authz.md) and [CORS](cors.md) are handled.
 
-[MapReverseProxy](xref:Microsoft.AspNetCore.Builder.ReverseProxyIEndpointRouteBuilderExtensions.MapReverseProxy) provides an overload that lets you build a middleware pipeline that will run only for requests matched to proxy configured routes.
+[ReverseProxyIEndpointRouteBuilderExtensions](xref:Microsoft.AspNetCore.Builder.ReverseProxyIEndpointRouteBuilderExtensions) provides an overload of `MapReverseProxy` that lets you build a middleware pipeline that will run only for requests matched to proxy configured routes.
 
 ```
 endpoints.MapReverseProxy(proxyPipeline =>

--- a/docs/docfx/articles/runtimes.md
+++ b/docs/docfx/articles/runtimes.md
@@ -13,9 +13,9 @@ YARP is taking advantage of ASP.NET Core 5.0 features and optimizations. This do
 
 ### Yarp.ReverseProxy package
 The following features are supported on NET 5.0 and higher:
-- [EnableMultipleHttp2Connections](proxy-httpclient-config.md#HttpClient) - enables opening additional HTTP/2 connections to the same server when the maximum number of concurrent streams is reached on all existing connections. Full path: `ClusterConfig.HttpClient.EnableMultipleHttp2Connections`. Type: `bool?`
-- [RequestHeaderEncoding](proxy-httpclient-config.md#HttpClient) - allows to set a non-ASCII header encoding for outgoing requests. Full path: `ClusterConfig.HttpClient.RequestHeaderEncoding`. Type: `string?`
-- [VersionPolicy](proxy-httpclient-config.md#HttpRequest) - policy applied to version selection, e.g. whether to prefer downgrades, upgrades or request an exact version. The default is `RequestVersionOrLower`. Full path: `ClusterConfig.HttpRequest.VersionPolicy`. Type: `HttpVersionPolicy?`
+- [EnableMultipleHttp2Connections](http-client-config.md#httpclient) - enables opening additional HTTP/2 connections to the same server when the maximum number of concurrent streams is reached on all existing connections. Full path: `ClusterConfig.HttpClient.EnableMultipleHttp2Connections`. Type: `bool?`
+- [RequestHeaderEncoding](http-client-config.md#httpclient) - allows to set a non-ASCII header encoding for outgoing requests. Full path: `ClusterConfig.HttpClient.RequestHeaderEncoding`. Type: `string?`
+- [VersionPolicy](http-client-config.md#httprequest) - policy applied to version selection, e.g. whether to prefer downgrades, upgrades or request an exact version. The default is `RequestVersionOrLower`. Full path: `ClusterConfig.HttpRequest.VersionPolicy`. Type: `HttpVersionPolicy?`
 
 ### Yarp.ReverseProxy.Telemetry.Consumption package
 On .NET Core 3.1 it supports only:

--- a/docs/docfx/articles/service-fabric-int.md
+++ b/docs/docfx/articles/service-fabric-int.md
@@ -83,7 +83,7 @@ These are the supported parameters:
 - `YARP.EnableDynamicOverrides` - indicates whether application parameters replacement is enabled on the service. Default `false`
 - `YARP.Backend.LoadBalancingPolicy` - configures YARP load balancing policy. Optional parameter
 - `YARP.Backend.SessionAffinity.*` - configures YARP session affinity. Available parameters and their meanings are provided on [the respective documentation page](session-affinity.md). Optional parameter
-- `YARP.Backend.HttpRequest.*` - sets proxied HTTP request properties. Available parameters and their meanings are provided on [the respective documentation page](proxy-httpclient-config.md) in 'HttpRequest' section. Optional parameter
+- `YARP.Backend.HttpRequest.*` - sets proxied HTTP request properties. Available parameters and their meanings are provided on [the respective documentation page](http-client-config.md) in 'HttpRequest' section. Optional parameter
 - `YARP.Backend.HealthCheck.Active.*` - configures YARP active health checks to be run against the given service. Available parameters and their meanings are provided on [the respective documentation page](dests-health-checks.md). There is one label in this group `YARP.Backend.HealthCheck.Active.ServiceFabric.ListenerName` which is not covered by that document because it's SF specific. Its purpose is explained below. Optional parameter
 - `YARP.Backend.HealthCheck.Active.ServiceFabric.ListenerName` - sets an explicit listener name for the health probing endpoint for each replica/instance that is used to probe replica/instance health state and is stored on the `Destination.Health` property in YARP's model. Optional parameter
 - `YARP.Backend.HealthCheck.Passive.*` - configures YARP passive health checks to be run against the given service. Available parameters and their meanings are provided on [the respective documentation page](dests-health-checks.md). Optional parameter
@@ -177,7 +177,7 @@ Once a `ClusterConfig` and all its `DestinationConfig`'s have been built, `IDisc
 
 If the `ClusterConfig` has been successfully validated, `IDiscoverer` proceeds to the final conversion step where it calls `LabelsParser` to create [RouteConfig](xref:Yarp.ReverseProxy.Configuration.RouteConfig) from `YARP.Routes.*` extension labels. New `RouteConfig`'s are also passed down to `IConfigValidator` to ensure their validity. A failure in `RouteConfig` construction is communicated to SF cluster in form of a service health report similar to other service conversion failures.
 
-After all applications and their services have been processed and a new complete YARP configuration has been constructed, `ServiceFabricConfigProvier` updates [IProxyConfig](xref:Yarp.ReverseProxy.Service.IProxyConfig) and notifies the rest of YARP about a configuration change.
+After all applications and their services have been processed and a new complete YARP configuration has been constructed, `ServiceFabricConfigProvier` updates [IProxyConfig](xref:Yarp.ReverseProxy.Configuration.IProxyConfig) and notifies the rest of YARP about a configuration change.
 
 The above process is regularly repeated with the period set in `DiscoveryPeriod` parameter.
 

--- a/docs/docfx/articles/transforms.md
+++ b/docs/docfx/articles/transforms.md
@@ -113,7 +113,7 @@ Developers that want to integrate their custom transforms with the `Transforms` 
 
 Transforms can be added to routes programmatically by calling the [AddTransforms](xref:Microsoft.Extensions.DependencyInjection.ReverseProxyServiceCollectionExtensions) method.
 
-`AddTransforms` can be called from `Startup.ConfigureServices` to provide a callback for configuring transforms. This callback is invoked each time a route is built or rebuilt and allows the developer to inspect the [RouteConfig](xref:Yarp.ReverseProxy.Abstractions.RouteConfig) information and conditionally add transforms for it.
+`AddTransforms` can be called from `Startup.ConfigureServices` to provide a callback for configuring transforms. This callback is invoked each time a route is built or rebuilt and allows the developer to inspect the [RouteConfig](xref:Yarp.ReverseProxy.Configuration.RouteConfig) information and conditionally add transforms for it.
 
 The `AddTransforms` callback provides a [TransformBuilderContext](xref:Yarp.ReverseProxy.Transforms.Builder.TransformBuilderContext) where transforms can be added or configured. Most transforms provide `TransformBuilderContext` extension methods to make them easier to add. These are extensions documented below with the individual transform descriptions.
 
@@ -511,7 +511,7 @@ routeConfig = routeConfig.WithTransformRequestHeadersAllowed("Header1", "header2
 transformBuilderContext.AddRequestHeadersAllowed("Header1", "header2");
 ```
 
-YARP copies most request headers to the proxy request by default (see [RequestHeadersCopy](#RequestHeadersCopy)). Some security models only allow specific headers to be proxied. This transform disables RequestHeadersCopy and only copies the given headers. Other transforms that modify or append to existing headers may be affected if not included in the allow list.
+YARP copies most request headers to the proxy request by default (see [RequestHeadersCopy](transforms.md#requestheaderscopy)). Some security models only allow specific headers to be proxied. This transform disables RequestHeadersCopy and only copies the given headers. Other transforms that modify or append to existing headers may be affected if not included in the allow list.
 
 Note that there are some headers YARP does not copy by default since they are connection specific or otherwise security sensitive (e.g. `Connection`, `Alt-Svc`). Putting those header names in the allow list will bypass that restriction but is strongly discouraged as it may negatively affect the functionality of the proxy or cause security vulnerabilities.
 
@@ -804,7 +804,7 @@ routeConfig = routeConfig.WithTransformResponseHeadersAllowed("Header1", "header
 transformBuilderContext.AddResponseHeadersAllowed("Header1", "header2");
 ```
 
-YARP copies most response headers from the proxy response by default (see [ResponseHeadersCopy](#ResponseHeadersCopy)). Some security models only allow specific headers to be proxied. This transform disables ResponseHeadersCopy and only copies the given headers. Other transforms that modify or append to existing headers may be affected if not included in the allow list.
+YARP copies most response headers from the proxy response by default (see [ResponseHeadersCopy](transforms.md#responseheaderscopy)). Some security models only allow specific headers to be proxied. This transform disables ResponseHeadersCopy and only copies the given headers. Other transforms that modify or append to existing headers may be affected if not included in the allow list.
 
 Note that there are some headers YARP does not copy by default since they are connection specific or otherwise security sensitive (e.g. `Connection`, `Alt-Svc`). Putting those header names in the allow list will bypass that restriction but is strongly discouraged as it may negatively affect the functionality of the proxy or cause security vulnerabilities.
 
@@ -871,7 +871,7 @@ HeaderName: value
 
 Response trailers are headers sent at the end of the response body. Support for trailers is uncommon in HTTP/1.1 implementations but is becoming common in HTTP/2 implementations. Check your client and server for support.
 
-ResponseTrailer follows the same structure and guidance as [ResponseHeader](#ResponseHeader).
+ResponseTrailer follows the same structure and guidance as [ResponseHeader](transforms.md#responseheader).
 
 ### ResponseTrailerRemove
 
@@ -904,7 +904,7 @@ AnotherHeader: another-value
 
 This removes the named trailing header.
 
-ResponseTrailerRemove follows the same structure and guidance as [ResponseHeaderRemove](#ResponseHeaderRemove).
+ResponseTrailerRemove follows the same structure and guidance as [ResponseHeaderRemove](transforms.md#responseheaderremove).
 
 ### ResponseTrailersAllowed
 
@@ -926,7 +926,7 @@ routeConfig = routeConfig.WithTransformResponseTrailersAllowed("Header1", "heade
 transformBuilderContext.AddResponseTrailersAllowed("Header1", "header2");
 ```
 
-YARP copies most response trailers from the proxy response by default (see [ResponseTrailersCopy](#ResponseTrailersCopy)). Some security models only allow specific headers to be proxied. This transform disables ResponseTrailersCopy and only copies the given headers. Other transforms that modify or append to existing headers may be affected if not included in the allow list.
+YARP copies most response trailers from the proxy response by default (see [ResponseTrailersCopy](transforms.md#responsetrailerscopy)). Some security models only allow specific headers to be proxied. This transform disables ResponseTrailersCopy and only copies the given headers. Other transforms that modify or append to existing headers may be affected if not included in the allow list.
 
 Note that there are some headers YARP does not copy by default since they are connection specific or otherwise security sensitive (e.g. `Connection`, `Alt-Svc`). Putting those header names in the allow list will bypass that restriction but is strongly discouraged as it may negatively affect the functionality of the proxy or cause security vulnerabilities.
 
@@ -967,7 +967,7 @@ All response trailers transforms must derive from the abstract base class [Respo
 
 ### ITransformProvider
 
-[ITransformProvider](xref:Yarp.ReverseProxy.Transforms.ITransformProvider) provides the functionality of `AddTransforms` described above as well as DI integration and validation support.
+[ITransformProvider](xref:Yarp.ReverseProxy.Transforms.Builder.ITransformProvider) provides the functionality of `AddTransforms` described above as well as DI integration and validation support.
 
 `ITransformProvider`'s can be registered in DI by calling [AddTransforms&lt;T&gt;()](xref:Microsoft.Extensions.DependencyInjection.ReverseProxyServiceCollectionExtensions). Multiple `ITransformProvider` implementations can be registered and all will be run.
 
@@ -1021,7 +1021,7 @@ internal class MyTransformProvider : ITransformProvider
 
 ### ITransformFactory
 
-Developers that want to integrate their custom transforms with the `Transforms` section of configuration can implement an [ITransformFactory](xref:Yarp.ReverseProxy.Transforms.ITransformFactory). This should be registered in DI using the `AddTransformFactory<T>()` method. Multiple factories can be registered and all will be used.
+Developers that want to integrate their custom transforms with the `Transforms` section of configuration can implement an [ITransformFactory](xref:Yarp.ReverseProxy.Transforms.Builder.ITransformFactory). This should be registered in DI using the `AddTransformFactory<T>()` method. Multiple factories can be registered and all will be used.
 
 `ITransformFactory` provides two methods, `Validate` and `Build`. These process one set of transform values at a time, represented by a `IReadOnlyDictionary<string, string>`.
 

--- a/docs/docfx/index.md
+++ b/docs/docfx/index.md
@@ -21,4 +21,4 @@ Eventually we expect YARP to ship as a library, project template, and a single-f
 
 YARP is designed with customizability as a primary scenario rather than requiring you to break out to script or rebuild the library from source.
 
-See the [Getting Started](xref:getting-started.md) guide for a brief tutorial, or [Basic Sample](https://github.com/microsoft/reverse-proxy/tree/main/samples/BasicYarpSample) for a fully commented sample showing how to use the YARP library to implement a fairly well featured proxy.
+See the [Getting Started](articles/getting-started.md) guide for a brief tutorial, or [Basic Sample](https://github.com/microsoft/reverse-proxy/tree/main/samples/BasicYarpSample) for a fully commented sample showing how to use the YARP library to implement a fairly well featured proxy.

--- a/src/OperatorFramework/examples/BasicOperator/Models/V1alpha1HelloWorld.cs
+++ b/src/OperatorFramework/examples/BasicOperator/Models/V1alpha1HelloWorld.cs
@@ -15,15 +15,12 @@ namespace BasicOperator.Models
         public const string KubeGroup = "basic-operator.example.io";
         public const string KubeKind = "HelloWorld";
 
-        /// <inheritdoc/>
         [JsonProperty("apiVersion")]
         public string ApiVersion { get; set; }
 
-        /// <inheritdoc/>
         [JsonProperty("kind")]
         public string Kind { get; set; }
 
-        /// <inheritdoc/>
         [JsonProperty("metadata")]
         public V1ObjectMeta Metadata { get; set; }
 

--- a/src/OperatorFramework/examples/UsingCustomResources/Models/V1alpha1Ticket.cs
+++ b/src/OperatorFramework/examples/UsingCustomResources/Models/V1alpha1Ticket.cs
@@ -31,15 +31,12 @@ namespace UsingCustomResources.Models
         /// </summary>
         public const string KubeKind = "Ticket";
 
-        /// <inheritdoc/>
         [JsonProperty("apiVersion")]
         public string ApiVersion { get; set; }
 
-        /// <inheritdoc/>
         [JsonProperty("kind")]
         public string Kind { get; set; }
 
-        /// <inheritdoc/>
         [JsonProperty("metadata")]
         public V1ObjectMeta Metadata { get; set; }
 

--- a/src/OperatorFramework/examples/UsingCustomResources/Models/V1alpha1TicketProvider.cs
+++ b/src/OperatorFramework/examples/UsingCustomResources/Models/V1alpha1TicketProvider.cs
@@ -29,15 +29,12 @@ namespace UsingCustomResources.Models
         /// </summary>
         public const string KubeKind = "TicketProvider";
 
-        /// <inheritdoc/>
         [JsonProperty("apiVersion")]
         public string ApiVersion { get; set; }
 
-        /// <inheritdoc/>
         [JsonProperty("kind")]
         public string Kind { get; set; }
 
-        /// <inheritdoc/>
         [JsonProperty("metadata")]
         public V1ObjectMeta Metadata { get; set; }
 

--- a/src/OperatorFramework/src/Controller/Hosting/HostedServiceAdapter.cs
+++ b/src/OperatorFramework/src/Controller/Hosting/HostedServiceAdapter.cs
@@ -22,10 +22,8 @@ namespace Microsoft.Kubernetes.Controller.Hosting
         /// <param name="service">The service interface to delegate onto.</param>
         public HostedServiceAdapter(TService service) => _service = service;
 
-        /// <inheritdoc/>
         public Task StartAsync(CancellationToken cancellationToken) => _service.StartAsync(cancellationToken);
 
-        /// <inheritdoc/>
         public Task StopAsync(CancellationToken cancellationToken) => _service.StopAsync(cancellationToken);
     }
 }

--- a/src/OperatorFramework/src/Controller/Queues/DelayingQueue.cs
+++ b/src/OperatorFramework/src/Controller/Queues/DelayingQueue.cs
@@ -41,7 +41,6 @@ namespace Microsoft.Kubernetes.Controller.Queues
         /// <summary>
         /// Shuts down.
         /// </summary>
-        /// <inheritdoc />
         public override void ShutDown()
         {
             _shuttingDown.Cancel();

--- a/src/OperatorFramework/src/Core/Client/AnyResourceKind.cs
+++ b/src/OperatorFramework/src/Core/Client/AnyResourceKind.cs
@@ -57,7 +57,6 @@ namespace Microsoft.Kubernetes.Client
             }
         }
 
-        /// <inheritdoc/>
         public async Task<HttpOperationResponse<KubernetesList<TResource>>> ListClusterAnyResourceKindWithHttpMessagesAsync<TResource>(string group, string version, string plural, string continueParameter = null, string fieldSelector = null, string labelSelector = null, int? limit = null, string resourceVersion = null, int? timeoutSeconds = null, bool? watch = null, string pretty = null, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default) where TResource : IKubernetesObject
         {
             if (group == null)
@@ -241,7 +240,7 @@ namespace Microsoft.Kubernetes.Client
             return _result;
         }
 
-        /// <inheritdoc/>
+        
         public async Task<HttpOperationResponse<object>> CreateAnyResourceKindWithHttpMessagesAsync<TResource>(TResource body, string group, string version, string namespaceParameter, string plural, string dryRun = default(string), string fieldManager = default(string), string pretty = default(string), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken)) where TResource : IKubernetesObject
         {
             if (body == null)
@@ -407,7 +406,7 @@ namespace Microsoft.Kubernetes.Client
             return _result;
         }
 
-        /// <inheritdoc/>
+        
         public async Task<HttpOperationResponse<object>> PatchAnyResourceKindWithHttpMessagesAsync(V1Patch body, string group, string version, string namespaceParameter, string plural, string name, string dryRun = default(string), string fieldManager = default(string), bool? force = default(bool?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (body == null)
@@ -579,7 +578,7 @@ namespace Microsoft.Kubernetes.Client
             return _result;
         }
 
-        /// <inheritdoc/>
+        
         public async Task<HttpOperationResponse<object>> DeleteAnyResourceKindWithHttpMessagesAsync(string group, string version, string namespaceParameter, string plural, string name, V1DeleteOptions body = default(V1DeleteOptions), int? gracePeriodSeconds = default(int?), bool? orphanDependents = default(bool?), string propagationPolicy = default(string), string dryRun = default(string), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (group == null)

--- a/src/OperatorFramework/src/Core/GroupKindNamespacedName.cs
+++ b/src/OperatorFramework/src/Core/GroupKindNamespacedName.cs
@@ -87,13 +87,11 @@ namespace Microsoft.Kubernetes
                 NamespacedName.From(resource));
         }
 
-        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             return obj is GroupKindNamespacedName name && Equals(name);
         }
 
-        /// <inheritdoc/>
         public bool Equals([AllowNull] GroupKindNamespacedName other)
         {
             return Group == other.Group &&
@@ -101,7 +99,6 @@ namespace Microsoft.Kubernetes
                    NamespacedName.Equals(other.NamespacedName);
         }
 
-        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return HashCode.Combine(Group, Kind, NamespacedName);

--- a/src/OperatorFramework/src/Core/NamespacedName.cs
+++ b/src/OperatorFramework/src/Core/NamespacedName.cs
@@ -104,19 +104,16 @@ namespace Microsoft.Kubernetes
                 ownerReference.Name);
         }
 
-        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             return obj is NamespacedName name && Equals(name);
         }
 
-        /// <inheritdoc/>
         public bool Equals([AllowNull] NamespacedName other)
         {
             return Namespace == other.Namespace && Name == other.Name;
         }
 
-        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return HashCode.Combine(Namespace, Name);

--- a/src/OperatorFramework/src/Core/Resources/ResourceSerializers.cs
+++ b/src/OperatorFramework/src/Core/Resources/ResourceSerializers.cs
@@ -44,7 +44,6 @@ namespace Microsoft.Kubernetes.Resources
             };
         }
 
-        /// <inheritdoc/>
         public T DeserializeYaml<T>(string yaml)
         {
             var resource = _yamlDeserializer.Deserialize<object>(yaml);
@@ -52,19 +51,16 @@ namespace Microsoft.Kubernetes.Resources
             return Convert<T>(resource);
         }
 
-        /// <inheritdoc/>
         public T DeserializeJson<T>(string json)
         {
             return SafeJsonConvert.DeserializeObject<T>(json);
         }
 
-        /// <inheritdoc/>
         public string SerializeJson(object resource)
         {
             return SafeJsonConvert.SerializeObject(resource, _serializationSettings);
         }
 
-        /// <inheritdoc/>
         public TResource Convert<TResource>(object resource)
         {
             var json = SafeJsonConvert.SerializeObject(resource, _serializationSettings);
@@ -74,7 +70,6 @@ namespace Microsoft.Kubernetes.Resources
 
         private class NonStringScalarTypeResolver : INodeTypeResolver
         {
-            /// <inheritdoc/>
             bool INodeTypeResolver.Resolve(NodeEvent nodeEvent, ref Type currentType)
             {
                 if (currentType == typeof(object) && nodeEvent is Scalar)

--- a/src/OperatorFramework/src/Operator/Generators/GenerateResult.cs
+++ b/src/OperatorFramework/src/Operator/Generators/GenerateResult.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 namespace Microsoft.Kubernetes.Operator.Generators
 {
     /// <summary>
-    /// Class GenerateResult is returned from <see cref="IOperatorGenerator.Generate(TResource)"/>
+    /// Class GenerateResult is returned from "IOperatorGenerator.GenerateAsync"/>
     /// to determine how the operator should proceed.
     /// </summary>
     public class GenerateResult

--- a/src/OperatorFramework/test/UnitTests/CustomResources/TypicalResource.cs
+++ b/src/OperatorFramework/test/UnitTests/CustomResources/TypicalResource.cs
@@ -17,15 +17,12 @@ namespace Microsoft.Kubernetes.CustomResources
         public const string KubeGroup = "test-group";
         public const string KubeKind = "Typical";
 
-        /// <inheritdoc/>
         [JsonProperty("apiVersion")]
         public string ApiVersion { get; set; }
 
-        /// <inheritdoc/>
         [JsonProperty("kind")]
         public string Kind { get; set; }
 
-        /// <inheritdoc/>
         [JsonProperty("metadata")]
         public V1ObjectMeta Metadata { get; set; }
 

--- a/src/OperatorFramework/test/UnitTests/Microsoft.Kubernetes.UnitTests.xml
+++ b/src/OperatorFramework/test/UnitTests/Microsoft.Kubernetes.UnitTests.xml
@@ -9,15 +9,6 @@
             TypicalResource doc comment
             </summary>
         </member>
-        <member name="P:Microsoft.Kubernetes.CustomResources.TypicalResource.ApiVersion">
-            <inheritdoc/>
-        </member>
-        <member name="P:Microsoft.Kubernetes.CustomResources.TypicalResource.Kind">
-            <inheritdoc/>
-        </member>
-        <member name="P:Microsoft.Kubernetes.CustomResources.TypicalResource.Metadata">
-            <inheritdoc/>
-        </member>
         <member name="P:Microsoft.Kubernetes.CustomResources.TypicalResource.Spec">
             <summary>
             Spec doc comment

--- a/src/ReverseProxy/Configuration/ActiveHealthCheckConfig.cs
+++ b/src/ReverseProxy/Configuration/ActiveHealthCheckConfig.cs
@@ -35,7 +35,6 @@ namespace Yarp.ReverseProxy.Configuration
         /// </summary>
         public string? Path { get; init; }
 
-        /// <inheritdoc />
         public bool Equals(ActiveHealthCheckConfig? other)
         {
             if (other == null)
@@ -50,7 +49,6 @@ namespace Yarp.ReverseProxy.Configuration
                 && string.Equals(Path, other.Path, StringComparison.OrdinalIgnoreCase);
         }
 
-        /// <inheritdoc />
         public override int GetHashCode()
         {
             return HashCode.Combine(Enabled,

--- a/src/ReverseProxy/Configuration/ClusterConfig.cs
+++ b/src/ReverseProxy/Configuration/ClusterConfig.cs
@@ -54,7 +54,6 @@ namespace Yarp.ReverseProxy.Configuration
         /// </summary>
         public IReadOnlyDictionary<string, string>? Metadata { get; init; }
 
-        /// <inheritdoc />
         public bool Equals(ClusterConfig? other)
         {
             if (other == null)
@@ -83,7 +82,6 @@ namespace Yarp.ReverseProxy.Configuration
                 && CaseInsensitiveEqualHelper.Equals(Metadata, other.Metadata);
         }
 
-        /// <inheritdoc />
         public override int GetHashCode()
         {
             return HashCode.Combine(

--- a/src/ReverseProxy/Configuration/DestinationConfig.cs
+++ b/src/ReverseProxy/Configuration/DestinationConfig.cs
@@ -28,7 +28,6 @@ namespace Yarp.ReverseProxy.Configuration
         /// </summary>
         public IReadOnlyDictionary<string, string>? Metadata { get; init; }
 
-        /// <inheritdoc />
         public bool Equals(DestinationConfig? other)
         {
             if (other == null)
@@ -41,7 +40,6 @@ namespace Yarp.ReverseProxy.Configuration
                 && CaseInsensitiveEqualHelper.Equals(Metadata, other.Metadata);
         }
 
-        /// <inheritdoc />
         public override int GetHashCode()
         {
             return HashCode.Combine(

--- a/src/ReverseProxy/Configuration/HealthCheckConfig.cs
+++ b/src/ReverseProxy/Configuration/HealthCheckConfig.cs
@@ -25,7 +25,6 @@ namespace Yarp.ReverseProxy.Configuration
         /// </summary>
         public string? AvailableDestinationsPolicy { get; init; }
 
-        /// <inheritdoc />
         public bool Equals(HealthCheckConfig? other)
         {
             if (other == null)
@@ -38,7 +37,6 @@ namespace Yarp.ReverseProxy.Configuration
                 && string.Equals(AvailableDestinationsPolicy, other.AvailableDestinationsPolicy, StringComparison.OrdinalIgnoreCase);
         }
 
-        /// <inheritdoc />
         public override int GetHashCode()
         {
             return HashCode.Combine(Passive, Active, AvailableDestinationsPolicy);

--- a/src/ReverseProxy/Configuration/HttpClientConfig.cs
+++ b/src/ReverseProxy/Configuration/HttpClientConfig.cs
@@ -45,8 +45,8 @@ namespace Yarp.ReverseProxy.Configuration
 #if NET
         /// <summary>
         /// Gets or sets a value that indicates whether additional HTTP/2 connections can
-        //  be established to the same server when the maximum number of concurrent streams
-        //  is reached on all existing connections.
+        /// be established to the same server when the maximum number of concurrent streams
+        /// is reached on all existing connections.
         /// </summary>
         public bool? EnableMultipleHttp2Connections { get; init; }
 
@@ -56,7 +56,6 @@ namespace Yarp.ReverseProxy.Configuration
         public string? RequestHeaderEncoding { get; init; }
 #endif
 
-        /// <inheritdoc />
         public bool Equals(HttpClientConfig? other)
         {
             if (other == null)
@@ -76,7 +75,6 @@ namespace Yarp.ReverseProxy.Configuration
                    && WebProxy == other.WebProxy;
         }
 
-        /// <inheritdoc />
         public override int GetHashCode()
         {
             return HashCode.Combine(SslProtocols,

--- a/src/ReverseProxy/Configuration/PassiveHealthCheckConfig.cs
+++ b/src/ReverseProxy/Configuration/PassiveHealthCheckConfig.cs
@@ -25,7 +25,6 @@ namespace Yarp.ReverseProxy.Configuration
         /// </summary>
         public TimeSpan? ReactivationPeriod { get; init; }
 
-        /// <inheritdoc />
         public bool Equals(PassiveHealthCheckConfig? other)
         {
             if (other == null)
@@ -38,7 +37,6 @@ namespace Yarp.ReverseProxy.Configuration
                 && ReactivationPeriod == other.ReactivationPeriod;
         }
 
-        /// <inheritdoc />
         public override int GetHashCode()
         {
             return HashCode.Combine(Enabled,

--- a/src/ReverseProxy/Configuration/RouteConfig.cs
+++ b/src/ReverseProxy/Configuration/RouteConfig.cs
@@ -58,11 +58,10 @@ namespace Yarp.ReverseProxy.Configuration
         public IReadOnlyDictionary<string, string>? Metadata { get; init; }
 
         /// <summary>
-        /// Parameters used to transform the request and response. See <see cref="Service.ITransformBuilder"/>.
+        /// Parameters used to transform the request and response. See <see cref="Transforms.Builder.ITransformBuilder"/>.
         /// </summary>
         public IReadOnlyList<IReadOnlyDictionary<string, string>>? Transforms { get; init; }
 
-        /// <inheritdoc />
         public bool Equals(RouteConfig? other)
         {
             if (other == null)
@@ -80,7 +79,6 @@ namespace Yarp.ReverseProxy.Configuration
                 && CaseInsensitiveEqualHelper.Equals(Transforms, other.Transforms);
         }
 
-        /// <inheritdoc />
         public override int GetHashCode()
         {
             return HashCode.Combine(Order,

--- a/src/ReverseProxy/Configuration/RouteHeader.cs
+++ b/src/ReverseProxy/Configuration/RouteHeader.cs
@@ -38,7 +38,6 @@ namespace Yarp.ReverseProxy.Configuration
         /// </summary>
         public bool IsCaseSensitive { get; init; }
 
-        /// <inheritdoc />
         public bool Equals(RouteHeader? other)
         {
             if (other == null)
@@ -54,7 +53,6 @@ namespace Yarp.ReverseProxy.Configuration
                     : CaseInsensitiveEqualHelper.Equals(Values, other.Values));
         }
 
-        /// <inheritdoc />
         public override int GetHashCode()
         {
             return HashCode.Combine(Mode, IsCaseSensitive,

--- a/src/ReverseProxy/Configuration/RouteMatch.cs
+++ b/src/ReverseProxy/Configuration/RouteMatch.cs
@@ -33,7 +33,6 @@ namespace Yarp.ReverseProxy.Configuration
         /// </summary>
         public IReadOnlyList<RouteHeader>? Headers { get; init; }
 
-        /// <inheritdoc />
         public bool Equals(RouteMatch? other)
         {
             if (other == null)
@@ -76,7 +75,6 @@ namespace Yarp.ReverseProxy.Configuration
             return true;
         }
 
-        /// <inheritdoc />
         public override int GetHashCode()
         {
             return HashCode.Combine(

--- a/src/ReverseProxy/Configuration/SessionAffinityConfig.cs
+++ b/src/ReverseProxy/Configuration/SessionAffinityConfig.cs
@@ -43,7 +43,6 @@ namespace Yarp.ReverseProxy.Configuration
         /// </summary>
         public SessionAffinityCookieConfig? Cookie { get; init; }
 
-        /// <inheritdoc />
         public bool Equals(SessionAffinityConfig? other)
         {
             if (other == null)
@@ -58,7 +57,6 @@ namespace Yarp.ReverseProxy.Configuration
                 && Cookie == other.Cookie;
         }
 
-        /// <inheritdoc />
         public override int GetHashCode()
         {
             return HashCode.Combine(Enabled,

--- a/src/ReverseProxy/Configuration/SessionAffinityCookieConfig.cs
+++ b/src/ReverseProxy/Configuration/SessionAffinityCookieConfig.cs
@@ -26,7 +26,7 @@ namespace Yarp.ReverseProxy.Configuration
         /// <summary>
         /// Indicates whether a cookie is accessible by client-side script.
         /// </summary>
-        /// <remarks>Defaults to <see cref="true"/>.</remarks>
+        /// <remarks>Defaults to "true".</remarks>
         public bool? HttpOnly { get; init; }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Yarp.ReverseProxy.Configuration
         /// Indicates if this cookie is essential for the application to function correctly. If true then
         /// consent policy checks may be bypassed.
         /// </summary>
-        /// <remarks>Defaults to <see cref="false"/>.</remarks>
+        /// <remarks>Defaults to "false".</remarks>
         public bool? IsEssential { get; init; }
 
         public bool Equals(SessionAffinityCookieConfig? other)

--- a/src/ReverseProxy/Configuration/WebProxyConfig.cs
+++ b/src/ReverseProxy/Configuration/WebProxyConfig.cs
@@ -27,7 +27,6 @@ namespace Yarp.ReverseProxy.Configuration
         /// </summary>
         public bool? UseDefaultCredentials { get; init; }
 
-        /// <inheritdoc/>
         public bool Equals(WebProxyConfig? other)
         {
             if (other == null)
@@ -40,7 +39,6 @@ namespace Yarp.ReverseProxy.Configuration
                 && UseDefaultCredentials == other.UseDefaultCredentials;
         }
 
-        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return HashCode.Combine(

--- a/src/ReverseProxy/Forwarder/ForwarderRequestConfig.cs
+++ b/src/ReverseProxy/Forwarder/ForwarderRequestConfig.cs
@@ -43,7 +43,6 @@ namespace Yarp.ReverseProxy.Forwarder
         /// </summary>
         public bool? AllowResponseBuffering { get; init; }
 
-        /// <inheritdoc />
         public bool Equals(ForwarderRequestConfig? other)
         {
             if (other == null)
@@ -59,7 +58,6 @@ namespace Yarp.ReverseProxy.Forwarder
                 && AllowResponseBuffering == other.AllowResponseBuffering;
         }
 
-        /// <inheritdoc />
         public override int GetHashCode()
         {
             return HashCode.Combine(Timeout,

--- a/src/ReverseProxy/Model/ClusterState.cs
+++ b/src/ReverseProxy/Model/ClusterState.cs
@@ -41,7 +41,7 @@ namespace Yarp.ReverseProxy.Model
         /// <summary>
         /// All of the destinations associated with this cluster. This collection is populated by the configuration system
         /// and should only be directly modified in a test environment.
-        /// Call <see cref="IClusterDestinationsUpdater"/> after modifying this collection.
+        /// Call <see cref="Health.IClusterDestinationsUpdater"/> after modifying this collection.
         /// </summary>
         public ConcurrentDictionary<string, DestinationState> Destinations { get; } = new(StringComparer.OrdinalIgnoreCase);
 

--- a/src/ReverseProxy/Model/DestinationState.cs
+++ b/src/ReverseProxy/Model/DestinationState.cs
@@ -59,11 +59,9 @@ namespace Yarp.ReverseProxy.Model
 
         internal AtomicCounter ConcurrencyCounter { get; } = new AtomicCounter();
 
-        /// <inheritdoc/>
         DestinationState IReadOnlyList<DestinationState>.this[int index]
             => index == 0 ? this : throw new IndexOutOfRangeException();
 
-        /// <inheritdoc/>
         int IReadOnlyCollection<DestinationState>.Count => 1;
 
         private Enumerator GetEnumerator()
@@ -71,13 +69,11 @@ namespace Yarp.ReverseProxy.Model
             return new Enumerator(this);
         }
 
-        /// <inheritdoc/>
         IEnumerator<DestinationState> IEnumerable<DestinationState>.GetEnumerator()
         {
             return GetEnumerator();
         }
 
-        /// <inheritdoc/>
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();

--- a/src/ReverseProxy/Model/ReverseProxyApplicationBuilder.cs
+++ b/src/ReverseProxy/Model/ReverseProxyApplicationBuilder.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Http.Features;
 
 namespace Yarp.ReverseProxy.Model
 {
-    /// <inheritdoc/>
     public class ReverseProxyApplicationBuilder : IReverseProxyApplicationBuilder
     {
         private readonly IApplicationBuilder _applicationBuilder;


### PR DESCRIPTION
Fixes most of the docfx warnings. It leaves only 5 active warnings which complain about missing metadata references in `src/OperatorFramework/examples/BasicOperator/BasicOperator.csproj`. They can be ignored for now.

Contributes to #1067 