### PR TITLE
Use zero-byte reads in StreamCopier

### DIFF
--- a/src/ReverseProxy/Forwarder/StreamCopier.cs
+++ b/src/ReverseProxy/Forwarder/StreamCopier.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Buffers;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,75 +20,32 @@ internal static class StreamCopier
     // Based on performance investigations, see https://github.com/microsoft/reverse-proxy/pull/330#issuecomment-758851852.
     private const int DefaultBufferSize = 65536;
 
-    private static readonly TimeSpan TimeBetweenTransferringEvents = TimeSpan.FromSeconds(1);
-
-    /// <inheritdoc/>
-    /// <remarks>
-    /// Based on <c>Microsoft.AspNetCore.Http.StreamCopyOperationInternal.CopyToAsync</c>.
-    /// See: <see href="https://github.com/dotnet/aspnetcore/blob/080660967b6043f731d4b7163af9e9e6047ef0c4/src/Http/Shared/StreamCopyOperationInternal.cs"/>.
-    /// </remarks>
-    public static async ValueTask<(StreamCopyResult, Exception?)> CopyAsync(bool isRequest, Stream input, Stream output, IClock clock, ActivityCancellationTokenSource activityToken, CancellationToken cancellation)
+    public static ValueTask<(StreamCopyResult, Exception?)> CopyAsync(bool isRequest, Stream input, Stream output, IClock clock, ActivityCancellationTokenSource activityToken, CancellationToken cancellation)
     {
-        _ = input ?? throw new ArgumentNullException(nameof(input));
-        _ = output ?? throw new ArgumentNullException(nameof(output));
+        Debug.Assert(input is not null);
+        Debug.Assert(output is not null);
+        Debug.Assert(clock is not null);
+        Debug.Assert(activityToken is not null);
 
-        var telemetryEnabled = ForwarderTelemetry.Log.IsEnabled();
+        // Avoid capturing 'isRequest' and 'clock' in the state machine when telemetry is disabled
+        var telemetry = ForwarderTelemetry.Log.IsEnabled(EventLevel.Informational, EventKeywords.All)
+            ? new StreamCopierTelemetry(isRequest, clock)
+            : null;
 
+        return CopyAsync(input, output, telemetry, activityToken, cancellation);
+    }
+
+    private static async ValueTask<(StreamCopyResult, Exception?)> CopyAsync(Stream input, Stream output, StreamCopierTelemetry? telemetry, ActivityCancellationTokenSource activityToken, CancellationToken cancellation)
+    {
         var buffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
-        var reading = true;
-
-        long contentLength = 0;
-        long iops = 0;
-        var readTime = TimeSpan.Zero;
-        var writeTime = TimeSpan.Zero;
-        var firstReadTime = TimeSpan.FromMilliseconds(-1);
-
+        var read = 0;
         try
         {
-            var lastTime = TimeSpan.Zero;
-            var nextTransferringEvent = TimeSpan.Zero;
-
-            if (telemetryEnabled)
-            {
-                ForwarderTelemetry.Log.ForwarderStage(isRequest ? ForwarderStage.RequestContentTransferStart : ForwarderStage.ResponseContentTransferStart);
-
-                lastTime = clock.GetStopwatchTime();
-                nextTransferringEvent = lastTime + TimeBetweenTransferringEvents;
-            }
-
             while (true)
             {
-                if (cancellation.IsCancellationRequested)
-                {
-                    return (StreamCopyResult.Canceled, new OperationCanceledException(cancellation));
-                }
+                read = await input.ReadAsync(buffer.AsMemory(), cancellation);
 
-                reading = true;
-                var read = 0;
-                try
-                {
-                    read = await input.ReadAsync(buffer.AsMemory(), cancellation);
-
-                    // Success, reset the activity monitor.
-                    activityToken.ResetTimeout();
-                }
-                finally
-                {
-                    if (telemetryEnabled)
-                    {
-                        contentLength += read;
-                        iops++;
-
-                        var readStop = clock.GetStopwatchTime();
-                        var currentReadTime = readStop - lastTime;
-                        lastTime = readStop;
-                        readTime += currentReadTime;
-                        if (firstReadTime.Ticks < 0)
-                        {
-                            firstReadTime = currentReadTime;
-                        }
-                    }
-                }
+                telemetry?.AfterRead(read);
 
                 // End of the source stream.
                 if (read == 0)
@@ -94,66 +53,138 @@ internal static class StreamCopier
                     return (StreamCopyResult.Success, null);
                 }
 
-                if (cancellation.IsCancellationRequested)
+                // Success, reset the activity monitor.
+                activityToken.ResetTimeout();
+
+                await output.WriteAsync(buffer.AsMemory(0, read), cancellation);
+
+                telemetry?.AfterWrite();
+
+                // Success, reset the activity monitor.
+                activityToken.ResetTimeout();
+
+                read = 0;
+
+                // Issue a zero-byte read to the input stream to defer buffer allocation until data is available.
+                // Note that if the underlying stream does not supporting blocking on zero byte reads, then this will
+                // complete immediately and won't save any memory, but will still function correctly.
+                var zeroByteReadTask = input.ReadAsync(Memory<byte>.Empty, cancellation);
+                if (zeroByteReadTask.IsCompletedSuccessfully)
                 {
-                    return (StreamCopyResult.Canceled, new OperationCanceledException(cancellation));
+                    // Consume the ValueTask's result in case it is backed by an IValueTaskSource
+                    _ = zeroByteReadTask.Result;
                 }
-
-                reading = false;
-                try
+                else
                 {
-                    await output.WriteAsync(buffer.AsMemory(0, read), cancellation);
+                    // Take care not to return the same buffer to the pool twice in case zeroByteReadTask throws
+                    var bufferToReturn = buffer;
+                    buffer = null;
+                    ArrayPool<byte>.Shared.Return(bufferToReturn);
 
-                    // Success, reset the activity monitor.
-                    activityToken.ResetTimeout();
-                }
-                finally
-                {
-                    if (telemetryEnabled)
-                    {
-                        var writeStop = clock.GetStopwatchTime();
-                        writeTime += writeStop - lastTime;
-                        lastTime = writeStop;
-                        if (lastTime >= nextTransferringEvent)
-                        {
-                            ForwarderTelemetry.Log.ContentTransferring(
-                                isRequest,
-                                contentLength,
-                                iops,
-                                readTime.Ticks,
-                                writeTime.Ticks);
+                    await zeroByteReadTask;
 
-                            // Avoid attributing the time taken by logging ContentTransferring to the next read call
-                            lastTime = clock.GetStopwatchTime();
-                            nextTransferringEvent = lastTime + TimeBetweenTransferringEvents;
-                        }
-                    }
+                    buffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
                 }
             }
-        }
-        catch (OperationCanceledException oex)
-        {
-            return (StreamCopyResult.Canceled, oex);
         }
         catch (Exception ex)
         {
-            return (reading ? StreamCopyResult.InputError : StreamCopyResult.OutputError, ex);
+            if (read == 0)
+            {
+                telemetry?.AfterRead(0);
+            }
+            else
+            {
+                telemetry?.AfterWrite();
+            }
+
+            var result = ex is OperationCanceledException ? StreamCopyResult.Canceled :
+                (read == 0 ? StreamCopyResult.InputError : StreamCopyResult.OutputError);
+
+            return (result, ex);
         }
         finally
         {
-            // We can afford the perf impact of clearArray == true since we only do this twice per request.
-            ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
-
-            if (telemetryEnabled)
+            if (buffer is not null)
             {
-                ForwarderTelemetry.Log.ContentTransferred(
-                    isRequest,
-                    contentLength,
-                    iops,
-                    readTime.Ticks,
-                    writeTime.Ticks,
-                    Math.Max(0, firstReadTime.Ticks));
+                ArrayPool<byte>.Shared.Return(buffer);
             }
+
+            telemetry?.Stop();
+        }
+    }
+
+    private sealed class StreamCopierTelemetry
+    {
+        private static readonly TimeSpan _timeBetweenTransferringEvents = TimeSpan.FromSeconds(1);
+
+        private readonly bool _isRequest;
+        private readonly IClock _clock;
+        private long _contentLength;
+        private long _iops;
+        private TimeSpan _readTime;
+        private TimeSpan _writeTime;
+        private TimeSpan _firstReadTime;
+        private TimeSpan _lastTime;
+        private TimeSpan _nextTransferringEvent;
+
+        public StreamCopierTelemetry(bool isRequest, IClock clock)
+        {
+            _isRequest = isRequest;
+            _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+            _firstReadTime = new TimeSpan(-1);
+
+            ForwarderTelemetry.Log.ForwarderStage(isRequest ? ForwarderStage.RequestContentTransferStart : ForwarderStage.ResponseContentTransferStart);
+
+            _lastTime = clock.GetStopwatchTime();
+            _nextTransferringEvent = _lastTime + _timeBetweenTransferringEvents;
+        }
+
+        public void AfterRead(int read)
+        {
+            _contentLength += read;
+            _iops++;
+
+            var readStop = _clock.GetStopwatchTime();
+            var currentReadTime = readStop - _lastTime;
+            _lastTime = readStop;
+            _readTime += currentReadTime;
+            if (_firstReadTime.Ticks < 0)
+            {
+                _firstReadTime = currentReadTime;
+            }
+        }
+
+        public void AfterWrite()
+        {
+            var writeStop = _clock.GetStopwatchTime();
+            _writeTime += writeStop - _lastTime;
+            _lastTime = writeStop;
+
+            if (writeStop >= _nextTransferringEvent)
+            {
+                ForwarderTelemetry.Log.ContentTransferring(
+                    _isRequest,
+                    _contentLength,
+                    _iops,
+                    _readTime.Ticks,
+                    _writeTime.Ticks);
+
+                // Avoid attributing the time taken by logging ContentTransferring to the next read call
+                _lastTime = _clock.GetStopwatchTime();
+                _nextTransferringEvent = _lastTime + _timeBetweenTransferringEvents;
+            }
+        }
+
+        public void Stop()
+        {
+            ForwarderTelemetry.Log.ContentTransferred(
+                _isRequest,
+                _contentLength,
+                _iops,
+                _readTime.Ticks,
+                _writeTime.Ticks,
+                Math.Max(0, _firstReadTime.Ticks));
         }
     }
 }

