### PR TITLE
Build doc comments and include them in the packages 

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,5 +6,6 @@
   <PropertyGroup>
     <IsShipping>true</IsShipping>
     <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 </Project>

--- a/src/ReverseProxy/Configuration/IProxyConfigFilter.cs
+++ b/src/ReverseProxy/Configuration/IProxyConfigFilter.cs
@@ -15,6 +15,7 @@ namespace Yarp.ReverseProxy.Configuration
         /// Allows modification of a cluster configuration.
         /// </summary>
         /// <param name="cluster">The <see cref="ClusterConfig"/> instance to configure.</param>
+        /// <param name="cancel"></param>
         ValueTask<ClusterConfig> ConfigureClusterAsync(ClusterConfig cluster, CancellationToken cancel);
 
         /// <summary>
@@ -22,6 +23,7 @@ namespace Yarp.ReverseProxy.Configuration
         /// </summary>
         /// <param name="route">The <see cref="RouteConfig"/> instance to configure.</param>
         /// <param name="cluster">The <see cref="ClusterConfig"/> instance related to <see cref="RouteConfig"/>.</param>
+        /// <param name="cancel"></param>
         ValueTask<RouteConfig> ConfigureRouteAsync(RouteConfig route, ClusterConfig? cluster, CancellationToken cancel);
     }
 }

--- a/src/ReverseProxy/Forwarder/IHttpForwarderExtensions.cs
+++ b/src/ReverseProxy/Forwarder/IHttpForwarderExtensions.cs
@@ -16,6 +16,7 @@ namespace Yarp.ReverseProxy.Forwarder
         /// <summary>
         /// Forwards the incoming request to the destination server, and the response back to the client.
         /// </summary>
+        /// <param name="forwarder">The forwarder instance.</param>
         /// <param name="context">The HttpContext to forward.</param>
         /// <param name="destinationPrefix">The url prefix for where to forward the request to.</param>
         /// <param name="httpClient">The HTTP client used to forward the request.</param>
@@ -34,6 +35,7 @@ namespace Yarp.ReverseProxy.Forwarder
         /// <summary>
         /// Forwards the incoming request to the destination server, and the response back to the client.
         /// </summary>
+        /// <param name="forwarder">The forwarder instance.</param>
         /// <param name="context">The HttpContext to forward.</param>
         /// <param name="destinationPrefix">The url prefix for where to forward the request to.</param>
         /// <param name="httpClient">The HTTP client used to forward the request.</param>
@@ -53,6 +55,7 @@ namespace Yarp.ReverseProxy.Forwarder
         /// <summary>
         /// Forwards the incoming request to the destination server, and the response back to the client.
         /// </summary>
+        /// <param name="forwarder">The forwarder instance.</param>
         /// <param name="context">The HttpContext to forward.</param>
         /// <param name="destinationPrefix">The url prefix for where to forward the request to.</param>
         /// <param name="httpClient">The HTTP client used to forward the request.</param>
@@ -67,6 +70,7 @@ namespace Yarp.ReverseProxy.Forwarder
         /// <summary>
         /// Forwards the incoming request to the destination server, and the response back to the client.
         /// </summary>
+        /// <param name="forwarder">The forwarder instance.</param>
         /// <param name="context">The HttpContext to forward.</param>
         /// <param name="destinationPrefix">The url prefix for where to forward the request to.</param>
         /// <param name="httpClient">The HTTP client used to forward the request.</param>

--- a/src/ReverseProxy/Forwarder/StreamCopyHttpContent.cs
+++ b/src/ReverseProxy/Forwarder/StreamCopyHttpContent.cs
@@ -56,7 +56,7 @@ namespace Yarp.ReverseProxy.Forwarder
 
         /// <summary>
         /// Gets a <see cref="System.Threading.Tasks.Task"/> that completes in successful or failed state
-        /// mimicking the result of <see cref="SerializeToStreamAsync"/>.
+        /// mimicking the result of SerializeToStreamAsync.
         /// </summary>
         public Task<(StreamCopyResult, Exception?)> ConsumptionTask => _tcs.Task;
 

