### PR TITLE
Fast-path zero-byte reads in WebSocketsTelemetryStream ReadAsync

### DIFF
--- a/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetryStream.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetryStream.cs
@@ -73,6 +73,11 @@ internal sealed class WebSocketsTelemetryStream : DelegatingStream
     {
         var readTask = base.ReadAsync(buffer, cancellationToken);
 
+        if (buffer.Length == 0)
+        {
+            return readTask;
+        }
+
         if (readTask.IsCompletedSuccessfully)
         {
             var read = readTask.GetAwaiter().GetResult();


### PR DESCRIPTION
Followup to #1415

A `Consume` of zero bytes is a no-op on the parser, so we can just return the original read task to the caller.

Since we are always doing zero-byte reads, this effectively means that if the underlying stream supports it, `WebSocketsTelemetryStream`'s `ReadAsync` will never allocate.