### PR TITLE
Fix PathPattern encoding 

### DIFF
--- a/docs/docfx/articles/transforms.md
+++ b/docs/docfx/articles/transforms.md
@@ -79,10 +79,10 @@ Here is an example of common transforms:
       "route2" : {
         "ClusterId": "cluster1",
         "Match": {
-          "Path": "/api/{plugin}/stuff/{*remainder}"
+          "Path": "/api/{plugin}/stuff/{**remainder}"
         },
         "Transforms": [
-          { "PathPattern": "/foo/{plugin}/bar/{remainder}" },
+          { "PathPattern": "/foo/{plugin}/bar/{**remainder}" },
           {
             "QueryStringParameter": "q",
             "Append": "plugin"
@@ -235,27 +235,27 @@ This will set the request path with the given value.
 
 Config:
 ```JSON
-{ "PathPattern": "/my/{plugin}/api/{remainder}" }
+{ "PathPattern": "/my/{plugin}/api/{**remainder}" }
 ```
 Code:
 ```csharp
-routeConfig = routeConfig.WithTransformPathRouteValues(pattern: new PathString("/my/{plugin}/api/{remainder}"));
+routeConfig = routeConfig.WithTransformPathRouteValues(pattern: new PathString("/my/{plugin}/api/{**remainder}"));
 ```
 ```C#
-transformBuilderContext.AddPathRouteValues(pattern: new PathString("/my/{plugin}/api/{remainder}"));
+transformBuilderContext.AddPathRouteValues(pattern: new PathString("/my/{plugin}/api/{**remainder}"));
 ```
 
-This will set the request path with the given value and replace any `{}` segments with the associated route value. `{}` segments without a matching route value are removed. See ASP.NET Core's [routing docs](https://docs.microsoft.com/aspnet/core/fundamentals/routing#route-template-reference) for more information about route templates.
+This will set the request path with the given value and replace any `{}` segments with the associated route value. `{}` segments without a matching route value are removed. The final `{}` segment can be marked as `{**remainder}` to indicate this is a catch-all segment that may contain multiple path segments. See ASP.NET Core's [routing docs](https://docs.microsoft.com/aspnet/core/fundamentals/routing#route-template-reference) for more information about route templates.
 
 Example:
 
 | Step | Value |
 |------|-------|
-| Route definition | `/api/{plugin}/stuff/{*remainder}` |
+| Route definition | `/api/{plugin}/stuff/{**remainder}` |
 | Request path | `/api/v1/stuff/more/stuff` |
 | Plugin value | `v1` |
 | Remainder value | `more/stuff` |
-| PathPattern | `/my/{plugin}/api/{remainder}` |
+| PathPattern | `/my/{plugin}/api/{**remainder}` |
 | Result | `/my/v1/api/more/stuff` |
 
 ### QueryValueParameter

--- a/test/ReverseProxy.Tests/Transforms/PathRouteValuesTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/PathRouteValuesTransformTests.cs
@@ -17,7 +17,7 @@ namespace Yarp.ReverseProxy.Transforms.Tests
         [InlineData("/{a}/{b}/{c}", "/6/7/8")]
         [InlineData("/{a}/foo/{b}/{c}/{d}", "/6/foo/7/8")] // Unknown value (d) dropped
         [InlineData("/{a}/foo/{b}", "/6/foo/7")] // Extra values (c) dropped
-        public async Task Set_PathPattern_ReplacesPathWithRouteValues(string transformValue, string expected)
+        public async Task ReplacesPatternWithRouteValues(string transformValue, string expected)
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddOptions();
@@ -41,6 +41,36 @@ namespace Yarp.ReverseProxy.Transforms.Tests
             var transform = new PathRouteValuesTransform(transformValue, services.GetRequiredService<TemplateBinderFactory>());
             await transform.ApplyAsync(context);
             Assert.Equal(expected, context.Path);
+
+            // The transform should not modify the original request's route values
+            Assert.Equal(routeValues, httpContext.Request.RouteValues);
+        }
+
+        [Fact]
+        public async Task RouteValuesWithSlashesNotEncoded()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddOptions();
+            serviceCollection.AddRouting();
+            using var services = serviceCollection.BuildServiceProvider();
+
+            var routeValues = new Dictionary<string, object>
+            {
+                { "a", "abc" },
+                { "b", "def" },
+                { "remainder", "klm/nop/qrs" },
+            };
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.RouteValues = new RouteValueDictionary(routeValues);
+            var context = new RequestTransformContext()
+            {
+                Path = "/",
+                HttpContext = httpContext
+            };
+            var transform = new PathRouteValuesTransform("/{a}/{b}/{**remainder}", services.GetRequiredService<TemplateBinderFactory>());
+            await transform.ApplyAsync(context);
+            Assert.Equal("/abc/def/klm/nop/qrs", context.Path.Value);
 
             // The transform should not modify the original request's route values
             Assert.Equal(routeValues, httpContext.Request.RouteValues);

--- a/test/ReverseProxy.Tests/Transforms/PathTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/PathTransformExtensionsTests.cs
@@ -137,7 +137,7 @@ namespace Yarp.ReverseProxy.Transforms.Tests
         {
             var requestTransform = Assert.Single(builderContext.RequestTransforms);
             var pathRouteValuesTransform = Assert.IsType<PathRouteValuesTransform>(requestTransform);
-            Assert.Equal("/path#", pathRouteValuesTransform.Template.TemplateText);
+            Assert.Equal("/path#", pathRouteValuesTransform.Pattern.RawText);
         }
     }
 }

