### PR TITLE
Clean up proxy url generation 

### DIFF
--- a/src/ReverseProxy/Forwarder/RequestUtilities.cs
+++ b/src/ReverseProxy/Forwarder/RequestUtilities.cs
@@ -134,18 +134,12 @@ namespace Yarp.ReverseProxy.Forwarder
 
             // Check if any escaping is required.
             var value = path.Value!;
-            var i = 0;
-            for (; i < value.Length; i++)
+            for (var i = 0; i < value.Length; i++)
             {
                 if (!IsValidPathChar(value[i]))
                 {
-                    break;
+                    return EncodePath(value, i);
                 }
-            }
-
-            if (i < value.Length)
-            {
-                return EncodePath(value, i);
             }
 
             return value;

--- a/src/ReverseProxy/Forwarder/RequestUtilities.cs
+++ b/src/ReverseProxy/Forwarder/RequestUtilities.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
+using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
@@ -118,9 +119,139 @@ namespace Yarp.ReverseProxy.Forwarder
                 prefixSpan = prefixSpan[0..^1];
             }
 
-            var targetAddress = string.Concat(prefixSpan, path.ToUriComponent(), query.ToUriComponent());
+            var targetAddress = string.Concat(prefixSpan, EncodePath(path), query.ToUriComponent());
 
             return new Uri(targetAddress, UriKind.Absolute);
+        }
+
+        // This isn't using PathString.ToUriComponent() because it doesn't round trip some escape sequences the way we want.
+        private static string EncodePath(PathString path)
+        {
+            if (!path.HasValue)
+            {
+                return string.Empty;
+            }
+
+            // Check if any escaping is required.
+            var value = path.Value!;
+            var i = 0;
+            for (; i < value.Length; i++)
+            {
+                if (!IsValidPathChar(value[i]))
+                {
+                    break;
+                }
+            }
+
+            if (i < value.Length)
+            {
+                return EncodePath(value, i);
+            }
+
+            return value;
+        }
+
+        private static string EncodePath(string value, int i)
+        {
+            StringBuilder? buffer = null;
+
+            var start = 0;
+            var count = i;
+            var requiresEscaping = false;
+
+            while (i < value.Length)
+            {
+                if (IsValidPathChar(value[i]))
+                {
+                    if (requiresEscaping)
+                    {
+                        // the current segment requires escape
+                        buffer ??= new StringBuilder(value.Length * 3);
+                        buffer.Append(Uri.EscapeDataString(value.Substring(start, count)));
+
+                        requiresEscaping = false;
+                        start = i;
+                        count = 0;
+                    }
+
+                    count++;
+                    i++;
+                }
+                else
+                {
+                    if (!requiresEscaping)
+                    {
+                        // the current segment doesn't require escape
+                        buffer ??= new StringBuilder(value.Length * 3);
+                        buffer.Append(value, start, count);
+
+                        requiresEscaping = true;
+                        start = i;
+                        count = 0;
+                    }
+
+                    count++;
+                    i++;
+                }
+            }
+
+            if (count == value.Length && !requiresEscaping)
+            {
+                return value;
+            }
+            else
+            {
+                if (count > 0)
+                {
+                    buffer ??= new StringBuilder(value.Length * 3);
+
+                    if (requiresEscaping)
+                    {
+                        buffer.Append(Uri.EscapeDataString(value.Substring(start, count)));
+                    }
+                    else
+                    {
+                        buffer.Append(value, start, count);
+                    }
+                }
+
+                return buffer?.ToString() ?? string.Empty;
+            }
+        }
+
+        // https://datatracker.ietf.org/doc/html/rfc3986/#appendix-A
+        // pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+        // pct-encoded   = "%" HEXDIG HEXDIG
+        // unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
+        // reserved      = gen-delims / sub-delims
+        // gen-delims    = ":" / "/" / "?" / "#" / "[" / "]" / "@"
+        // sub-delims    = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+
+        // uint[] bits uses 1 cache line (Array info + 16 bytes)
+        // bool[] would use 3 cache lines (Array info + 128 bytes)
+        // So we use 128 bits rather than 128 bytes/bools
+        private static readonly uint[] ValidPathChars = {
+            0b_0000_0000__0000_0000__0000_0000__0000_0000, // 0x00 - 0x1F
+            0b_0010_1111__1111_1111__1111_1111__1101_0010, // 0x20 - 0x3F
+            0b_1000_0111__1111_1111__1111_1111__1111_1111, // 0x40 - 0x5F
+            0b_0100_0111__1111_1111__1111_1111__1111_1110, // 0x60 - 0x7F
+        };
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsValidPathChar(char c)
+        {
+            // Use local array and uint .Length compare to elide the bounds check on array access
+            var validChars = ValidPathChars;
+            var i = (int)c;
+
+            // Array is in chunks of 32 bits, so get offset by dividing by 32
+            var offset = i >> 5;		// i / 32;
+            // Significant bit position is the remainder of the above calc; i % 32 => i & 31
+            var significantBit = 1u << (i & 31);
+
+            // Check offset in bounds and check if significant bit set
+            return (uint)offset < (uint)validChars.Length &&
+                ((validChars[offset] & significantBit) != 0);
         }
 
         // Note: HttpClient.SendAsync will end up sending the union of

