### PR TITLE
#1210 Rebuild configuration for any ingress change

### DIFF
--- a/src/Kubernetes.Controller/Caching/ICache.cs
+++ b/src/Kubernetes.Controller/Caching/ICache.cs
@@ -17,8 +17,9 @@ namespace Yarp.Kubernetes.Controller.Caching;
 public interface ICache
 {
     void Update(WatchEventType eventType, V1Ingress ingress);
-    void Update(WatchEventType eventType, V1Service service);
+    ImmutableList<string> Update(WatchEventType eventType, V1Service service);
     ImmutableList<string> Update(WatchEventType eventType, V1Endpoints endpoints);
     bool TryGetReconcileData(NamespacedName key, out ReconcileData data);
     void GetKeys(List<NamespacedName> keys);
+    IEnumerable<IngressData> GetIngresses();
 }

--- a/src/Kubernetes.Controller/Caching/IngressCache.cs
+++ b/src/Kubernetes.Controller/Caching/IngressCache.cs
@@ -30,14 +30,15 @@ public class IngressCache : ICache
         Namespace(ingress.Namespace()).Update(eventType, ingress);
     }
 
-    public void Update(WatchEventType eventType, V1Service service)
+
+    public ImmutableList<string> Update(WatchEventType eventType, V1Service service)
     {
         if (service is null)
         {
             throw new ArgumentNullException(nameof(service));
         }
 
-        Namespace(service.Namespace()).Update(eventType, service);
+        return Namespace(service.Namespace()).Update(eventType, service);
     }
 
     public ImmutableList<string> Update(WatchEventType eventType, V1Endpoints endpoints)
@@ -61,6 +62,20 @@ public class IngressCache : ICache
         }
     }
 
+    public IEnumerable<IngressData> GetIngresses()
+    {
+        var ingresses = new List<IngressData>();
+
+        lock (_sync)
+        {
+            foreach (var ns in _namespaceCaches)
+            {
+                ingresses.AddRange(ns.Value.GetIngresses());
+            }
+        }
+
+        return ingresses;
+    }
 
     private NamespaceCache Namespace(string key)
     {

--- a/src/Kubernetes.Controller/Caching/NamespaceCache.cs
+++ b/src/Kubernetes.Controller/Caching/NamespaceCache.cs
@@ -120,7 +120,7 @@ public class NamespaceCache
         }
     }
 
-    public void Update(WatchEventType eventType, V1Service service)
+    public ImmutableList<string> Update(WatchEventType eventType, V1Service service)
     {
         if (service is null)
         {
@@ -137,6 +137,15 @@ public class NamespaceCache
             else if (eventType == WatchEventType.Deleted)
             {
                 _serviceData.Remove(serviceName);
+            }
+
+            if (_serviceToIngressNames.TryGetValue(serviceName, out var ingressNames))
+            {
+                return ingressNames;
+            }
+            else
+            {
+                return ImmutableList<string>.Empty;
             }
         }
     }
@@ -185,6 +194,11 @@ public class NamespaceCache
                 return ImmutableList<string>.Empty;
             }
         }
+    }
+
+    public IEnumerable<IngressData> GetIngresses()
+    {
+        return _ingressData.Values;
     }
 
     public bool TryLookup(NamespacedName key, out ReconcileData data)

--- a/src/Kubernetes.Controller/Converters/YarpConfigContext.cs
+++ b/src/Kubernetes.Controller/Converters/YarpConfigContext.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Yarp.ReverseProxy.Configuration;
+
+namespace Yarp.Kubernetes.Controller.Services;
+
+internal class YarpConfigContext
+{
+    public Dictionary<string, ClusterTransfer> ClusterTransfers { get; set; } = new Dictionary<string, ClusterTransfer>();
+    public List<RouteConfig> Routes { get; set; } = new List<RouteConfig>();
+
+    public List<ClusterConfig> BuildClusterConfig()
+    {
+        return ClusterTransfers.Values.Select(c => new ClusterConfig() { Destinations = c.Destinations, ClusterId = c.ClusterId }).ToList();
+    }
+}

