### PR TITLE
Enable net6.0 in auth sample 

### DIFF
--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -4,6 +4,7 @@
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
 
   <PropertyGroup>
+    <IsShipping>false</IsShipping>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 </Project>

--- a/samples/ReverseProxy.Auth.Sample/ReverseProxy.Auth.Sample.csproj
+++ b/samples/ReverseProxy.Auth.Sample/ReverseProxy.Auth.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.Sample</RootNamespace>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
Fixes #1363

The symbols build error was caused by our samples defaulting to IsShipping and doing more verification than needed.