### PR TITLE
Remove PreReleaseVersionLabel

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,6 +7,8 @@
       That ensures that if we get up to preview 10, it doesn't sort as between preview 1 and preview 2!
       See https://semver.org/spec/v2.0.0.html for details.
     -->
-    <PreReleaseVersionLabel>rc.2</PreReleaseVersionLabel>
+    <!--
+    <PreReleaseVersionLabel>preview.1</PreReleaseVersionLabel>
+    -->
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes #1317
Contributes to #1353

Should we be switching `main` to `1.1.0.preview.1` or drop the preview altogether `1.1.0`?