### PR TITLE
Move to 1ES servicing pools in release/latest

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,11 +47,11 @@ stages:
       - job: Windows
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: NetCorePublic-Pool
-            queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
+            name: NetCore1ESPool-Svc-Public
+            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
-            name: NetCoreInternal-Pool
-            queue: BuildPool.Windows.10.Amd64.VS2019.Pre
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre
         variables:
 
 


### PR DESCRIPTION
We're required to move all servicing branches to the new 1ES servicing pools by September 30. This accomplishes that for release/latest.

Tracking issue: https://github.com/dotnet/core-eng/issues/14276