### PR TITLE
Throw on wrong Content-Length

### DIFF
--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -644,6 +644,7 @@ internal sealed class HttpForwarder : IHttpForwarder
         if (destinationResponseContent != null)
         {
             using var destinationResponseStream = await destinationResponseContent.ReadAsStreamAsync();
+            // The response content-length is enforced by the server.
             return await StreamCopier.CopyAsync(isRequest: false, destinationResponseStream, clientResponseStream, -1, _clock, activityCancellationSource, activityCancellationSource.Token);
         }
 

--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -406,7 +406,6 @@ internal sealed class HttpForwarder : IHttpForwarder
             // but for now, out of an abundance of caution, we only do it for requests that look like gRPC.
             return new StreamCopyHttpContent(
                 source: request.Body,
-                contentLength: request.Headers.ContentLength,
                 autoFlushHttpClientOutgoingStream: isStreamingRequest,
                 clock: _clock,
                 activityToken);

--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -586,8 +586,8 @@ internal sealed class HttpForwarder : IHttpForwarder
         // :: Step 7-A-2: Copy duplex streams
         using var destinationStream = await destinationResponse.Content.ReadAsStreamAsync();
 
-        var requestTask = StreamCopier.CopyAsync(isRequest: true, clientStream, destinationStream, context.Request.ContentLength ?? -1, _clock, activityCancellationSource, activityCancellationSource.Token).AsTask();
-        var responseTask = StreamCopier.CopyAsync(isRequest: false, destinationStream, clientStream, -1, _clock, activityCancellationSource, activityCancellationSource.Token).AsTask();
+        var requestTask = StreamCopier.CopyAsync(isRequest: true, clientStream, destinationStream, StreamCopier.UnknownLength, _clock, activityCancellationSource, activityCancellationSource.Token).AsTask();
+        var responseTask = StreamCopier.CopyAsync(isRequest: false, destinationStream, clientStream, StreamCopier.UnknownLength, _clock, activityCancellationSource, activityCancellationSource.Token).AsTask();
 
         // Make sure we report the first failure.
         var firstTask = await Task.WhenAny(requestTask, responseTask);
@@ -645,7 +645,7 @@ internal sealed class HttpForwarder : IHttpForwarder
         {
             using var destinationResponseStream = await destinationResponseContent.ReadAsStreamAsync();
             // The response content-length is enforced by the server.
-            return await StreamCopier.CopyAsync(isRequest: false, destinationResponseStream, clientResponseStream, -1, _clock, activityCancellationSource, activityCancellationSource.Token);
+            return await StreamCopier.CopyAsync(isRequest: false, destinationResponseStream, clientResponseStream, StreamCopier.UnknownLength, _clock, activityCancellationSource, activityCancellationSource.Token);
         }
 
         return (StreamCopyResult.Success, null);

--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -586,8 +586,8 @@ internal sealed class HttpForwarder : IHttpForwarder
         // :: Step 7-A-2: Copy duplex streams
         using var destinationStream = await destinationResponse.Content.ReadAsStreamAsync();
 
-        var requestTask = StreamCopier.CopyAsync(isRequest: true, clientStream, destinationStream, context.Request.ContentLength, _clock, activityCancellationSource, activityCancellationSource.Token).AsTask();
-        var responseTask = StreamCopier.CopyAsync(isRequest: false, destinationStream, clientStream, null, _clock, activityCancellationSource, activityCancellationSource.Token).AsTask();
+        var requestTask = StreamCopier.CopyAsync(isRequest: true, clientStream, destinationStream, context.Request.ContentLength ?? -1, _clock, activityCancellationSource, activityCancellationSource.Token).AsTask();
+        var responseTask = StreamCopier.CopyAsync(isRequest: false, destinationStream, clientStream, -1, _clock, activityCancellationSource, activityCancellationSource.Token).AsTask();
 
         // Make sure we report the first failure.
         var firstTask = await Task.WhenAny(requestTask, responseTask);
