### PR TITLE
Make use of NonValidated headers

### DIFF
--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -522,15 +522,12 @@ internal sealed class HttpForwarder : IHttpForwarder
 
     private static void RestoreUpgradeHeaders(HttpContext context, HttpResponseMessage response)
     {
-        if (response.Headers.TryGetValues(HeaderNames.Connection, out var connectionValues)
-            && response.Headers.TryGetValues(HeaderNames.Upgrade, out var upgradeValues))
+        // We don't use RequestUtilities.TryGetValues for the Connection as we do want value validation.
+        // HttpHeaders.TryGetValues will handle the parsing and split the values for us.
+        if (RequestUtilities.TryGetValues(response.Headers, HeaderNames.Upgrade, out var upgradeValues)
+            && response.Headers.TryGetValues(HeaderNames.Connection, out var connectionValues))
         {
-            var upgradeStringValues = StringValues.Empty;
-            foreach (var value in upgradeValues)
-            {
-                upgradeStringValues = StringValues.Concat(upgradeStringValues, value);
-            }
-            context.Response.Headers.TryAdd(HeaderNames.Upgrade, upgradeStringValues);
+            context.Response.Headers.TryAdd(HeaderNames.Upgrade, upgradeValues);
 
             foreach (var value in connectionValues)
             {

--- a/src/ReverseProxy/Forwarder/HttpTransformer.cs
+++ b/src/ReverseProxy/Forwarder/HttpTransformer.cs
@@ -130,8 +130,8 @@ public class HttpTransformer
         // remove the received Content-Length field prior to forwarding such
         // a message downstream.
         if (proxyResponse.Content != null
-            && proxyResponse.Headers.TryGetValues(HeaderNames.TransferEncoding, out var _)
-            && proxyResponse.Content.Headers.TryGetValues(HeaderNames.ContentLength, out var _))
+            && RequestUtilities.ContainsHeader(proxyResponse.Headers, HeaderNames.TransferEncoding)
+            && RequestUtilities.ContainsHeader(proxyResponse.Content.Headers, HeaderNames.ContentLength))
         {
             httpContext.Response.Headers.Remove(HeaderNames.ContentLength);
         }
@@ -164,6 +164,20 @@ public class HttpTransformer
 
     private static void CopyResponseHeaders(HttpHeaders source, IHeaderDictionary destination)
     {
+        // We want to append to any prior values, if any.
+        // Not using Append here because it skips empty headers.
+#if NET6_0_OR_GREATER
+        foreach (var header in source.NonValidated)
+        {
+            var headerName = header.Key;
+            if (RequestUtilities.ShouldSkipResponseHeader(headerName))
+            {
+                continue;
+            }
+
+            destination[headerName] = RequestUtilities.Concat(destination[headerName], header.Value);
+        }
+#else
         foreach (var header in source)
         {
             var headerName = header.Key;
@@ -174,10 +188,8 @@ public class HttpTransformer
 
             Debug.Assert(header.Value is string[]);
             var values = header.Value as string[] ?? header.Value.ToArray();
-            // We want to append to any prior values, if any.
-            // Not using Append here because it skips empty headers.
-            values = StringValues.Concat(destination[headerName], values);
-            destination[headerName] = values;
+            destination[headerName] = StringValues.Concat(destination[headerName], values);
         }
+#endif
     }
 }

--- a/src/ReverseProxy/Forwarder/RequestUtilities.cs
+++ b/src/ReverseProxy/Forwarder/RequestUtilities.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.AspNetCore.Http;
@@ -343,5 +344,96 @@ public static class RequestUtilities
         {
             request.Headers.Remove(headerName);
         }
+    }
+
+#if NET6_0_OR_GREATER
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static StringValues Concat(in StringValues existing, in HeaderStringValues values)
+    {
+        if (values.Count <= 1)
+        {
+            return StringValues.Concat(existing, values.ToString());
+        }
+        else
+        {
+            return ConcatSlow(existing, values);
+        }
+
+        static StringValues ConcatSlow(in StringValues existing, in HeaderStringValues values)
+        {
+            Debug.Assert(values.Count > 1);
+
+            var count = existing.Count;
+            var newArray = new string[count + values.Count];
+
+            if (count == 1)
+            {
+                newArray[0] = existing.ToString();
+            }
+            else
+            {
+                existing.ToArray().CopyTo(newArray, 0);
+            }
+
+            foreach (var value in values)
+            {
+                newArray[count++] = value;
+            }
+            Debug.Assert(count == newArray.Length);
+
+            return newArray;
+        }
+    }
+#endif
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool TryGetValues(HttpHeaders headers, string headerName, out StringValues values)
+    {
+#if NET6_0_OR_GREATER
+        if (headers.NonValidated.TryGetValues(headerName, out var headerStringValues))
+        {
+            if (headerStringValues.Count <= 1)
+            {
+                values = headerStringValues.ToString();
+            }
+            else
+            {
+                values = ToArray(headerStringValues);
+            }
+            return true;
+        }
+
+        static StringValues ToArray(in HeaderStringValues values)
+        {
+            var array = new string[values.Count];
+            var i = 0;
+            foreach (var value in values)
+            {
+                array[i++] = value;
+            }
+            Debug.Assert(i == array.Length);
+            return array;
+        }
+#else
+        if (headers.TryGetValues(headerName, out var headerValues))
+        {
+            Debug.Assert(headerValues is string[]);
+            values = headerValues as string[] ?? headerValues.ToArray();
+            return true;
+        }
+#endif
+
+        values = default;
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool ContainsHeader(HttpHeaders headers, string headerName)
+    {
+#if NET6_0_OR_GREATER
+        return headers.NonValidated.Contains(headerName);
+#else
+        return headers.TryGetValues(headerName, out _);
+#endif
     }
 }

