### PR TITLE
Added missed penultimate bytes in `SniHelper_TruncatedData_Fails` scenario

### DIFF
--- a/test/ReverseProxy.Tests/Utilities/TlsFrameHelperTests.cs
+++ b/test/ReverseProxy.Tests/Utilities/TlsFrameHelperTests.cs
@@ -138,13 +138,13 @@ public class TlsFrameHelperTests
         var uniqueInvalidHellos = new HashSet<string>();
         foreach (byte[] invalidClientHello in InvalidClientHello())
         {
-            for (int i = 0; i < invalidClientHello.Length - 1; i++)
+            for (int i = 0; i < invalidClientHello.Length; i++)
             {
                 uniqueInvalidHellos.Add(Convert.ToBase64String(invalidClientHello.Take(i).ToArray()));
             }
         }
 
-        for (int i = 0; i < s_validClientHello.Length - 1; i++)
+        for (int i = 0; i < s_validClientHello.Length; i++)
         {
             uniqueInvalidHellos.Add(Convert.ToBase64String(s_validClientHello.Take(i).ToArray()));
         }


### PR DESCRIPTION
When I was trying to break test `SniHelper_TruncatedData_Fails` https://github.com/microsoft/reverse-proxy/pull/1433 I noticed that we missed penultimate bytes in generator, added them into the scenario.