### PR TITLE
Fixes build of docker image

### DIFF
--- a/samples/KuberenetesIngress.Sample/Ingress/Dockerfile
+++ b/samples/KuberenetesIngress.Sample/Ingress/Dockerfile
@@ -15,7 +15,7 @@ COPY ["src/OperatorFramework/src/Core/Microsoft.Kubernetes.Core.csproj", "src/Op
 COPY ["src/ReverseProxy/Yarp.ReverseProxy.csproj", "src/ReverseProxy/"]
 COPY ["src/Kubernetes.Protocol/Yarp.Kubernetes.Protocol.csproj", "src/Kubernetes.Protocol/"]
 COPY ["src/Directory.Build.props", "src/"]
-COPY ["Directory.Build.*", ""]
+COPY ["Directory.Build.*", "./"]
 COPY ["global.json", ""]
 COPY ["NuGet.config", ""]
 

--- a/src/Kubernetes.Controller/Dockerfile
+++ b/src/Kubernetes.Controller/Dockerfile
@@ -15,7 +15,7 @@ COPY ["src/Kubernetes.Controller/Yarp.Kubernetes.Controller.csproj", "src/Kubern
 COPY ["src/Kubernetes.Protocol/Yarp.Kubernetes.Protocol.csproj", "src/Kubernetes.Protocol/"]
 COPY ["src/ReverseProxy/Yarp.ReverseProxy.csproj", "src/ReverseProxy/"]
 COPY ["src/Directory.Build.props", "src/"]
-COPY ["Directory.Build.*", ""]
+COPY ["Directory.Build.*", "./"]
 COPY ["global.json", ""]
 COPY ["NuGet.config", ""]
 


### PR DESCRIPTION
Fixes the following docker image build error:
When using COPY with more than one source file, the destination must be
a directory and end with a /