--- a/testassets/ReverseProxy.Config/appsettings.json
+++ b/testassets/ReverseProxy.Config/appsettings.json
@@ -78,10 +78,10 @@
         "ClusterId": "cluster2",
         "Match": {
           "Hosts": [ "localhost" ],
-          "Path": "/api/{plugin}/stuff/{*remainder}"
+          "Path": "/api/{plugin}/stuff/{**remainder}"
         },
         "Transforms": [
-          { "PathPattern": "/foo/{plugin}/bar/{remainder}" },
+          { "PathPattern": "/foo/{plugin}/bar/{**remainder}" },
           {
             "X-Forwarded": "Append",
             "HeaderPrefix": "X-Forwarded-"
@@ -92,10 +92,6 @@
             "ForFormat": "IpAndPort"
           },
           { "ClientCert": "X-Client-Cert" },
-
-          { "PathSet": "/apis" },
-          { "PathPrefix": "/apis" },
-          { "PathRemovePrefix": "/apis" },
 
           { "RequestHeadersCopy": "true" },
           { "RequestHeaderOriginalHost": "true" },


### PR DESCRIPTION
Fixes #1307

Sample route from the issue:
```
      "CommonRestRoute": {
        "ClusterId": "cluster1",
        "Match": {
          "Path": "/service1/rest/{**remainder}"
        },
        "Transforms": [
          { "PathPattern": "/{remainder}" },
        ]
      },
```

PathPattern is supposed to take route parameters matched from the path and inject them into the given pattern. `**` in the path pattern indicates a catch-all that will capture the remainder of the path.

Problem: When the catch-all captured multiple path segments the resulting path would have the `/`'s escaped as %2F. You should have been able to specify the PathPattern as `{ "PathPattern": "/{**remainder}" },` to avoid this, but it doesn't work with the  RouteTemplate type we're using.

Solution: Use RoutePattern instead of RouteTemplate. This comes with a few usage differences.
- If you try to bind a value not present in the template it will be added as a query parameter. I had to filter these out.
- We had been passing the RouteParameters in to the `defaults` parameter to avoid the prior issue, but with RoutePattern it would cause default segments to be dropped. We no longer pass in the defaults collection.