### PR TITLE
Fixed invalid heading markdown for Metrics.Sample Readme

### DIFF
--- a/samples/ReverseProxy.Metrics.Sample/README.md
+++ b/samples/ReverseProxy.Metrics.Sample/README.md
@@ -1,4 +1,4 @@
-#ReverseProxy.Metrics.Sample
+# ReverseProxy.Metrics.Sample
 
 This sample demonstrates how to use the ReverseProxy.Telemetry.Consumption library to listen to telemetry data from YARP.
 In this case it uses the events to create a per-request data structure with detailed timings for each operation that takes place as part of the proxy operation.


### PR DESCRIPTION
Previously the heading wasn't rendered correctly as there was no space after the #. Just added the #