### PR TITLE
Update CI to macos-latest

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -129,10 +129,10 @@ stages:
             artifactType: Container
             parallel: true
 
-      - job: macOS_10_14
-        displayName: 'macOS 10.14'
+      - job: macOS_latest
+        displayName: 'macOS latest'
         pool:
-          vmImage: macOS-10.14
+          vmImage: macOS-latest
         variables:
         - name: _SignType
           value: none


### PR DESCRIPTION
Resolves CI build warning:
```
##[warning]The macOS-10.14 environment is deprecated and will be removed on December 10, 2021. For more details see https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/
```