### PR TITLE
Skip optional middlewares in benchmarks

### DIFF
--- a/testassets/BenchmarkApp/Startup.cs
+++ b/testassets/BenchmarkApp/Startup.cs
@@ -54,7 +54,10 @@ namespace BenchmarkApp
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
-                endpoints.MapReverseProxy();
+                endpoints.MapReverseProxy(builder =>
+                {
+                    // Skip SessionAffinity, LoadBalancing and PassiveHealthChecks
+                });
             });
         }
     }


### PR DESCRIPTION
Avoid the overhead of indirection / extra state machines in the benchmark app.

Note that the benchmark was not measuring the impact of full session affinity / passive health checks work since they were never enabled in the config.

Results in a 1-2% increase in RPS.