### PR TITLE
Add the net6.0 TFM

### DIFF
--- a/src/Kubernetes.Controller/Yarp.Kubernetes.Controller.csproj
+++ b/src/Kubernetes.Controller/Yarp.Kubernetes.Controller.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
       <UserSecretsId>8436591a-094d-47de-973a-d41a5d91b895</UserSecretsId>
       <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
       <IsPackable>$('System.TeamProject') != 'internal'</IsPackable>

--- a/src/Kubernetes.Protocol/Yarp.Kubernetes.Protocol.csproj
+++ b/src/Kubernetes.Protocol/Yarp.Kubernetes.Protocol.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <IsPackable>$('System.TeamProject') != 'internal'</IsPackable>
   </PropertyGroup>
 

--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -514,7 +514,7 @@ namespace Yarp.ReverseProxy.Forwarder
                 // Don't explicitly set the field if the default reason phrase is used
                 if (source.ReasonPhrase != ReasonPhrases.GetReasonPhrase((int)source.StatusCode))
                 {
-                    context.Features.Get<IHttpResponseFeature>().ReasonPhrase = source.ReasonPhrase;
+                    context.Features.Get<IHttpResponseFeature>()!.ReasonPhrase = source.ReasonPhrase;
                 }
             }
 
@@ -562,6 +562,14 @@ namespace Yarp.ReverseProxy.Forwarder
 
             // :: Step 7-A-1: Upgrade the client channel. This will also send response headers.
             var upgradeFeature = context.Features.Get<IHttpUpgradeFeature>();
+            if (upgradeFeature == null)
+            {
+                var ex = new InvalidOperationException("Invalid 101 response when upgrades aren't supported.");
+                destinationResponse.Dispose();
+                ReportProxyError(context, ForwarderError.UpgradeResponseDestination, ex);
+                return ForwarderError.UpgradeResponseDestination;
+            }
+
             Stream upgradeResult;
             try
             {

--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -558,17 +558,18 @@ namespace Yarp.ReverseProxy.Forwarder
                 throw new InvalidOperationException("A response content is required for upgrades.");
             }
 
-            RestoreUpgradeHeaders(context, destinationResponse);
-
             // :: Step 7-A-1: Upgrade the client channel. This will also send response headers.
             var upgradeFeature = context.Features.Get<IHttpUpgradeFeature>();
             if (upgradeFeature == null)
             {
                 var ex = new InvalidOperationException("Invalid 101 response when upgrades aren't supported.");
                 destinationResponse.Dispose();
+                context.Response.StatusCode = StatusCodes.Status502BadGateway;
                 ReportProxyError(context, ForwarderError.UpgradeResponseDestination, ex);
                 return ForwarderError.UpgradeResponseDestination;
             }
+
+            RestoreUpgradeHeaders(context, destinationResponse);
 
             Stream upgradeResult;
             try

--- a/src/ReverseProxy/Forwarder/ProtocolHelper.cs
+++ b/src/ReverseProxy/Forwarder/ProtocolHelper.cs
@@ -49,7 +49,7 @@ namespace Yarp.ReverseProxy.Forwarder
         /// Takes inspiration from
         /// <see href="https://github.com/grpc/grpc-dotnet/blob/3ce9b104524a4929f5014c13cd99ba9a1c2431d4/src/Shared/CommonGrpcProtocolHelpers.cs#L26"/>.
         /// </summary>
-        public static bool IsGrpcContentType(string contentType)
+        public static bool IsGrpcContentType(string? contentType)
         {
             if (contentType == null)
             {

--- a/src/ReverseProxy/Transforms/ResponseTrailerRemoveTransform.cs
+++ b/src/ReverseProxy/Transforms/ResponseTrailerRemoveTransform.cs
@@ -42,7 +42,7 @@ namespace Yarp.ReverseProxy.Transforms
             if (Always || Success(context))
             {
                 var responseTrailersFeature = context.HttpContext.Features.Get<IHttpResponseTrailersFeature>();
-                var responseTrailers = responseTrailersFeature.Trailers;
+                var responseTrailers = responseTrailersFeature?.Trailers;
                 // Support should have already been checked by the caller.
                 Debug.Assert(responseTrailers != null);
                 Debug.Assert(!responseTrailers.IsReadOnly);

--- a/src/ReverseProxy/Transforms/ResponseTrailersTransform.cs
+++ b/src/ReverseProxy/Transforms/ResponseTrailersTransform.cs
@@ -45,7 +45,7 @@ namespace Yarp.ReverseProxy.Transforms
             Debug.Assert(context.ProxyResponse != null);
 
             var responseTrailersFeature = context.HttpContext.Features.Get<IHttpResponseTrailersFeature>();
-            var responseTrailers = responseTrailersFeature.Trailers;
+            var responseTrailers = responseTrailersFeature?.Trailers;
             // Support should have already been checked by the caller.
             Debug.Assert(responseTrailers != null);
             Debug.Assert(!responseTrailers.IsReadOnly);
@@ -70,7 +70,7 @@ namespace Yarp.ReverseProxy.Transforms
         public static void SetHeader(ResponseTrailersTransformContext context, string headerName, StringValues values)
         {
             var responseTrailersFeature = context.HttpContext.Features.Get<IHttpResponseTrailersFeature>();
-            var responseTrailers = responseTrailersFeature.Trailers;
+            var responseTrailers = responseTrailersFeature?.Trailers;
             // Support should have already been checked by the caller.
             Debug.Assert(responseTrailers != null);
             Debug.Assert(!responseTrailers.IsReadOnly);

--- a/src/ReverseProxy/Yarp.ReverseProxy.csproj
+++ b/src/ReverseProxy/Yarp.ReverseProxy.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Reverse proxy toolkit for building fast proxy servers in .NET using the infrastructure from ASP.NET and .NET</Description>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Yarp.ReverseProxy</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/ServiceFabric/Yarp.ReverseProxy.ServiceFabric.csproj
+++ b/src/ServiceFabric/Yarp.ReverseProxy.ServiceFabric.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Service Fabric integration for Yarp.ReverseProxy</Description>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Yarp.ReverseProxy.ServiceFabric</RootNamespace>
     <PlatformTarget>x64</PlatformTarget>

--- a/src/TelemetryConsumption/Yarp.Telemetry.Consumption.csproj
+++ b/src/TelemetryConsumption/Yarp.Telemetry.Consumption.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Yarp.ReverseProxy extension package for in-process telemetry consumption</Description>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Yarp.Telemetry.Consumption</RootNamespace>
     <LangVersion>9.0</LangVersion>


### PR DESCRIPTION
Contributes to #1055

Since .NET 6.0 is nearly released we're adding the TFM to our packages to indicate that it's supported. We were already running tests for this TFM.

Targeting 6.0 added a few new nullability warnings that I've addressed here. One is an interesting corner case where the destination could return a 101 response even if the request did not support upgrades.