--- a/src/ReverseProxy/Forwarder/StreamCopier.cs
+++ b/src/ReverseProxy/Forwarder/StreamCopier.cs
@@ -43,26 +43,6 @@ internal static class StreamCopier
         {
             while (true)
             {
-                read = await input.ReadAsync(buffer.AsMemory(), cancellation);
-
-                telemetry?.AfterRead(read);
-
-                // Success, reset the activity monitor.
-                activityToken.ResetTimeout();
-
-                // End of the source stream.
-                if (read == 0)
-                {
-                    return (StreamCopyResult.Success, null);
-                }
-
-                await output.WriteAsync(buffer.AsMemory(0, read), cancellation);
-
-                telemetry?.AfterWrite();
-
-                // Success, reset the activity monitor.
-                activityToken.ResetTimeout();
-
                 read = 0;
 
                 // Issue a zero-byte read to the input stream to defer buffer allocation until data is available.
@@ -85,6 +65,26 @@ internal static class StreamCopier
 
                     buffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
                 }
+
+                read = await input.ReadAsync(buffer.AsMemory(), cancellation);
+
+                telemetry?.AfterRead(read);
+
+                // Success, reset the activity monitor.
+                activityToken.ResetTimeout();
+
+                // End of the source stream.
+                if (read == 0)
+                {
+                    return (StreamCopyResult.Success, null);
+                }
+
+                await output.WriteAsync(buffer.AsMemory(0, read), cancellation);
+
+                telemetry?.AfterWrite();
+
+                // Success, reset the activity monitor.
+                activityToken.ResetTimeout();
             }
         }
         catch (Exception ex)

