### PR TITLE
Servicing docs

### DIFF
--- a/docs/operations/BackportingToPreview.md
+++ b/docs/operations/BackportingToPreview.md
@@ -18,3 +18,17 @@ Backporting changes is very similar to a regular release. Changes are made on th
   - `git tag v1.0.0-previewX.build.d`
   - `git push upstream --tags`
 - Create a new [release](https://github.com/microsoft/reverse-proxy/releases).
+
+# Internal fixes
+
+Issues with significant security or disclosure concerns need to be fixed privately first. All of this work will happen on the internal Azdo repo and be merged to the public github repo at the time of disclosure.
+
+- Make a separate clone of https://dnceng@dev.azure.com/dnceng/internal/_git/microsoft-reverse-proxy to avoid accidentally pushing to the public repo.
+- Create a branch named `internal/release/{version being patched}` starting from the tagged commit of the prior release.
+- Update versioning as needed.
+- Create a feature branch, fix the issue, and send a PR using Azdo.
+- Once approved and merged, the `internal/release/{version}` branch should build automatically and publish to the `.NET 6 Internal` channel, visible at https://dev.azure.com/dnceng/internal/_packaging?_a=feed&feed=dotnet6-internal. This is configured using the `darc` tool.
+- [Release the build](https://github.com/microsoft/reverse-proxy/blob/main/docs/operations/Release.md#release-the-build)
+- Tag the commit and push it to the public repo
+- Cherry pick the changes to public main as needed.
+- Finish the standard release checklist.


### PR DESCRIPTION
I did a test internal patch build in preparation for potential security patches. The infrastructure should be set up correctly now. Here are steps to follow for an internal patch.