@@ -644,7 +644,7 @@ internal sealed class HttpForwarder : IHttpForwarder
         if (destinationResponseContent != null)
         {
             using var destinationResponseStream = await destinationResponseContent.ReadAsStreamAsync();
-            return await StreamCopier.CopyAsync(isRequest: false, destinationResponseStream, clientResponseStream, null, _clock, activityCancellationSource, activityCancellationSource.Token);
+            return await StreamCopier.CopyAsync(isRequest: false, destinationResponseStream, clientResponseStream, -1, _clock, activityCancellationSource, activityCancellationSource.Token);
         }
 
         return (StreamCopyResult.Success, null);

--- a/src/ReverseProxy/Forwarder/StreamCopier.cs
+++ b/src/ReverseProxy/Forwarder/StreamCopier.cs
@@ -20,7 +20,7 @@ internal static class StreamCopier
     // Based on performance investigations, see https://github.com/microsoft/reverse-proxy/pull/330#issuecomment-758851852.
     private const int DefaultBufferSize = 65536;
 
-    public static ValueTask<(StreamCopyResult, Exception?)> CopyAsync(bool isRequest, Stream input, Stream output, IClock clock, ActivityCancellationTokenSource activityToken, CancellationToken cancellation)
+    public static ValueTask<(StreamCopyResult, Exception?)> CopyAsync(bool isRequest, Stream input, Stream output, long? promisedContentLength, IClock clock, ActivityCancellationTokenSource activityToken, CancellationToken cancellation)
     {
         Debug.Assert(input is not null);
         Debug.Assert(output is not null);
@@ -32,13 +32,14 @@ internal static class StreamCopier
             ? new StreamCopierTelemetry(isRequest, clock)
             : null;
 
-        return CopyAsync(input, output, telemetry, activityToken, cancellation);
+        return CopyAsync(input, output, promisedContentLength, telemetry, activityToken, cancellation);
     }
 
