### PR TITLE
Avoid boxing ILIst enumerators per request

### DIFF
--- a/src/ReverseProxy/Transforms/Builder/StructuredTransformer.cs
+++ b/src/ReverseProxy/Transforms/Builder/StructuredTransformer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -27,9 +28,9 @@ internal sealed class StructuredTransformer : HttpTransformer
         ShouldCopyRequestHeaders = copyRequestHeaders;
         ShouldCopyResponseHeaders = copyResponseHeaders;
         ShouldCopyResponseTrailers = copyResponseTrailers;
-        RequestTransforms = requestTransforms ?? throw new ArgumentNullException(nameof(requestTransforms));
-        ResponseTransforms = responseTransforms ?? throw new ArgumentNullException(nameof(responseTransforms));
-        ResponseTrailerTransforms = responseTrailerTransforms ?? throw new ArgumentNullException(nameof(responseTrailerTransforms));
+        RequestTransforms = requestTransforms?.ToArray() ?? throw new ArgumentNullException(nameof(requestTransforms));
+        ResponseTransforms = responseTransforms?.ToArray() ?? throw new ArgumentNullException(nameof(responseTransforms));
+        ResponseTrailerTransforms = responseTrailerTransforms?.ToArray() ?? throw new ArgumentNullException(nameof(responseTrailerTransforms));
     }
 
     /// <summary>
@@ -50,17 +51,17 @@ internal sealed class StructuredTransformer : HttpTransformer
     /// <summary>
     /// Request transforms.
     /// </summary>
-    internal IList<RequestTransform> RequestTransforms { get; }
+    internal RequestTransform[] RequestTransforms { get; }
 
     /// <summary>
     /// Response header transforms.
     /// </summary>
-    internal IList<ResponseTransform> ResponseTransforms { get; }
+    internal ResponseTransform[] ResponseTransforms { get; }
 
     /// <summary>
     /// Response trailer transforms.
     /// </summary>
-    internal IList<ResponseTrailersTransform> ResponseTrailerTransforms { get; }
+    internal ResponseTrailersTransform[] ResponseTrailerTransforms { get; }
 
     public override async ValueTask TransformRequestAsync(HttpContext httpContext, HttpRequestMessage proxyRequest, string destinationPrefix)
     {
@@ -69,7 +70,7 @@ internal sealed class StructuredTransformer : HttpTransformer
             await base.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix);
         }
 
-        if (RequestTransforms.Count == 0)
+        if (RequestTransforms.Length == 0)
         {
             return;
         }
@@ -101,7 +102,7 @@ internal sealed class StructuredTransformer : HttpTransformer
             await base.TransformResponseAsync(httpContext, proxyResponse);
         }
 
-        if (ResponseTransforms.Count == 0)
+        if (ResponseTransforms.Length == 0)
         {
             return true;
         }
@@ -128,7 +129,7 @@ internal sealed class StructuredTransformer : HttpTransformer
             await base.TransformResponseTrailersAsync(httpContext, proxyResponse);
         }
 
-        if (ResponseTrailerTransforms.Count == 0)
+        if (ResponseTrailerTransforms.Length == 0)
         {
             return;
         }

--- a/test/ReverseProxy.Tests/Transforms/Builder/TransformBuilderTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/Builder/TransformBuilderTests.cs
@@ -51,7 +51,7 @@ public class TransformBuilderTests
         Assert.Empty(results.ResponseTransforms);
         Assert.Empty(results.ResponseTrailerTransforms);
 
-        Assert.Equal(6, results.RequestTransforms.Count);
+        Assert.Equal(6, results.RequestTransforms.Length);
         var hostTransform = Assert.Single(results.RequestTransforms.OfType<RequestHeaderOriginalHostTransform>());
         Assert.False(hostTransform.UseOriginalHost);
         var forTransform = Assert.Single(results.RequestTransforms.OfType<RequestHeaderXForwardedForTransform>());
@@ -94,7 +94,7 @@ public class TransformBuilderTests
         Assert.Empty(results.ResponseTransforms);
         Assert.Empty(results.ResponseTrailerTransforms);
 
-        Assert.Equal(6, results.RequestTransforms.Count);
+        Assert.Equal(6, results.RequestTransforms.Length);
         var hostTransform = Assert.Single(results.RequestTransforms.OfType<RequestHeaderOriginalHostTransform>());
         Assert.False(hostTransform.UseOriginalHost);
         var forTransform = Assert.Single(results.RequestTransforms.OfType<RequestHeaderXForwardedForTransform>());
@@ -212,7 +212,7 @@ public class TransformBuilderTests
         Assert.Equal(1, provider2.ApplyCalls);
         Assert.Equal(1, provider3.ApplyCalls);
 
-        Assert.Equal(3, transforms.ResponseTrailerTransforms.Count);
+        Assert.Equal(3, transforms.ResponseTrailerTransforms.Length);
     }
 
     [Fact]
@@ -400,7 +400,7 @@ public class TransformBuilderTests
         Assert.Empty(errors);
 
         var results = transformBuilder.BuildInternal(route, new ClusterConfig());
-        Assert.Equal(5, results.RequestTransforms.Count);
+        Assert.Equal(5, results.RequestTransforms.Length);
         Assert.All(
             results.RequestTransforms.Skip(1).Select(t => (dynamic)t),
             t =>


### PR DESCRIPTION
We're storing the transforms as `IList`s, which means every `foreach` over them allocates (enumerator gets boxed).
These are internal, so we can just avoid the overhead by storing an array instead.