--- a/test/ReverseProxy.Tests/Forwarder/RequestUtilitiesTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/RequestUtilitiesTests.cs
@@ -93,10 +93,65 @@ namespace Yarp.ReverseProxy.Forwarder.Tests
         [InlineData("http://localhost/base", "/path", "?query", "http://localhost/base/path?query")]
         [InlineData("http://localhost/base/", "/path", "?query", "http://localhost/base/path?query")]
         [InlineData("http://localhost/base/", "/path/", "?query", "http://localhost/base/path/?query")]
+        [InlineData("http://localhost/base/", "/path/你好", "?query%E4%BD%A0%E5%A5%BD", "http://localhost/base/path/%E4%BD%A0%E5%A5%BD?query%E4%BD%A0%E5%A5%BD")]
+        // pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+        // unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
+        // sub-delims    = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+        [InlineData("http://localhost/base/", "/path/!$&'()*+,;=:@/%?#[]", "?query", "http://localhost/base/path/!$&'()*+,;=:@/%25%3F%23%5B%5D?query")]
+        // #if NET6.0 [InlineData("http://localhost/base/", "/path/", "?query%4A", "http://localhost/base/path/?query%4A")] // https://github.com/dotnet/runtime/issues/58057
+        // PathString should be fully un-escaped to start with and QueryString should be fully escaped.
+        [InlineData("http://localhost/base/", "/path/%2F%20", "?query%20", "http://localhost/base/path/%252F%2520?query%20")]
         public void MakeDestinationAddress(string destinationPrefix, string path, string query, string expected)
         {
             var uri = RequestUtilities.MakeDestinationAddress(destinationPrefix, new PathString(path), new QueryString(query));
             Assert.Equal(expected, uri.AbsoluteUri);
+        }
+
+        // https://datatracker.ietf.org/doc/html/rfc3986/#appendix-A
+        // pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+        // pct-encoded   = "%" HEXDIG HEXDIG
+        // unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
+        // reserved      = gen-delims / sub-delims
+        // gen-delims    = ":" / "/" / "?" / "#" / "[" / "]" / "@"
+        // sub-delims    = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+
+        [Fact]
+        public void ValidPathCharacters()
+        {
+            var valids = new char[]
+            {
+                 '!', '$', '&', '\'', '(', ')', '*', '+', ',', '-', '.', '/',
+                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                ':', ';', '=', '@',
+                'A', 'B', 'C', 'D', 'E', 'F','G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+                '_',
+                'a', 'b', 'c', 'd', 'e', 'f','g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+                '~'
+            };
+            foreach (var c in valids)
+            {
+                var isValid = RequestUtilities.IsValidPathChar(c);
+
+                Assert.True(isValid, c.ToString());
+            }
+        }
+
+        [Fact]
+        public void InvalidPathCharacters()
+        {
+            var invalids = new char[]
+            {
+                // Controls
+                (char)0x00, (char)0x01, (char)0x02, (char)0x03, (char)0x04, (char)0x05, (char)0x06, (char)0x00, (char)0x07, (char)0x08, (char)0x09, (char)0x0A, (char)0x0B, (char)0x0C, (char)0x0D, (char)0x0E, (char)0x0F,
+                (char)0x10, (char)0x11, (char)0x02, (char)0x13, (char)0x14, (char)0x15, (char)0x16, (char)0x10, (char)0x17, (char)0x18, (char)0x19, (char)0x1A, (char)0x1B, (char)0x1C, (char)0x1D, (char)0x1E, (char)0x1F,
+                ' ', '"', '#', '%', '<', '>', '?', '[', '\\', ']', '^', '`', '{', '|', '}'
+            };
+            foreach (var c in invalids)
+            {
+                var isValid = RequestUtilities.IsValidPathChar(c);
+
+                Assert.False(isValid, c.ToString());
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #1219

The default PathString.ToUriComponent() doesn't round trip all the encoded values we want so we now encode it ourselves.