-    private static async ValueTask<(StreamCopyResult, Exception?)> CopyAsync(Stream input, Stream output, StreamCopierTelemetry? telemetry, ActivityCancellationTokenSource activityToken, CancellationToken cancellation)
+    private static async ValueTask<(StreamCopyResult, Exception?)> CopyAsync(Stream input, Stream output, long? promisedContentLength, StreamCopierTelemetry? telemetry, ActivityCancellationTokenSource activityToken, CancellationToken cancellation)
     {
         var buffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
         var read = 0;
+        long contentLength = 0;
         try
         {
             while (true)
@@ -67,8 +68,9 @@ internal static class StreamCopier
                 }
 
                 read = await input.ReadAsync(buffer.AsMemory(), cancellation);
+                contentLength += read;
 
-                telemetry?.AfterRead(read);
+                telemetry?.AfterRead(contentLength);
 
                 // Success, reset the activity monitor.
                 activityToken.ResetTimeout();
@@ -76,7 +78,16 @@ internal static class StreamCopier
                 // End of the source stream.
                 if (read == 0)
                 {
-                    return (StreamCopyResult.Success, null);
+                    if (!promisedContentLength.HasValue || contentLength == promisedContentLength)
+                    {
+                        return (StreamCopyResult.Success, null);
+                    }
+                    else
+                    {
+                        return (StreamCopyResult.InputError,
+                            new Exception($"Sent {contentLength} request content bytes, but Content-Length promised {promisedContentLength}."));
+                    }
+                    
                 }
 
                 await output.WriteAsync(buffer.AsMemory(0, read), cancellation);
@@ -91,7 +102,7 @@ internal static class StreamCopier
         {
             if (read == 0)
             {
-                telemetry?.AfterRead(0);
+                telemetry?.AfterRead(contentLength);
             }
             else
             {
@@ -140,9 +151,9 @@ internal static class StreamCopier
             _nextTransferringEvent = _lastTime + _timeBetweenTransferringEvents;
         }
 
-        public void AfterRead(int read)
+        public void AfterRead(long contentLength)
         {
-            _contentLength += read;
+            _contentLength = contentLength;
             _iops++;
 
             var readStop = _clock.GetStopwatchTime();

--- a/src/ReverseProxy/Forwarder/StreamCopier.cs
+++ b/src/ReverseProxy/Forwarder/StreamCopier.cs
@@ -78,16 +78,16 @@ internal static class StreamCopier
                 // End of the source stream.
                 if (read == 0)
                 {
-                    if (promisedContentLength < 0 || contentLength == promisedContentLength)
+                    if (promisedContentLength == UnknownLength || contentLength == promisedContentLength)
                     {
                         return (StreamCopyResult.Success, null);
                     }
                     else
                     {
+                        // This can happen if something in the proxy consumes or modifies part or all of the request body before proxying.
                         return (StreamCopyResult.InputError,
                             new Exception($"Sent {contentLength} request content bytes, but Content-Length promised {promisedContentLength}."));
                     }
-                    
                 }
 
                 await output.WriteAsync(buffer.AsMemory(0, read), cancellation);

--- a/src/ReverseProxy/Forwarder/StreamCopier.cs
+++ b/src/ReverseProxy/Forwarder/StreamCopier.cs
@@ -20,7 +20,7 @@ internal static class StreamCopier
     // Based on performance investigations, see https://github.com/microsoft/reverse-proxy/pull/330#issuecomment-758851852.
     private const int DefaultBufferSize = 65536;
 
-    public static ValueTask<(StreamCopyResult, Exception?)> CopyAsync(bool isRequest, Stream input, Stream output, long? promisedContentLength, IClock clock, ActivityCancellationTokenSource activityToken, CancellationToken cancellation)
+    public static ValueTask<(StreamCopyResult, Exception?)> CopyAsync(bool isRequest, Stream input, Stream output, long promisedContentLength, IClock clock, ActivityCancellationTokenSource activityToken, CancellationToken cancellation)
     {
         Debug.Assert(input is not null);
         Debug.Assert(output is not null);
@@ -78,7 +78,7 @@ internal static class StreamCopier
                 // End of the source stream.
                 if (read == 0)
                 {
-                    if (!promisedContentLength.HasValue || contentLength == promisedContentLength)
+                    if (promisedContentLength < 0 || contentLength == promisedContentLength)
                     {
                         return (StreamCopyResult.Success, null);
                     }

--- a/src/ReverseProxy/Forwarder/StreamCopier.cs
+++ b/src/ReverseProxy/Forwarder/StreamCopier.cs
@@ -70,6 +70,11 @@ internal static class StreamCopier
 
                 read = await input.ReadAsync(buffer.AsMemory(), cancellation);
                 contentLength += read;
+                // Normally this is enforced by the server, but it could get out of sync if something in the proxy modified the body.
+                if (promisedContentLength != UnknownLength && contentLength > promisedContentLength)
+                {
+                    return (StreamCopyResult.InputError, new InvalidOperationException("More bytes received than the specified Content-Length."));
+                }
 
                 telemetry?.AfterRead(contentLength);
 

--- a/src/ReverseProxy/Forwarder/StreamCopier.cs
+++ b/src/ReverseProxy/Forwarder/StreamCopier.cs
@@ -35,7 +35,7 @@ internal static class StreamCopier
         return CopyAsync(input, output, promisedContentLength, telemetry, activityToken, cancellation);
     }
 
-    private static async ValueTask<(StreamCopyResult, Exception?)> CopyAsync(Stream input, Stream output, long? promisedContentLength, StreamCopierTelemetry? telemetry, ActivityCancellationTokenSource activityToken, CancellationToken cancellation)
+    private static async ValueTask<(StreamCopyResult, Exception?)> CopyAsync(Stream input, Stream output, long promisedContentLength, StreamCopierTelemetry? telemetry, ActivityCancellationTokenSource activityToken, CancellationToken cancellation)
     {
         var buffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
         var read = 0;

--- a/src/ReverseProxy/Forwarder/StreamCopier.cs
+++ b/src/ReverseProxy/Forwarder/StreamCopier.cs
@@ -19,7 +19,7 @@ internal static class StreamCopier
 {
     // Based on performance investigations, see https://github.com/microsoft/reverse-proxy/pull/330#issuecomment-758851852.
     private const int DefaultBufferSize = 65536;
-    public static readonly long UnknownLength = -1;
+    public const long UnknownLength = -1;
 
     public static ValueTask<(StreamCopyResult, Exception?)> CopyAsync(bool isRequest, Stream input, Stream output, long promisedContentLength, IClock clock, ActivityCancellationTokenSource activityToken, CancellationToken cancellation)
     {

--- a/src/ReverseProxy/Forwarder/StreamCopier.cs
+++ b/src/ReverseProxy/Forwarder/StreamCopier.cs
@@ -19,6 +19,7 @@ internal static class StreamCopier
 {
     // Based on performance investigations, see https://github.com/microsoft/reverse-proxy/pull/330#issuecomment-758851852.
     private const int DefaultBufferSize = 65536;
+    public static readonly long UnknownLength = -1;
 
     public static ValueTask<(StreamCopyResult, Exception?)> CopyAsync(bool isRequest, Stream input, Stream output, long promisedContentLength, IClock clock, ActivityCancellationTokenSource activityToken, CancellationToken cancellation)
     {
@@ -86,7 +87,7 @@ internal static class StreamCopier
                     {
                         // This can happen if something in the proxy consumes or modifies part or all of the request body before proxying.
                         return (StreamCopyResult.InputError,
-                            new Exception($"Sent {contentLength} request content bytes, but Content-Length promised {promisedContentLength}."));
+                            new InvalidOperationException($"Sent {contentLength} request content bytes, but Content-Length promised {promisedContentLength}."));
                     }
                 }
 

--- a/src/ReverseProxy/Forwarder/StreamCopyHttpContent.cs
+++ b/src/ReverseProxy/Forwarder/StreamCopyHttpContent.cs
@@ -53,7 +53,7 @@ internal sealed class StreamCopyHttpContent : HttpContent
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
 
         _activityToken = activityToken;
-        _promisedContentLength = contentLength ?? -1;
+        _promisedContentLength = contentLength ?? StreamCopier.UnknownLength;
     }
 
     /// <summary>

--- a/src/ReverseProxy/Forwarder/StreamCopyHttpContent.cs
+++ b/src/ReverseProxy/Forwarder/StreamCopyHttpContent.cs
@@ -183,6 +183,7 @@ internal sealed class StreamCopyHttpContent : HttpContent
                 return;
             }
 
+            // Check that the content-length matches the request body size. This can be removed in .NET 7 now that SocketsHttpHandler enforces this: https://github.com/dotnet/runtime/issues/62258.
             var (result, error) = await StreamCopier.CopyAsync(isRequest: true, _source, stream, _promisedContentLength, _clock, _activityToken, cancellationToken);
             _tcs.TrySetResult((result, error));
 

--- a/src/ReverseProxy/Forwarder/StreamCopyHttpContent.cs
+++ b/src/ReverseProxy/Forwarder/StreamCopyHttpContent.cs
@@ -44,14 +44,16 @@ internal sealed class StreamCopyHttpContent : HttpContent
     private readonly ActivityCancellationTokenSource _activityToken;
     private readonly TaskCompletionSource<(StreamCopyResult, Exception?)> _tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private int _started;
+    private readonly long? _requiredContentLength;
 
-    public StreamCopyHttpContent(Stream source, bool autoFlushHttpClientOutgoingStream, IClock clock, ActivityCancellationTokenSource activityToken)
+    public StreamCopyHttpContent(Stream source, long? contentLength, bool autoFlushHttpClientOutgoingStream, IClock clock, ActivityCancellationTokenSource activityToken)
     {
         _source = source ?? throw new ArgumentNullException(nameof(source));
         _autoFlushHttpClientOutgoingStream = autoFlushHttpClientOutgoingStream;
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
 
         _activityToken = activityToken;
+        _requiredContentLength = contentLength;
     }
 
     /// <summary>
@@ -181,7 +183,7 @@ internal sealed class StreamCopyHttpContent : HttpContent
                 return;
             }
 
-            var (result, error) = await StreamCopier.CopyAsync(isRequest: true, _source, stream, _clock, _activityToken, cancellationToken);
+            var (result, error) = await StreamCopier.CopyAsync(isRequest: true, _source, stream, _requiredContentLength, _clock, _activityToken, cancellationToken);
             _tcs.TrySetResult((result, error));
 
             // Check for errors that weren't the result of the destination failing.

--- a/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
@@ -684,6 +684,7 @@ public class HttpForwarderTests
     [Theory]
     [InlineData(1, "")]
     [InlineData(1, "aa")]
+    [InlineData(2, "a")]
     public async Task RequestWithBodies_WrongContentLength(long contentLength, string body)
     {
         var events = TestEventListener.Collect();

--- a/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
@@ -56,8 +56,10 @@ public class HttpForwarderTests
         httpContext.Request.Headers.Add(":authority", "example.com:3456");
         httpContext.Request.Headers.Add("x-ms-request-test", "request");
         httpContext.Request.Headers.Add("Content-Language", "requestLanguage");
-        httpContext.Request.Headers.Add("Content-Length", "1");
-        httpContext.Request.Body = StringToStream("request content");
+
+        var requestBody = "request content";
+        httpContext.Request.Headers.Add("Content-Length", requestBody.Length.ToString());
+        httpContext.Request.Body = StringToStream(requestBody);
         httpContext.Connection.RemoteIpAddress = IPAddress.Loopback;
 
         var proxyResponseStream = new MemoryStream();
@@ -630,16 +632,16 @@ public class HttpForwarderTests
     }
 
     [Theory]
-    [InlineData("POST", "HTTP/2", "")]
-    [InlineData("PATCH", "HTTP/2", "")]
-    [InlineData("UNKNOWN", "HTTP/2", "")]
-    [InlineData("UNKNOWN", "HTTP/1.1", "Content-Length:10")]
-    [InlineData("UNKNOWN", "HTTP/1.1", "transfer-encoding:Chunked")]
-    [InlineData("GET", "HTTP/1.1", "Content-Length:10")]
-    [InlineData("GET", "HTTP/2", "Content-Length:10")]
-    [InlineData("HEAD", "HTTP/1.1", "transfer-encoding:Chunked")]
-    [InlineData("HEAD", "HTTP/2", "transfer-encoding:Chunked")]
-    public async Task RequestWithBodies_HasHttpContent(string method, string protocol, string headers)
+    [InlineData("POST", "HTTP/2", "", "")]
+    [InlineData("PATCH", "HTTP/2", "", "")]
+    [InlineData("UNKNOWN", "HTTP/2", "", "")]
+    [InlineData("UNKNOWN", "HTTP/1.1", "Content-Length:10", "aaaaaaaaaa")]
+    [InlineData("UNKNOWN", "HTTP/1.1", "transfer-encoding:Chunked", "")]
+    [InlineData("GET", "HTTP/1.1", "Content-Length:10", "aaaaaaaaaa")]
+    [InlineData("GET", "HTTP/2", "Content-Length:10", "aaaaaaaaaa")]
+    [InlineData("HEAD", "HTTP/1.1", "transfer-encoding:Chunked", "")]
+    [InlineData("HEAD", "HTTP/2", "transfer-encoding:Chunked", "")]
+    public async Task RequestWithBodies_HasHttpContent(string method, string protocol, string headers, string body)
     {
         var events = TestEventListener.Collect();
 
@@ -653,6 +655,7 @@ public class HttpForwarderTests
             var value = parts[1];
             httpContext.Request.Headers[key] = value;
         }
+        httpContext.Request.Body = StringToStream(body);
 
         var destinationPrefix = "https://localhost/";
         var sut = CreateProxy();
@@ -661,6 +664,86 @@ public class HttpForwarderTests
             {
                 Assert.Equal(new Version(2, 0), request.Version);
                 Assert.Equal(method, request.Method.Method, StringComparer.OrdinalIgnoreCase);
+
+                Assert.NotNull(request.Content);
+
+                // Must consume the body
+                await request.Content.CopyToWithCancellationAsync(Stream.Null);
+
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(Array.Empty<byte>()) };
+            });
+
+        await sut.SendAsync(httpContext, destinationPrefix, client);
+
+        Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
+
+        AssertProxyStartStop(events, destinationPrefix, httpContext.Response.StatusCode);
+        events.AssertContainProxyStages();
+    }
+
+    [Theory]
+    [InlineData(1, "")]
+    [InlineData(1, "aa")]
+    public async Task RequestWithBodies_WrongContentLength(long contentLength, string body)
+    {
+        var events = TestEventListener.Collect();
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Method = "POST";
+        httpContext.Request.ContentLength = contentLength;
+        httpContext.Request.Body = StringToStream(body);
+
+        var destinationPrefix = "https://localhost/";
+        var sut = CreateProxy();
+        var client = MockHttpHandler.CreateClient(
+            async (HttpRequestMessage request, CancellationToken cancellationToken) =>
+            {
+                Assert.Equal(new Version(2, 0), request.Version);
+
+                Assert.NotNull(request.Content);
+
+                // Must throw
+                try
+                {
+                    await request.Content.CopyToWithCancellationAsync(Stream.Null);
+                }
+                catch (HttpRequestException ex)
+                {
+                    Assert.Contains("Content-Length", ex.InnerException.InnerException.Message);
+                    throw ex;
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(Array.Empty<byte>()) };
+            });
+
+        var proxyError = await sut.SendAsync(httpContext, destinationPrefix, client);
+
+        Assert.Equal(ForwarderError.RequestBodyClient, proxyError);
+        Assert.Equal(StatusCodes.Status400BadRequest, httpContext.Response.StatusCode);
+        var errorFeature = httpContext.Features.Get<IForwarderErrorFeature>();
+        Assert.Equal(ForwarderError.RequestBodyClient, errorFeature.Error);
+        Assert.IsType<AggregateException>(errorFeature.Exception);
+
+        AssertProxyStartFailedStop(events, destinationPrefix, httpContext.Response.StatusCode, errorFeature.Error);
+        events.AssertContainProxyStages(new[] { ForwarderStage.SendAsyncStart, ForwarderStage.RequestContentTransferStart });
+    }
+
+    [Fact]
+    public async Task RequestWithBodies_WithoutContentLength()
+    {
+        var events = TestEventListener.Collect();
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Method = "POST";
+        httpContext.Request.Protocol = "HTTP/2";
+        httpContext.Request.Body = StringToStream("request content");
+
+        var destinationPrefix = "https://localhost/";
+        var sut = CreateProxy();
+        var client = MockHttpHandler.CreateClient(
+            async (HttpRequestMessage request, CancellationToken cancellationToken) =>
+            {
+                Assert.Equal(new Version(2, 0), request.Version);
 
                 Assert.NotNull(request.Content);
 
@@ -1102,7 +1185,7 @@ public class HttpForwarderTests
             memory.Span[0] = (byte)'a';
             return 1;
         });
-        httpContext.Request.ContentLength = 1;
+        httpContext.Request.ContentLength = expectedReads;
 
         var proxyResponseStream = new MemoryStream();
         httpContext.Response.Body = proxyResponseStream;

--- a/test/ReverseProxy.Tests/Forwarder/StreamCopierTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/StreamCopierTests.cs
@@ -104,7 +104,7 @@ public class StreamCopierTests : TestAutoMockBase
 
         using var cts = ActivityCancellationTokenSource.Rent(TimeSpan.FromSeconds(10), CancellationToken.None);
         cts.Cancel();
-        var (result, error) = await StreamCopier.CopyAsync(isRequest, source, destination, -1, new ManualClock(), cts, cts.Token);
+        var (result, error) = await StreamCopier.CopyAsync(isRequest, source, destination, StreamCopier.UnknownLength, new ManualClock(), cts, cts.Token);
         Assert.Equal(StreamCopyResult.Canceled, result);
         Assert.IsAssignableFrom<OperationCanceledException>(error);
 

--- a/test/ReverseProxy.Tests/Forwarder/StreamCopierTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/StreamCopierTests.cs
@@ -51,7 +51,7 @@ public class StreamCopierTests : TestAutoMockBase
         var destination = new MemoryStream();
 
         using var cts = ActivityCancellationTokenSource.Rent(TimeSpan.FromSeconds(10), CancellationToken.None);
-        var (result, error) = await StreamCopier.CopyAsync(isRequest, source, destination, UnknownLength, clock, cts, cts.Token);
+        var (result, error) = await StreamCopier.CopyAsync(isRequest, source, destination, StreamCopier.UnknownLength, clock, cts, cts.Token);
         Assert.Equal(StreamCopyResult.InputError, result);
         Assert.IsAssignableFrom<IOException>(error);
 

--- a/test/ReverseProxy.Tests/Forwarder/StreamCopierTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/StreamCopierTests.cs
@@ -51,7 +51,7 @@ public class StreamCopierTests : TestAutoMockBase
         var destination = new MemoryStream();
 
         using var cts = ActivityCancellationTokenSource.Rent(TimeSpan.FromSeconds(10), CancellationToken.None);
-        var (result, error) = await StreamCopier.CopyAsync(isRequest, source, destination, null, clock, cts, cts.Token);
+        var (result, error) = await StreamCopier.CopyAsync(isRequest, source, destination, -1, clock, cts, cts.Token);
         Assert.Equal(StreamCopyResult.InputError, result);
         Assert.IsAssignableFrom<IOException>(error);
 
@@ -104,7 +104,7 @@ public class StreamCopierTests : TestAutoMockBase
 
         using var cts = ActivityCancellationTokenSource.Rent(TimeSpan.FromSeconds(10), CancellationToken.None);
         cts.Cancel();
-        var (result, error) = await StreamCopier.CopyAsync(isRequest, source, destination, null, new ManualClock(), cts, cts.Token);
+        var (result, error) = await StreamCopier.CopyAsync(isRequest, source, destination, -1, new ManualClock(), cts, cts.Token);
         Assert.Equal(StreamCopyResult.Canceled, result);
         Assert.IsAssignableFrom<OperationCanceledException>(error);
 

--- a/test/ReverseProxy.Tests/Forwarder/StreamCopierTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/StreamCopierTests.cs
@@ -51,7 +51,7 @@ public class StreamCopierTests : TestAutoMockBase
         var destination = new MemoryStream();
 
         using var cts = ActivityCancellationTokenSource.Rent(TimeSpan.FromSeconds(10), CancellationToken.None);
-        var (result, error) = await StreamCopier.CopyAsync(isRequest, source, destination, -1, clock, cts, cts.Token);
+        var (result, error) = await StreamCopier.CopyAsync(isRequest, source, destination, UnknownLength, clock, cts, cts.Token);
         Assert.Equal(StreamCopyResult.InputError, result);
         Assert.IsAssignableFrom<IOException>(error);
 

--- a/test/ReverseProxy.Tests/Forwarder/StreamCopyHttpContentTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/StreamCopyHttpContentTests.cs
@@ -24,7 +24,7 @@ public class StreamCopyHttpContentTests
 
         contentCancellation ??= ActivityCancellationTokenSource.Rent(TimeSpan.FromSeconds(10), CancellationToken.None);
 
-        return new StreamCopyHttpContent(source, null, autoFlushHttpClientOutgoingStream, clock, contentCancellation);
+        return new StreamCopyHttpContent(source, autoFlushHttpClientOutgoingStream, clock, contentCancellation);
     }
 
     [Fact]

--- a/test/ReverseProxy.Tests/Forwarder/StreamCopyHttpContentTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/StreamCopyHttpContentTests.cs
@@ -24,7 +24,7 @@ public class StreamCopyHttpContentTests
 
         contentCancellation ??= ActivityCancellationTokenSource.Rent(TimeSpan.FromSeconds(10), CancellationToken.None);
 
-        return new StreamCopyHttpContent(source, autoFlushHttpClientOutgoingStream, clock, contentCancellation);
+        return new StreamCopyHttpContent(source, null, autoFlushHttpClientOutgoingStream, clock, contentCancellation);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #1412 

Throwing an exception when `Content-Length` is set but doesn't match with actual length in request. This allows to avoid unclear hangings as described in the issue above.