--- a/src/Kubernetes.Controller/Converters/YarpIngressContext.cs
+++ b/src/Kubernetes.Controller/Converters/YarpIngressContext.cs
@@ -17,9 +17,6 @@ internal sealed class YarpIngressContext
     }
 
     public YarpIngressOptions Options { get; set; } = new YarpIngressOptions();
-    public Dictionary<string, ClusterTransfer> ClusterTransfers { get; set; } = new Dictionary<string, ClusterTransfer>();
-    public List<RouteConfig> Routes { get; set; } = new List<RouteConfig>();
-    public List<ClusterConfig> Clusters { get; set; } = new List<ClusterConfig>();
     public IngressData Ingress { get; }
     public List<ServiceData> Services { get; }
     public List<Endpoints> Endpoints { get; }

--- a/src/Kubernetes.Controller/Converters/YarpParser.cs
+++ b/src/Kubernetes.Controller/Converters/YarpParser.cs
@@ -10,60 +10,46 @@ namespace Yarp.Kubernetes.Controller.Converters;
 
 internal static class YarpParser
 {
-    internal static void CovertFromKubernetesIngress(YarpIngressContext context)
+    internal static void ConvertFromKubernetesIngress(YarpIngressContext ingressContext, YarpConfigContext configContext)
     {
-        var spec = context.Ingress.Spec;
+        var spec = ingressContext.Ingress.Spec;
         var defaultBackend = spec?.DefaultBackend;
         var defaultService = defaultBackend?.Service;
         IList<V1EndpointSubset> defaultSubsets = default;
 
         if (!string.IsNullOrEmpty(defaultService?.Name))
         {
-            defaultSubsets = context.Endpoints.SingleOrDefault(x => x.Name == defaultService?.Name).Subsets;
+            defaultSubsets = ingressContext.Endpoints.SingleOrDefault(x => x.Name == defaultService?.Name).Subsets;
         }
 
         // cluster can contain multiple replicas for each destination, need to know the lookup base don endpoints
-        var options = HandleAnnotations(context, context.Ingress.Metadata);
+        var options = HandleAnnotations(ingressContext, ingressContext.Ingress.Metadata);
 
         foreach (var rule in spec.Rules ?? Enumerable.Empty<V1IngressRule>())
         {
-            HandleIngressRule(context, context.Endpoints, defaultSubsets, rule);
-        }
-
-        CreateClusters(context);
-    }
-
-    private static void CreateClusters(YarpIngressContext context)
-    {
-        foreach (var cluster in context.ClusterTransfers)
-        {
-            context.Clusters.Add(new ClusterConfig()
-            {
-                Destinations = cluster.Value.Destinations,
-                ClusterId = cluster.Value.ClusterId
-            });
+            HandleIngressRule(ingressContext, ingressContext.Endpoints, defaultSubsets, rule, configContext);
         }
     }
 
-    private static void HandleIngressRule(YarpIngressContext context, List<Endpoints> endpoints, IList<V1EndpointSubset> defaultSubsets, V1IngressRule rule)
+    private static void HandleIngressRule(YarpIngressContext ingressContext, List<Endpoints> endpoints, IList<V1EndpointSubset> defaultSubsets, V1IngressRule rule, YarpConfigContext configContext)
     {
         var http = rule.Http;
         foreach (var path in http.Paths ?? Enumerable.Empty<V1HTTPIngressPath>())
         {
-            var service = context.Services.SingleOrDefault(s => s.Metadata.Name == path.Backend.Service.Name);
+            var service = ingressContext.Services.SingleOrDefault(s => s.Metadata.Name == path.Backend.Service.Name);
             var servicePort = service.Spec.Ports.SingleOrDefault(p => MatchesPort(p, path.Backend.Service.Port));
-            HandleIngressRulePath(context, servicePort, endpoints, defaultSubsets, rule, path);
+            HandleIngressRulePath(ingressContext, servicePort, endpoints, defaultSubsets, rule, path, configContext);
         }
     }
 
-    private static void HandleIngressRulePath(YarpIngressContext context, V1ServicePort servicePort, List<Endpoints> endpoints, IList<V1EndpointSubset> defaultSubsets, V1IngressRule rule, V1HTTPIngressPath path)
+    private static void HandleIngressRulePath(YarpIngressContext ingressContext, V1ServicePort servicePort, List<Endpoints> endpoints, IList<V1EndpointSubset> defaultSubsets, V1IngressRule rule, V1HTTPIngressPath path, YarpConfigContext configContext)
     {
         var backend = path.Backend;
         var ingressServiceBackend = backend.Service;
         var subsets = defaultSubsets;
 
-        var clusters = context.ClusterTransfers;
-        var routes = context.Routes;
+        var clusters = configContext.ClusterTransfers;
+        var routes = configContext.Routes;
 
         if (!string.IsNullOrEmpty(ingressServiceBackend?.Name))
         {
@@ -85,33 +71,34 @@ internal static class YarpParser
         {
             foreach (var port in subset.Ports ?? Enumerable.Empty<V1EndpointPort>())
             {
+                if (!MatchesPort(port, servicePort.TargetPort))
+                {
+                    continue;
+                }
+
+                var pathMatch = FixupPathMatch(path);
+                var host = rule.Host;
+
+                routes.Add(new RouteConfig()
+                {
+                    Match = new RouteMatch()
+                    {
+                        Hosts = host != null ? new[] { host } : Array.Empty<string>(),
+                        Path = pathMatch
+                    },
+                    ClusterId = cluster.ClusterId,
+                    RouteId = $"{ingressContext.Ingress.Metadata.Name}:{path.Path}"
+                });
+
+                // Add destination for every endpoint address
                 foreach (var address in subset.Addresses ?? Enumerable.Empty<V1EndpointAddress>())
                 {
-                    if (!MatchesPort(port, servicePort.TargetPort))
-                    {
-                        continue;
-                    }
-
-                    var protocol = context.Options.Https ? "https" : "http";
+                    var protocol = ingressContext.Options.Https ? "https" : "http";
                     var uri = $"{protocol}://{address.Ip}:{port.Port}";
                     cluster.Destinations[uri] = new DestinationConfig()
                     {
                         Address = uri
                     };
-
-                    var pathMatch = FixupPathMatch(path);
-                    var host = rule.Host;
-
-                    routes.Add(new RouteConfig()
-                    {
-                        Match = new RouteMatch()
-                        {
-                            Hosts = host != null ? new[] { host } : Array.Empty<string>(),
-                            Path = pathMatch
-                        },
-                        ClusterId = cluster.ClusterId,
-                        RouteId = path.Path
-                    });
                 }
             }
         }

--- a/src/Kubernetes.Controller/Services/IReconciler.cs
+++ b/src/Kubernetes.Controller/Services/IReconciler.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.Kubernetes;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,5 +15,5 @@ namespace Yarp.Kubernetes.Controller.Services;
 public interface IReconciler
 {
     void OnAttach(Action<IDispatchTarget> attached);
-    Task ProcessAsync(IDispatchTarget target, NamespacedName key, ReconcileData data, CancellationToken cancellationToken);
+    Task ProcessAsync(CancellationToken cancellationToken);
 }

--- a/src/Kubernetes.Controller/Services/IngressController.cs
+++ b/src/Kubernetes.Controller/Services/IngressController.cs
@@ -74,7 +74,7 @@ public class IngressController : BackgroundHostedService
             endpointsInformer.Register(Notification),
         };
 
-        _queue = new ProcessingRateLimitedQueue<QueueItem>(0.5, 1);
+        _queue = new ProcessingRateLimitedQueue<QueueItem>(perSecond: 0.5, burst: 1);
 
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
         _reconciler = reconciler ?? throw new ArgumentNullException(nameof(reconciler));

--- a/src/Kubernetes.Controller/Services/QueueItem.cs
+++ b/src/Kubernetes.Controller/Services/QueueItem.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Kubernetes;
 using Yarp.Kubernetes.Controller.Dispatching;
 
 namespace Yarp.Kubernetes.Controller.Services;
@@ -13,16 +12,16 @@ namespace Yarp.Kubernetes.Controller.Services;
 /// </summary>
 public struct QueueItem : IEquatable<QueueItem>
 {
-    public QueueItem(NamespacedName namespacedName, IDispatchTarget dispatchTarget)
+    public QueueItem(string change, IDispatchTarget dispatchTarget)
     {
-        NamespacedName = namespacedName;
+        Change = change;
         DispatchTarget = dispatchTarget;
     }
 
     /// <summary>
     /// This identifies an Ingress which must be dispatched because it, or a related resource, has changed.
     /// </summary>
-    public NamespacedName NamespacedName { get; }
+    public string Change { get; }
 
     /// <summary>
     /// This idenitifies a single target if the work item is caused by a new connection, otherwise null
@@ -37,13 +36,13 @@ public struct QueueItem : IEquatable<QueueItem>
 
     public bool Equals(QueueItem other)
     {
-        return NamespacedName.Equals(other.NamespacedName) &&
+        return Change.Equals(other.Change, StringComparison.Ordinal) &&
                EqualityComparer<IDispatchTarget>.Default.Equals(DispatchTarget, other.DispatchTarget);
     }
 
     public override int GetHashCode()
     {
-        return HashCode.Combine(NamespacedName, DispatchTarget);
+        return HashCode.Combine(Change, DispatchTarget);
     }
 
     public static bool operator ==(QueueItem left, QueueItem right)

--- a/src/Kubernetes.Controller/Services/QueueItem.cs
+++ b/src/Kubernetes.Controller/Services/QueueItem.cs
@@ -19,7 +19,7 @@ public struct QueueItem : IEquatable<QueueItem>
     }
 
     /// <summary>
-    /// This identifies an Ingress which must be dispatched because it, or a related resource, has changed.
+    /// This identifies that a change has occured and either configuration requires to be rebuilt, or needs to be dispatched.
     /// </summary>
     public string Change { get; }
 

--- a/src/Kubernetes.Controller/Services/ReconcileData.cs
+++ b/src/Kubernetes.Controller/Services/ReconcileData.cs
@@ -8,7 +8,7 @@ namespace Yarp.Kubernetes.Controller.Services;
 
 /// <summary>
 /// ReconcileData is the information returned from <see cref="ICache.TryGetReconcileData(Microsoft.Kubernetes.NamespacedName, out ReconcileData)"/>
-/// and needed by <see cref="IReconciler.ProcessAsync(Dispatching.IDispatchTarget, Microsoft.Kubernetes.NamespacedName, ReconcileData, System.Threading.CancellationToken)"/>.
+/// and needed by <see cref="IReconciler.ProcessAsync(System.Threading.CancellationToken)"/>.
 /// </summary>
 #pragma warning disable CA1815 // Override equals and operator equals on value types
 public struct ReconcileData

--- a/src/OperatorFramework/src/Controller/Queues/ProcessingRateLimitedQueue.cs
+++ b/src/OperatorFramework/src/Controller/Queues/ProcessingRateLimitedQueue.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Kubernetes.Controller.Rate;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Kubernetes.Controller.Queues
+{
+    public class ProcessingRateLimitedQueue<TItem> : WorkQueue<TItem>
+    {
+        private readonly Limiter _limiter;
+
+        public ProcessingRateLimitedQueue(double perSecond, int burst)
+        {
+            _limiter = new Limiter(new Limit(perSecond), burst);
+        }
+
+        protected override async Task OnGetAsync(CancellationToken cancellationToken)
+        {
+            var delay = _limiter.Reserve().Delay();
+            await Task.Delay(delay, cancellationToken);
+        }
+    }
+}

--- a/src/OperatorFramework/src/Controller/Queues/WorkQueue.cs
+++ b/src/OperatorFramework/src/Controller/Queues/WorkQueue.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 
 #pragma warning disable CA2213 // Disposable fields should be disposed
 
-
 namespace Microsoft.Kubernetes.Controller.Queues;
 
 /// <summary>
@@ -78,6 +77,8 @@ public class WorkQueue<TItem> : IWorkQueue<TItem>
             try
             {
                 await _semaphore.WaitAsync(linkedTokenSource.Token);
+
+                await OnGetAsync(cancellationToken);
             }
             catch (OperationCanceledException)
             {
@@ -172,5 +173,15 @@ public class WorkQueue<TItem> : IWorkQueue<TItem>
 
             _disposedValue = true;
         }
+    }
+
+    /// <summary>
+    /// Called in GetAsync BEFORE the items is dequeued to allow rate-limiting of processing.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+    /// <returns>A task.</returns>
+    protected virtual Task OnGetAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
     }
 }