--- a/src/ReverseProxy/Transforms/QueryParameterRemoveTransform.cs
+++ b/src/ReverseProxy/Transforms/QueryParameterRemoveTransform.cs
@@ -28,7 +28,7 @@ public class QueryParameterRemoveTransform : RequestTransform
     {
         if (context == null)
         {
-            throw new System.ArgumentNullException(nameof(context));
+            throw new ArgumentNullException(nameof(context));
         }
 
         context.Query.Collection.Remove(Key);

--- a/src/ReverseProxy/Transforms/RequestHeaderValueTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderValueTransform.cs
@@ -38,16 +38,16 @@ public class RequestHeaderValueTransform : RequestTransform
             throw new ArgumentNullException(nameof(context));
         }
 
-        var existingValues = TakeHeader(context, HeaderName);
-
         if (Append)
         {
+            var existingValues = TakeHeader(context, HeaderName);
             var values = StringValues.Concat(existingValues, Value);
             AddHeader(context, HeaderName, values);
         }
         else
         {
             // Set
+            RemoveHeader(context, HeaderName);
             AddHeader(context, HeaderName, Value);
         }
 

--- a/src/ReverseProxy/Transforms/ResponseHeaderValueTransform.cs
+++ b/src/ReverseProxy/Transforms/ResponseHeaderValueTransform.cs
@@ -45,9 +45,9 @@ public class ResponseHeaderValueTransform : ResponseTransform
         if (Condition == ResponseCondition.Always
             || Success(context) == (Condition == ResponseCondition.Success))
         {
-            var existingHeader = TakeHeader(context, HeaderName);
             if (Append)
             {
+                var existingHeader = TakeHeader(context, HeaderName);
                 var value = StringValues.Concat(existingHeader, Value);
                 SetHeader(context, HeaderName, value);
             }

--- a/src/ReverseProxy/Transforms/ResponseHeadersAllowedTransform.cs
+++ b/src/ReverseProxy/Transforms/ResponseHeadersAllowedTransform.cs
@@ -9,6 +9,7 @@ using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
+using Yarp.ReverseProxy.Forwarder;
 
 namespace Yarp.ReverseProxy.Transforms;
 
@@ -60,17 +61,33 @@ public class ResponseHeadersAllowedTransform : ResponseTransform
         return default;
     }
 
-    // See https://github.com/microsoft/reverse-proxy/blob/51d797986b1fea03500a1ad173d13a1176fb5552/src/ReverseProxy/Forwarder/HttpTransformer.cs#L102-L115
+    // See https://github.com/microsoft/reverse-proxy/blob/main/src/ReverseProxy/Forwarder/HttpTransformer.cs#:~:text=void-,CopyResponseHeaders
     private void CopyResponseHeaders(HttpHeaders source, IHeaderDictionary destination)
     {
+#if NET6_0_OR_GREATER
+        foreach (var header in source.NonValidated)
+        {
+            var headerName = header.Key;
+            if (!AllowedHeadersSet.Contains(headerName))
+            {
+                continue;
+            }
+
+            destination[headerName] = RequestUtilities.Concat(destination[headerName], header.Value);
+        }
+#else
         foreach (var header in source)
         {
             var headerName = header.Key;
-            if (AllowedHeadersSet.Contains(headerName))
+            if (!AllowedHeadersSet.Contains(headerName))
             {
-                Debug.Assert(header.Value is string[]);
-                destination.Append(headerName, header.Value as string[] ?? header.Value.ToArray());
+                continue;
             }
+
+            Debug.Assert(header.Value is string[]);
+            var values = header.Value as string[] ?? header.Value.ToArray();
+            destination[headerName] = StringValues.Concat(destination[headerName], values);
         }
+#endif
     }
 }

--- a/src/ReverseProxy/Transforms/ResponseTrailerValueTransform.cs
+++ b/src/ReverseProxy/Transforms/ResponseTrailerValueTransform.cs
@@ -45,9 +45,9 @@ public class ResponseTrailerValueTransform : ResponseTrailersTransform
         if (Condition == ResponseCondition.Always
             || Success(context) == (Condition == ResponseCondition.Success))
         {
-            var existingHeader = TakeHeader(context, HeaderName);
             if (Append)
             {
+                var existingHeader = TakeHeader(context, HeaderName);
                 var value = StringValues.Concat(existingHeader, Value);
                 SetHeader(context, HeaderName, value);
             }


### PR DESCRIPTION
Closes #1347
Memory-wise, we go from 64 objects to 38 (-41%), or 4366 B to 3180 (-27%) per request.

RPS-wise, this change is a win of ~5-6% on citrine and ~7% on perf machines. Closes #1083

Before:
![image](https://user-images.githubusercontent.com/25307628/148824482-4677df7d-65cf-43c7-8908-40a682256e5b.png)

After:
![image](https://user-images.githubusercontent.com/25307628/148824524-d64a0a56-5849-4331-8062-c93fae7f768a.png)

We save 26 objects:
- 8x `string`
- 5x `string[]`
- 4x `HeaderStoreItemInfo`
- 4x (`MediaType`/`NameValue`/`Product`/`ProductInfo`)`HeaderValue`
- 2x `HttpHeadersEnumerator`
- 1x `ObjectCollection`
- 1x `Uri`
- 1x `DateTimeOffset` (box)