--- a/src/ReverseProxy/Forwarder/StreamCopier.cs
+++ b/src/ReverseProxy/Forwarder/StreamCopier.cs
@@ -47,14 +47,14 @@ internal static class StreamCopier
 
                 telemetry?.AfterRead(read);
 
+                // Success, reset the activity monitor.
+                activityToken.ResetTimeout();
+
                 // End of the source stream.
                 if (read == 0)
                 {
                     return (StreamCopyResult.Success, null);
                 }
-
-                // Success, reset the activity monitor.
-                activityToken.ResetTimeout();
 
                 await output.WriteAsync(buffer.AsMemory(0, read), cancellation);
 

--- a/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
@@ -1093,7 +1093,7 @@ public class HttpForwarderTests
         httpContext.Request.Method = "POST";
         httpContext.Request.Body = new CallbackReadStream(async (memory, ct) =>
         {
-            if (reads >= expectedReads)
+            if (memory.Length == 0 || reads >= expectedReads)
             {
                 return 0;
             }
@@ -1501,7 +1501,7 @@ public class HttpForwarderTests
         Assert.Empty(httpContext.Response.Headers);
         var errorFeature = httpContext.Features.Get<IForwarderErrorFeature>();
         Assert.Equal(ForwarderError.ResponseBodyCanceled, errorFeature.Error);
-        Assert.IsType<OperationCanceledException>(errorFeature.Exception);
+        Assert.IsType<TaskCanceledException>(errorFeature.Exception);
 
         AssertProxyStartFailedStop(events, destinationPrefix, httpContext.Response.StatusCode, errorFeature.Error);
         events.AssertContainProxyStages(hasRequestContent: false);
@@ -1542,7 +1542,7 @@ public class HttpForwarderTests
         Assert.Equal("bytes", httpContext.Response.Headers[HeaderNames.AcceptRanges]);
         var errorFeature = httpContext.Features.Get<IForwarderErrorFeature>();
         Assert.Equal(ForwarderError.ResponseBodyCanceled, errorFeature.Error);
-        Assert.IsType<OperationCanceledException>(errorFeature.Exception);
+        Assert.IsType<TaskCanceledException>(errorFeature.Exception);
 
         AssertProxyStartFailedStop(events, destinationPrefix, httpContext.Response.StatusCode, errorFeature.Error);
         events.AssertContainProxyStages(hasRequestContent: false);

--- a/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
@@ -2299,6 +2299,11 @@ public class HttpForwarderTests
 
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
+            if (buffer.Length == 0)
+            {
+                return new ValueTask<int>(0);
+            }
+
             cancellationToken.ThrowIfCancellationRequested();
             if (_firstRead && !ThrowOnFirstRead)
             {
@@ -2456,7 +2461,10 @@ public class HttpForwarderTests
 
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
-            OnCompleted();
+            if (buffer.Length != 0)
+            {
+                OnCompleted();
+            }
             return new ValueTask<int>(0);
         }
     }

--- a/test/ReverseProxy.Tests/Forwarder/StreamCopierTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/StreamCopierTests.cs
@@ -104,7 +104,7 @@ public class StreamCopierTests : TestAutoMockBase
 
         using var cts = ActivityCancellationTokenSource.Rent(TimeSpan.FromSeconds(10), CancellationToken.None);
         cts.Cancel();
-        var (result, error) = await StreamCopier.CopyAsync(isRequest, source, destination, new Clock(), cts, cts.Token);
+        var (result, error) = await StreamCopier.CopyAsync(isRequest, source, destination, new ManualClock(), cts, cts.Token);
         Assert.Equal(StreamCopyResult.Canceled, result);
         Assert.IsAssignableFrom<OperationCanceledException>(error);
 

--- a/test/ReverseProxy.Tests/Forwarder/StreamCopierTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/StreamCopierTests.cs
@@ -110,7 +110,7 @@ public class StreamCopierTests : TestAutoMockBase
 
         AssertContentTransferred(events, isRequest,
             contentLength: 0,
-            iops: 0,
+            iops: 1,
             firstReadTime: TimeSpan.Zero,
             readTime: TimeSpan.Zero,
             writeTime: TimeSpan.Zero);
@@ -306,6 +306,11 @@ public class StreamCopierTests : TestAutoMockBase
 
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
+            if (buffer.Length == 0)
+            {
+                return new ValueTask<int>(0);
+            }
+
             _clock.AdvanceClockBy(_waitTime);
             return base.ReadAsync(buffer.Slice(0, Math.Min(buffer.Length, MaxBytesPerRead)), cancellationToken);
         }