--- a/src/OperatorFramework/src/Controller/Queues/WorkQueue.cs
+++ b/src/OperatorFramework/src/Controller/Queues/WorkQueue.cs
@@ -78,7 +78,7 @@ public class WorkQueue<TItem> : IWorkQueue<TItem>
             {
                 await _semaphore.WaitAsync(linkedTokenSource.Token);
 
-                await OnGetAsync(cancellationToken);
+                await OnGetAsync(linkedTokenSource.Token);
             }
             catch (OperationCanceledException)
             {

--- a/test/Kubernetes.Tests/testassets/basic-ingress/ingress.yaml
+++ b/test/Kubernetes.Tests/testassets/basic-ingress/ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: minimal-ingress
+  namespace: default
 spec:
   rules:
   - http:
@@ -18,6 +19,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: frontend
+  namespace: default
 spec:
   selector:
     app: frontend
@@ -31,6 +33,7 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: frontend
+  namespace: default
 subsets:
   - addresses:
     - ip: 10.244.2.38

--- a/test/Kubernetes.Tests/testassets/exact-match/ingress.yaml
+++ b/test/Kubernetes.Tests/testassets/exact-match/ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: minimal-ingress
+  namespace: default
 spec:
   rules:
   - http:
@@ -18,6 +19,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: frontend
+  namespace: default
 spec:
   selector:
     app: frontend
@@ -31,6 +33,7 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: frontend
+  namespace: default
 subsets:
   - addresses:
     - ip: 10.244.2.38

--- a/test/Kubernetes.Tests/testassets/exact-match/routes.json
+++ b/test/Kubernetes.Tests/testassets/exact-match/routes.json
@@ -1,6 +1,6 @@
 [
   {
-    "RouteId": "/foo",
+    "RouteId": "minimal-ingress:/foo",
     "Match": {
       "Methods": null,
       "Hosts": [],

--- a/test/Kubernetes.Tests/testassets/hostname-routing/clusters.json
+++ b/test/Kubernetes.Tests/testassets/hostname-routing/clusters.json
@@ -1,0 +1,18 @@
+[
+  {
+    "ClusterId": "frontend:80",
+    "LoadBalancingPolicy": null,
+    "SessionAffinity": null,
+    "HealthCheck": null,
+    "HttpClient": null,
+    "HttpRequest": null,
+    "Destinations": {
+      "http://10.244.2.38:80": {
+        "Address": "http://10.244.2.38:80",
+        "Health": null,
+        "Metadata": null
+      }
+    },
+    "Metadata": null
+  }
+]

--- a/test/Kubernetes.Tests/testassets/hostname-routing/ingress.yaml
+++ b/test/Kubernetes.Tests/testassets/hostname-routing/ingress.yaml
@@ -1,45 +1,44 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: minimal-ingress
-  namespace: default
-  annotations:
-    yarp.ingress.kubernetes.io/backend-protocol: https
+  name: hostname-routing
+  namespace: foo
 spec:
   rules:
-  - http:
+  - host: foo.bar.com
+    http:
       paths:
-      - path: /foo
+      - path: /
         pathType: Prefix
         backend:
           service:
             name: frontend
             port:
-              number: 443
+              number: 80
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: frontend
-  namespace: default
+  namespace: foo
 spec:
   selector:
     app: frontend
   ports:
-  - name: https
-    port: 443
-    targetPort: 443
+  - name: http
+    port: 80
+    targetPort: 80
   type: ClusterIP
 ---
 apiVersion: v1
 kind: Endpoints
 metadata:
   name: frontend
-  namespace: default
+  namespace: foo
 subsets:
   - addresses:
     - ip: 10.244.2.38
     ports:
-    - name: https
-      port: 443
+    - name: http
+      port: 80
       protocol: TCP

--- a/test/Kubernetes.Tests/testassets/hostname-routing/routes.json
+++ b/test/Kubernetes.Tests/testassets/hostname-routing/routes.json
@@ -1,10 +1,10 @@
 [
   {
-    "RouteId": "minimal-ingress:/foo",
+    "RouteId": "hostname-routing:/",
     "Match": {
       "Methods": null,
-      "Hosts": [],
-      "Path": "/foo/{**catch-all}",
+      "Hosts": [ "foo.bar.com" ],
+      "Path": "/{**catch-all}",
       "Headers": null,
       "QueryParameters": null
     },

--- a/test/Kubernetes.Tests/testassets/https/routes.json
+++ b/test/Kubernetes.Tests/testassets/https/routes.json
@@ -1,6 +1,6 @@
 [
   {
-    "RouteId": "/foo",
+    "RouteId": "minimal-ingress:/foo",
     "Match": {
       "Methods": null,
       "Hosts": [],

--- a/test/Kubernetes.Tests/testassets/mapped-port/ingress.yaml
+++ b/test/Kubernetes.Tests/testassets/mapped-port/ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: mapped-port
+  namespace: default
 spec:
   rules:
   - http:
@@ -18,6 +19,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: backend
+  namespace: default
 spec:
   selector:
     app: backend
@@ -30,6 +32,7 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: backend
+  namespace: default
 subsets:
   - addresses:
     - ip: 10.244.2.33

--- a/test/Kubernetes.Tests/testassets/mapped-port/routes.json
+++ b/test/Kubernetes.Tests/testassets/mapped-port/routes.json
@@ -1,6 +1,6 @@
 [
   {
-    "RouteId": "/foo",
+    "RouteId": "mapped-port:/foo",
     "Match": {
       "Methods": null,
       "Hosts": [],

--- a/test/Kubernetes.Tests/testassets/multiple-endpoints-ports/ingress.yaml
+++ b/test/Kubernetes.Tests/testassets/multiple-endpoints-ports/ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: minimal-ingress
+  namespace: default
 spec:
   rules:
   - http:
@@ -18,6 +19,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: frontend
+  namespace: default
 spec:
   selector:
     app: frontend
@@ -34,6 +36,7 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: frontend
+  namespace: default
 subsets:
   - addresses:
     - ip: 10.244.2.38

--- a/test/Kubernetes.Tests/testassets/multiple-endpoints-ports/routes.json
+++ b/test/Kubernetes.Tests/testassets/multiple-endpoints-ports/routes.json
@@ -1,6 +1,6 @@
 [
   {
-    "RouteId": "/foo",
+    "RouteId": "minimal-ingress:/foo",
     "Match": {
       "Methods": null,
       "Hosts": [],

--- a/test/Kubernetes.Tests/testassets/multiple-ingresses-one-svc/clusters.json
+++ b/test/Kubernetes.Tests/testassets/multiple-ingresses-one-svc/clusters.json
@@ -1,0 +1,23 @@
+[
+  {
+    "ClusterId": "repro-service:http",
+    "LoadBalancingPolicy": null,
+    "SessionAffinity": null,
+    "HealthCheck": null,
+    "HttpClient": null,
+    "HttpRequest": null,
+    "Destinations": {
+      "http://10.244.1.11:80": {
+        "Address": "http://10.244.1.11:80",
+        "Health": null,
+        "Metadata": null
+      },
+      "http://10.244.1.12:80": {
+        "Address": "http://10.244.1.12:80",
+        "Health": null,
+        "Metadata": null
+      }
+    },
+    "Metadata": null
+  }
+]

--- a/test/Kubernetes.Tests/testassets/multiple-ingresses-one-svc/ingress.yaml
+++ b/test/Kubernetes.Tests/testassets/multiple-ingresses-one-svc/ingress.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: repro-service
+  namespace: foo
+spec:
+  selector:
+    app: repro-1
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: repro-service
+  namespace: foo
+subsets:
+  - addresses:
+    - ip: 10.244.1.11
+    - ip: 10.244.1.12
+    ports:
+    - name: http
+      port: 80
+      protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: repro-1-ingress
+  namespace: foo
+spec:
+  rules:
+    - host: 'subdomain1.example.com'
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: repro-service
+                port: 
+                  name: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: repro-2-ingress
+  namespace: foo
+spec:
+  rules:
+    - host: 'subdomain2.example.com'
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: repro-service
+                port: 
+                  name: http

--- a/test/Kubernetes.Tests/testassets/multiple-ingresses-one-svc/routes.json
+++ b/test/Kubernetes.Tests/testassets/multiple-ingresses-one-svc/routes.json
@@ -1,0 +1,34 @@
+[
+  {
+    "RouteId": "repro-1-ingress:/",
+    "Match": {
+      "Methods": null,
+      "Hosts": [ "subdomain1.example.com" ],
+      "Path": "/{**catch-all}",
+      "Headers": null,
+      "QueryParameters": null
+    },
+    "Order": null,
+    "ClusterId": "repro-service:http",
+    "AuthorizationPolicy": null,
+    "CorsPolicy": null,
+    "Metadata": null,
+    "Transforms": null
+  },
+  {
+    "RouteId": "repro-2-ingress:/",
+    "Match": {
+      "Methods": null,
+      "Hosts": [ "subdomain2.example.com" ],
+      "Path": "/{**catch-all}",
+      "Headers": null,
+      "QueryParameters": null
+    },
+    "Order": null,
+    "ClusterId": "repro-service:http",
+    "AuthorizationPolicy": null,
+    "CorsPolicy": null,
+    "Metadata": null,
+    "Transforms": null
+  }
+]

--- a/test/Kubernetes.Tests/testassets/multiple-ingresses/clusters.json
+++ b/test/Kubernetes.Tests/testassets/multiple-ingresses/clusters.json
@@ -1,0 +1,44 @@
+[
+  {
+    "ClusterId": "repro-1-service:http",
+    "LoadBalancingPolicy": null,
+    "SessionAffinity": null,
+    "HealthCheck": null,
+    "HttpClient": null,
+    "HttpRequest": null,
+    "Destinations": {
+      "http://10.244.1.11:80": {
+        "Address": "http://10.244.1.11:80",
+        "Health": null,
+        "Metadata": null
+      },
+      "http://10.244.1.12:80": {
+        "Address": "http://10.244.1.12:80",
+        "Health": null,
+        "Metadata": null
+      }
+    },
+    "Metadata": null
+  },
+  {
+    "ClusterId": "repro-2-service:http",
+    "LoadBalancingPolicy": null,
+    "SessionAffinity": null,
+    "HealthCheck": null,
+    "HttpClient": null,
+    "HttpRequest": null,
+    "Destinations": {
+      "http://10.244.2.22:80": {
+        "Address": "http://10.244.2.22:80",
+        "Health": null,
+        "Metadata": null
+      },
+      "http://10.244.2.23:80": {
+        "Address": "http://10.244.2.23:80",
+        "Health": null,
+        "Metadata": null
+      }
+    },
+    "Metadata": null
+  }
+]

--- a/test/Kubernetes.Tests/testassets/multiple-ingresses/ingress.yaml
+++ b/test/Kubernetes.Tests/testassets/multiple-ingresses/ingress.yaml
@@ -1,0 +1,91 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: repro-1-ingress
+  namespace: foo
+spec:
+  rules:
+    - host: 'subdomain1.example.com'
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: repro-1-service
+                port: 
+                  name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: repro-1-service
+  namespace: foo
+spec:
+  selector:
+    app: repro-1
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: repro-1-service
+  namespace: foo
+subsets:
+  - addresses:
+    - ip: 10.244.1.11
+    - ip: 10.244.1.12
+    ports:
+    - name: http
+      port: 80
+      protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: repro-2-ingress
+  namespace: foo
+spec:
+  rules:
+    - host: 'subdomain2.example.com'
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: repro-2-service
+                port: 
+                  name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: repro-2-service
+  namespace: foo
+spec:
+  selector:
+    app: repro-2
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: repro-2-service
+  namespace: foo
+subsets:
+  - addresses:
+    - ip: 10.244.2.22
+    - ip: 10.244.2.23
+    ports:
+    - name: http
+      port: 80
+      protocol: TCP

--- a/test/Kubernetes.Tests/testassets/multiple-ingresses/routes.json
+++ b/test/Kubernetes.Tests/testassets/multiple-ingresses/routes.json
@@ -1,0 +1,34 @@
+[
+  {
+    "RouteId": "repro-1-ingress:/",
+    "Match": {
+      "Methods": null,
+      "Hosts": [ "subdomain1.example.com" ],
+      "Path": "/{**catch-all}",
+      "Headers": null,
+      "QueryParameters": null
+    },
+    "Order": null,
+    "ClusterId": "repro-1-service:http",
+    "AuthorizationPolicy": null,
+    "CorsPolicy": null,
+    "Metadata": null,
+    "Transforms": null
+  },
+  {
+    "RouteId": "repro-2-ingress:/",
+    "Match": {
+      "Methods": null,
+      "Hosts": [ "subdomain2.example.com" ],
+      "Path": "/{**catch-all}",
+      "Headers": null,
+      "QueryParameters": null
+    },
+    "Order": null,
+    "ClusterId": "repro-2-service:http",
+    "AuthorizationPolicy": null,
+    "CorsPolicy": null,
+    "Metadata": null,
+    "Transforms": null
+  }
+]


### PR DESCRIPTION
- Modified the IngressController to rebuild all configuration on any ingress updates
- Split the `YarpIngressContext` into two classes - one for per-ingress context, the other (`YarpConfigContext`) for the configuration in the process of being built.
- Updated the service cache to return the names of an related ingresses
- Added test for multiple ingresses
- The dispatchTarget has been removed from the reconciler since this was not used. This allows the Dispatcher to be cleaned up further.

Since the configuration is rebuilt every time, the segregation of the queue in IngressController (by namespaced name) is technically no longer required. I've left unchanged for now but this has the affect of the configuration being generated multiple times on startup. If the fundamental change captured by this PR is acceptable, I'd propose to remove the queue segregation, since this would reduce the number of rebuilds of configuration.
