### PR TITLE
Disable packing/shipping the ServiceFabric package

### DIFF
--- a/src/ServiceFabric/Yarp.ReverseProxy.ServiceFabric.csproj
+++ b/src/ServiceFabric/Yarp.ReverseProxy.ServiceFabric.csproj
@@ -6,6 +6,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Yarp.ReverseProxy.ServiceFabric</RootNamespace>
     <PlatformTarget>x64</PlatformTarget>
+    <IsPackable>$('System.TeamProject') != 'internal'</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The SF work is continuing out of band and will not ship as part of YARP 1.0.