--- a/src/ReverseProxy/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Management/ProxyConfigManager.cs
@@ -25,14 +25,11 @@ using Yarp.ReverseProxy.Transforms.Builder;
 namespace Yarp.ReverseProxy.Management
 {
     /// <summary>
-    /// Provides a method to apply Proxy configuration changes
-    /// by leveraging <see cref="IDynamicConfigBuilder"/>.
+    /// Provides a method to apply Proxy configuration changes.
     /// Also an Implementation of <see cref="EndpointDataSource"/> that supports being dynamically updated
     /// in a thread-safe manner while avoiding locks on the hot path.
     /// </summary>
-    /// <remarks>
-    /// This takes inspiration from <a "https://github.com/dotnet/aspnetcore/blob/cbe16474ce9db7ff588aed89596ff4df5c3f62e1/src/Mvc/Mvc.Core/src/Routing/ActionEndpointDataSourceBase.cs"/>.
-    /// </remarks>
+    // https://github.com/dotnet/aspnetcore/blob/cbe16474ce9db7ff588aed89596ff4df5c3f62e1/src/Mvc/Mvc.Core/src/Routing/ActionEndpointDataSourceBase.cs
     internal sealed class ProxyConfigManager : EndpointDataSource, IDisposable
     {
         private static readonly IReadOnlyDictionary<string, ClusterConfig> _emptyClusterDictionary = new ReadOnlyDictionary<string, ClusterConfig>(new Dictionary<string, ClusterConfig>());

--- a/src/ReverseProxy/Transforms/RequestHeaderXForwardedForTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderXForwardedForTransform.cs
@@ -17,7 +17,7 @@ namespace Yarp.ReverseProxy.Transforms
         /// Creates a new transform.
         /// </summary>
         /// <param name="headerName">The header name.</param>
-        /// <param name="append">Action to applied to the header.</param>
+        /// <param name="action">Action to applied to the header.</param>
         public RequestHeaderXForwardedForTransform(string headerName, ForwardedTransformActions action)
         {
             if (string.IsNullOrEmpty(headerName))

--- a/src/ReverseProxy/Transforms/RequestHeaderXForwardedHostTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderXForwardedHostTransform.cs
@@ -17,7 +17,7 @@ namespace Yarp.ReverseProxy.Transforms
         /// Creates a new transform.
         /// </summary>
         /// <param name="headerName">The header name.</param>
-        /// <param name="append">Action to applied to the header.</param>
+        /// <param name="action">Action to applied to the header.</param>
         public RequestHeaderXForwardedHostTransform(string headerName, ForwardedTransformActions action)
         {
             if (string.IsNullOrEmpty(headerName))

--- a/src/ReverseProxy/Transforms/RequestHeaderXForwardedProtoTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderXForwardedProtoTransform.cs
@@ -17,7 +17,7 @@ namespace Yarp.ReverseProxy.Transforms
         /// Creates a new transform.
         /// </summary>
         /// <param name="headerName">The header name.</param>
-        /// <param name="append">Action to applied to the header.</param>
+        /// <param name="action">Action to applied to the header.</param>
         public RequestHeaderXForwardedProtoTransform(string headerName, ForwardedTransformActions action)
         {
             if (string.IsNullOrEmpty(headerName))

--- a/src/ReverseProxy/Transforms/RequestTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestTransform.cs
@@ -25,6 +25,7 @@ namespace Yarp.ReverseProxy.Transforms
         /// <see cref="RequestTransformContext.HeadersCopied"/> is not set.
         /// This ordering allows multiple transforms to mutate the same header.
         /// </summary>
+        /// <param name="context">The transform context.</param>
         /// <param name="headerName">The name of the header to take.</param>
         /// <returns>The requested header value, or StringValues.Empty if none.</returns>
         public static StringValues TakeHeader(RequestTransformContext context, string headerName)

--- a/src/ReverseProxy/Transforms/ResponseTrailersTransform.cs
+++ b/src/ReverseProxy/Transforms/ResponseTrailersTransform.cs
@@ -26,6 +26,7 @@ namespace Yarp.ReverseProxy.Transforms
         /// <see cref="ResponseTrailersTransformContext.HeadersCopied"/> is not set.
         /// This ordering allows multiple transforms to mutate the same header.
         /// </summary>
+        /// <param name="context">The transform context.</param>
         /// <param name="headerName">The name of the header to take.</param>
         /// <returns>The response header value, or StringValues.Empty if none.</returns>
         public static StringValues TakeHeader(ResponseTrailersTransformContext context, string headerName)

--- a/src/ReverseProxy/Transforms/ResponseTransform.cs
+++ b/src/ReverseProxy/Transforms/ResponseTransform.cs
@@ -24,6 +24,7 @@ namespace Yarp.ReverseProxy.Transforms
         /// <see cref="ResponseTransformContext.HeadersCopied"/> is not set.
         /// This ordering allows multiple transforms to mutate the same header.
         /// </summary>
+        /// <param name="context">The transform context.</param>
         /// <param name="headerName">The name of the header to take.</param>
         /// <returns>The response header value, or StringValues.Empty if none.</returns>
         public static StringValues TakeHeader(ResponseTransformContext context, string headerName)

--- a/src/ServiceFabric/ServiceDiscovery/Discoverer.cs
+++ b/src/ServiceFabric/ServiceDiscovery/Discoverer.cs
@@ -243,7 +243,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
 
         /// <summary>
         /// Finds all eligible destinations (replica endpoints) for the <paramref name="service"/> specified,
-        /// and populates the specified <paramref name="cluster"/>'s <see cref="ClusterConfig.Destinations"/> accordingly.
+        /// and returns the <see cref="ClusterConfig.Destinations"/> accordingly.
         /// </summary>
         /// <remarks>All non-fatal exceptions are caught and logged.</remarks>
         private async Task<IReadOnlyDictionary<string, DestinationConfig>> DiscoverDestinationsAsync(

--- a/src/ServiceFabric/ServiceDiscovery/Util/LabelsParser.cs
+++ b/src/ServiceFabric/ServiceDiscovery/Util/LabelsParser.cs
@@ -29,7 +29,7 @@ namespace Yarp.ReverseProxy.ServiceFabric
         /// </summary>
         private static readonly Regex _allowedHeaderNamesRegex = new Regex(@"^\[\d\d*\]$", RegexOptions.Compiled);
 
-
+        /// <summary>
         /// Requires all transform names to follow the .[0]. pattern to simulate indexing in an array
         /// </summary>
         private static readonly Regex _allowedTransformNamesRegex = new Regex(@"^\[\d\d*\]$", RegexOptions.Compiled);

--- a/src/TelemetryConsumption/IMetricsConsumer.cs
+++ b/src/TelemetryConsumption/IMetricsConsumer.cs
@@ -4,7 +4,7 @@
 namespace Yarp.Telemetry.Consumption
 {
     /// <summary>
-    /// A consumer of <see cref="TMetrics"/>.
+    /// A consumer of <typeparamref name="TMetrics"/>.
     /// </summary>
     public interface IMetricsConsumer<TMetrics>
     {


### PR DESCRIPTION
Fixes #1319

The doc comments weren't included in the nuget packages, so nobody would get intellisense.

Once building the docs was enabled I had to fix a few warnings.