### PR TITLE
Update samples

### DIFF
--- a/docs/docfx/articles/getting-started.md
+++ b/docs/docfx/articles/getting-started.md
@@ -111,7 +111,7 @@ Or create a new ASP.NET Core web application in Visual Studio 2022, and choose "
 
  ```XML
 <ItemGroup> 
-  <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.12.*" />
+  <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0" />
 </ItemGroup> 
 ```
 
@@ -158,7 +158,7 @@ You can find out more about the available configuration options by looking at [R
     "Clusters": {
       "cluster1": {
         "Destinations": {
-          "cluster1/destination1": {
+          "destination1": {
             "Address": "https://example.com/"
           }
         }

--- a/samples/BasicYarpSample/Startup.cs
+++ b/samples/BasicYarpSample/Startup.cs
@@ -21,7 +21,7 @@ namespace BasicYARPSample
         // the web application via services in the DI container.
         public void ConfigureServices(IServiceCollection services)
         {
-            // Add the reverse proxy to capability to the server
+            // Add the reverse proxy capability to the server
             var proxyBuilder = services.AddReverseProxy();
             // Initialize the reverse proxy from the "ReverseProxy" section of configuration
             proxyBuilder.LoadFromConfig(Configuration.GetSection("ReverseProxy"));

--- a/samples/Prometheus/ReverseProxy.Metrics-Promethius.Sample/Properties/launchSettings.json
+++ b/samples/Prometheus/ReverseProxy.Metrics-Promethius.Sample/Properties/launchSettings.json
@@ -8,7 +8,7 @@
     }
   },
   "profiles": {
-    "ReverseProxy.Sample": {
+    "ReverseProxy.Metrics.Promethius.Sample": {
       "commandName": "Project",
       "launchBrowser": false,
       "environmentVariables": {

--- a/samples/ReverseProxy.Auth.Sample/Properties/launchSettings.json
+++ b/samples/ReverseProxy.Auth.Sample/Properties/launchSettings.json
@@ -8,7 +8,7 @@
     }
   },
   "profiles": {
-    "ReverseProxy.Sample": {
+    "ReverseProxy.Auth.Sample": {
       "commandName": "Project",
       "launchBrowser": false,
       "environmentVariables": {

--- a/samples/ReverseProxy.Auth.Sample/ReverseProxy.Auth.Sample.csproj
+++ b/samples/ReverseProxy.Auth.Sample/ReverseProxy.Auth.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.Sample</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/samples/ReverseProxy.Auth.Sample/ReverseProxy.Auth.Sample.csproj
+++ b/samples/ReverseProxy.Auth.Sample/ReverseProxy.Auth.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.Sample</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/samples/ReverseProxy.Code.Sample/Properties/launchSettings.json
+++ b/samples/ReverseProxy.Code.Sample/Properties/launchSettings.json
@@ -8,7 +8,7 @@
     }
   },
   "profiles": {
-    "ReverseProxy.Sample": {
+    "ReverseProxy.Code.Sample": {
       "commandName": "Project",
       "launchBrowser": false,
       "environmentVariables": {

--- a/samples/ReverseProxy.Config.Sample/Properties/launchSettings.json
+++ b/samples/ReverseProxy.Config.Sample/Properties/launchSettings.json
@@ -8,7 +8,7 @@
     }
   },
   "profiles": {
-    "ReverseProxy.Sample": {
+    "ReverseProxy.Config.Sample": {
       "commandName": "Project",
       "launchBrowser": false,
       "environmentVariables": {

--- a/samples/ReverseProxy.Config.Sample/appsettings.json
+++ b/samples/ReverseProxy.Config.Sample/appsettings.json
@@ -27,7 +27,7 @@
         }
       },
       "allRouteProps": {
-        // matches /something/* and routes to "allclusterprops"
+        // matches /download/* and routes to "allClusterProps"
         "ClusterId": "allClusterProps", // Name of one of the clusters
         "Order": 0, // Lower numbers have higher precidence, default is 0
         "Authorization Policy": "Anonymous", // Name of the policy or "Default", "Anonymous"
@@ -107,7 +107,7 @@
         },
         "HttpClient": { // Configuration of HttpClient instance used to contact destinations
           "SSLProtocols": "Tls13",
-          "DangerousAcceptAnyServerCertificate": false, // Disables destination cert validation
+          "DangerousAcceptAnyServerCertificate": true, // Disables destination cert validation
           /* --Disabled in this sample as it requires certs to be present--
           "ClientCertificate": { // Specifies a client certificate to be used
             // From a file, use...

--- a/samples/ReverseProxy.ConfigFilter.Sample/Properties/launchSettings.json
+++ b/samples/ReverseProxy.ConfigFilter.Sample/Properties/launchSettings.json
@@ -8,7 +8,7 @@
     }
   },
   "profiles": {
-    "ReverseProxy.Sample": {
+    "ReverseProxy.ConfigFilter.Sample": {
       "commandName": "Project",
       "environmentVariables": {
         "Key": "Value",

--- a/samples/ReverseProxy.Direct.Sample/Properties/launchSettings.json
+++ b/samples/ReverseProxy.Direct.Sample/Properties/launchSettings.json
@@ -8,7 +8,7 @@
     }
   },
   "profiles": {
-    "ReverseProxy.Sample": {
+    "ReverseProxy.Direct.Sample": {
       "commandName": "Project",
       "launchBrowser": false,
       "environmentVariables": {

--- a/samples/ReverseProxy.Direct.Sample/Startup.cs
+++ b/samples/ReverseProxy.Direct.Sample/Startup.cs
@@ -81,8 +81,8 @@ namespace Yarp.Sample
                 endpoints.Map("/{**catch-all}", async httpContext =>
                 {
                     var error = await forwarder.SendAsync(httpContext, "https://example.com", httpClient, requestOptions, transformer);
-                // Check if the proxy operation was successful
-                if (error != ForwarderError.None)
+                    // Check if the proxy operation was successful
+                    if (error != ForwarderError.None)
                     {
                         var errorFeature = httpContext.Features.Get<IForwarderErrorFeature>();
                         var exception = errorFeature.Exception;

--- a/samples/ReverseProxy.Direct.Sample/Startup.cs
+++ b/samples/ReverseProxy.Direct.Sample/Startup.cs
@@ -119,7 +119,7 @@ namespace Yarp.Sample
                 queryContext.Collection["area"] = "xx2";
 
                 // Assign the custom uri. Be careful about extra slashes when concatenating here. RequestUtilities.MakeDestinationAddress is a safe default.
-                proxyRequest.RequestUri = RequestUtilities.MakeDestinationAddress("https://example.com", context.Request.Path, queryContext.QueryString);
+                proxyRequest.RequestUri = RequestUtilities.MakeDestinationAddress("https://example.com", httpContext.Request.Path, queryContext.QueryString);
 
                 // Suppress the original request header, use the one from the destination Uri.
                 proxyRequest.Headers.Host = null;

--- a/samples/ReverseProxy.Direct.Sample/Startup.cs
+++ b/samples/ReverseProxy.Direct.Sample/Startup.cs
@@ -58,8 +58,8 @@ namespace Yarp.Sample
                             queryContext.Collection.Remove("param1");
                             queryContext.Collection["area"] = "xx2";
 
-                            // Assign the custom uri. Be careful about extra slashes when concatenating here.
-                            proxyRequest.RequestUri = new Uri("https://example.com" + context.Request.Path + queryContext.QueryString);
+                            // Assign the custom uri. Be careful about extra slashes when concatenating here. RequestUtilities.MakeDestinationAddress is a safe default.
+                            proxyRequest.RequestUri = RequestUtilities.MakeDestinationAddress("https://example.com", context.Request.Path, queryContext.QueryString);
 
                             // Suppress the original request header, use the one from the destination Uri.
                             proxyRequest.Headers.Host = null;
@@ -118,8 +118,8 @@ namespace Yarp.Sample
                 queryContext.Collection.Remove("param1");
                 queryContext.Collection["area"] = "xx2";
 
-                // Assign the custom uri. Be careful about extra slashes when concatenating here.
-                proxyRequest.RequestUri = new Uri(destinationPrefix + httpContext.Request.Path + queryContext.QueryString);
+                // Assign the custom uri. Be careful about extra slashes when concatenating here. RequestUtilities.MakeDestinationAddress is a safe default.
+                proxyRequest.RequestUri = RequestUtilities.MakeDestinationAddress("https://example.com", context.Request.Path, queryContext.QueryString);
 
                 // Suppress the original request header, use the one from the destination Uri.
                 proxyRequest.Headers.Host = null;

--- a/samples/ReverseProxy.Metrics.Sample/ForwarderTelemetryConsumer.cs
+++ b/samples/ReverseProxy.Metrics.Sample/ForwarderTelemetryConsumer.cs
@@ -24,7 +24,6 @@ namespace Yarp.Sample
         public void OnForwarderFailed(DateTime timestamp, ForwarderError error)
         {
             var metrics = PerRequestMetrics.Current;
-            metrics.ProxyStopOffset = metrics.CalcOffset(timestamp);
             metrics.Error = error;
         }
 

--- a/samples/ReverseProxy.Metrics.Sample/HttpClientTelemetryConsumer.cs
+++ b/samples/ReverseProxy.Metrics.Sample/HttpClientTelemetryConsumer.cs
@@ -18,11 +18,7 @@ namespace Yarp.Sample
         public void OnRequestStop(DateTime timestamp)
         {
             var metrics = PerRequestMetrics.Current;
-            metrics.HttpRequestContentStopOffset = metrics.CalcOffset(timestamp);
-        }
-
-        public void OnRequestFailed(DateTime timestamp)
-        {      
+            metrics.HttpRequestStopOffset = metrics.CalcOffset(timestamp);
         }
 
         public void OnConnectionEstablished(DateTime timestamp, int versionMajor, int versionMinor)

--- a/samples/ReverseProxy.Metrics.Sample/PerRequestMetrics.cs
+++ b/samples/ReverseProxy.Metrics.Sample/PerRequestMetrics.cs
@@ -38,6 +38,7 @@ namespace Yarp.Sample
         public float HttpResponseHeadersStopOffset { get; set; }
         public float HttpResponseContentStopOffset { get; set; }
 
+        public float HttpRequestStopOffset { get; set; }
         public float ProxyStopOffset { get; set; }
 
         //Info about the request

--- a/samples/ReverseProxy.Metrics.Sample/Properties/launchSettings.json
+++ b/samples/ReverseProxy.Metrics.Sample/Properties/launchSettings.json
@@ -8,7 +8,7 @@
     }
   },
   "profiles": {
-    "ReverseProxy.Sample": {
+    "ReverseProxy.Metrics.Sample": {
       "commandName": "Project",
       "launchBrowser": false,
       "environmentVariables": {

--- a/samples/ReverseProxy.ServiceFabric.Sample/Properties/launchSettings.json
+++ b/samples/ReverseProxy.ServiceFabric.Sample/Properties/launchSettings.json
@@ -8,7 +8,7 @@
     }
   },
   "profiles": {
-    "ReverseProxy.Sample": {
+    "ReverseProxy.ServiceFabric.Sample": {
       "commandName": "Project",
       "launchBrowser": false,
       "environmentVariables": {

--- a/samples/ReverseProxy.Transforms.Sample/Properties/launchSettings.json
+++ b/samples/ReverseProxy.Transforms.Sample/Properties/launchSettings.json
@@ -8,7 +8,7 @@
     }
   },
   "profiles": {
-    "ReverseProxy.Sample": {
+    "ReverseProxy.Transforms.Sample": {
       "commandName": "Project",
       "launchBrowser": false,
       "environmentVariables": {

--- a/samples/SampleServer/Properties/launchSettings.json
+++ b/samples/SampleServer/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "ReverseProxy.Sample": {
+    "SampleServer": {
       "commandName": "Project",
       "launchBrowser": false,
       "environmentVariables": {

--- a/testassets/ReverseProxy.Code/Properties/launchSettings.json
+++ b/testassets/ReverseProxy.Code/Properties/launchSettings.json
@@ -8,7 +8,7 @@
     }
   },
   "profiles": {
-    "ReverseProxy.Sample": {
+    "ReverseProxy.Code": {
       "commandName": "Project",
       "launchBrowser": false,
       "environmentVariables": {

--- a/testassets/ReverseProxy.Config/Properties/launchSettings.json
+++ b/testassets/ReverseProxy.Config/Properties/launchSettings.json
@@ -8,7 +8,7 @@
     }
   },
   "profiles": {
-    "ReverseProxy.Sample": {
+    "ReverseProxy.Config": {
       "commandName": "Project",
       "launchBrowser": false,
       "environmentVariables": {

--- a/testassets/ReverseProxy.Direct/Properties/launchSettings.json
+++ b/testassets/ReverseProxy.Direct/Properties/launchSettings.json
@@ -8,7 +8,7 @@
     }
   },
   "profiles": {
-    "ReverseProxy.Sample": {
+    "ReverseProxy.Direct": {
       "commandName": "Project",
       "launchBrowser": false,
       "environmentVariables": {

--- a/testassets/TestClient/Properties/launchSettings.json
+++ b/testassets/TestClient/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "SampleClient": {
+    "TestClient": {
       "commandName": "Project",
       "commandLineArgs": "-t https://localhost:5001"
     }

--- a/testassets/TestServer/Properties/launchSettings.json
+++ b/testassets/TestServer/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "ReverseProxy.Sample": {
+    "TestServer": {
       "commandName": "Project",
       "launchBrowser": false,
       "environmentVariables": {


### PR DESCRIPTION
- ~~Added a 6.0 target to the Auth sample (leftover from https://github.com/microsoft/reverse-proxy/pull/972#issuecomment-840527110)~~
  - Reverted: #1363
- Updated profile names in `launchSettings.json`
- Used `RequestUtilities` in the direct sample when creating the Uri
- Fixed the metrics sample (it was logging an unrelated stop)
- Updated the package reference in the "getting started" article to 1.0.0
- Typos


I will cherry-pick this change onto the `release/1.0` branch
Contributes to #1353