--- a/test/ReverseProxy.Tests/Forwarder/StreamCopyHttpContentTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/StreamCopyHttpContentTests.cs
@@ -135,6 +135,11 @@ public class StreamCopyHttpContentTests
 
         var source = new ReadDelegatingStream(new MemoryStream(), async (buffer, cancellation) =>
         {
+            if (buffer.Length == 0)
+            {
+                return 0;
+            }
+
             Assert.False(cancellation.IsCancellationRequested);
             await tcs.Task;
             Assert.True(cancellation.IsCancellationRequested);
@@ -160,6 +165,11 @@ public class StreamCopyHttpContentTests
 
         var source = new ReadDelegatingStream(new MemoryStream(), async (buffer, cancellation) =>
         {
+            if (buffer.Length == 0)
+            {
+                return 0;
+            }
+
             Assert.False(cancellation.IsCancellationRequested);
             await tcs.Task;
             Assert.True(cancellation.IsCancellationRequested);


### PR DESCRIPTION
Fixes #1325

I moved all the telemetry-related logic into a separate `StreamCopierTelemetry` class to both simplify the code and reduce the size of the `CopyAsync` state machine. Also removed the try-finally blocks to minimize the overhead.

This change amounts to a 5.6% RPS improvement in our base (http-http 100-byte) benchmark.
About 4.6% of which comes the fact we are no longer clearing the entire rented ArrayPool buffer on both sides.
The extra 1% comes from the simplified `CopyAsync` implementation, even after you account for the extra work we are doing to issue the zero-byte read.

Memory-wise, for a persistent idle connection (e.g. WebSockets), we avoid holding onto the 64k buffer on the request content side. With support from runtime, we also avoid holding the 64k buffer on the response content side + the 32k SslStream buffer.
More detailed numbers here: https://github.com/microsoft/reverse-proxy/issues/1325#issuecomment-965889438.