### PR TITLE
Add support for Route Metadata in Kubernetes via annotations

### DIFF
--- a/src/Kubernetes.Controller/Converters/YarpIngressOptions.cs
+++ b/src/Kubernetes.Controller/Converters/YarpIngressOptions.cs
@@ -16,5 +16,5 @@ internal sealed class YarpIngressOptions
     public string LoadBalancingPolicy { get; set; }
     public string CorsPolicy { get; set; }
     public HealthCheckConfig HealthCheck { get; set; }
-    public Dictionary<string, string> Metadata { get; set; }
+    public Dictionary<string, string> RouteMetadata { get; set; }
 }

--- a/src/Kubernetes.Controller/Converters/YarpIngressOptions.cs
+++ b/src/Kubernetes.Controller/Converters/YarpIngressOptions.cs
@@ -16,4 +16,5 @@ internal sealed class YarpIngressOptions
     public string LoadBalancingPolicy { get; set; }
     public string CorsPolicy { get; set; }
     public HealthCheckConfig HealthCheck { get; set; }
+    public Dictionary<string, string> Metadata { get; set; }
 }

--- a/src/Kubernetes.Controller/Converters/YarpParser.cs
+++ b/src/Kubernetes.Controller/Converters/YarpParser.cs
@@ -98,6 +98,7 @@ internal static class YarpParser
                     Transforms = ingressContext.Options.Transforms,
                     AuthorizationPolicy = ingressContext.Options.AuthorizationPolicy,
                     CorsPolicy = ingressContext.Options.CorsPolicy,
+                    Metadata = ingressContext.Options.Metadata,
                 });
 
                 // Add destination for every endpoint address
@@ -192,6 +193,10 @@ internal static class YarpParser
         if (annotations.TryGetValue("yarp.ingress.kubernetes.io/health-check", out var healthCheck))
         {
             options.HealthCheck = YamlDeserializer.Deserialize<HealthCheckConfig>(healthCheck);
+        }
+        if (annotations.TryGetValue("yarp.ingress.kubernetes.io/metadata", out var routeMetadata))
+        {
+            options.Metadata = YamlDeserializer.Deserialize<Dictionary<string, string>>(routeMetadata);
         }
 
         // metadata to support:

--- a/src/Kubernetes.Controller/Converters/YarpParser.cs
+++ b/src/Kubernetes.Controller/Converters/YarpParser.cs
@@ -98,7 +98,7 @@ internal static class YarpParser
                     Transforms = ingressContext.Options.Transforms,
                     AuthorizationPolicy = ingressContext.Options.AuthorizationPolicy,
                     CorsPolicy = ingressContext.Options.CorsPolicy,
-                    Metadata = ingressContext.Options.Metadata,
+                    Metadata = ingressContext.Options.RouteMetadata,
                 });
 
                 // Add destination for every endpoint address
@@ -194,9 +194,9 @@ internal static class YarpParser
         {
             options.HealthCheck = YamlDeserializer.Deserialize<HealthCheckConfig>(healthCheck);
         }
-        if (annotations.TryGetValue("yarp.ingress.kubernetes.io/metadata", out var routeMetadata))
+        if (annotations.TryGetValue("yarp.ingress.kubernetes.io/route-metadata", out var routeMetadata))
         {
-            options.Metadata = YamlDeserializer.Deserialize<Dictionary<string, string>>(routeMetadata);
+            options.RouteMetadata = YamlDeserializer.Deserialize<Dictionary<string, string>>(routeMetadata);
         }
 
         // metadata to support:

--- a/test/Kubernetes.Tests/IngressConversionTests.cs
+++ b/test/Kubernetes.Tests/IngressConversionTests.cs
@@ -20,7 +20,6 @@ using Xunit;
 using Yarp.Kubernetes.Controller.Caching;
 using Yarp.Kubernetes.Controller.Converters;
 using Yarp.Kubernetes.Controller.Services;
-using JsonConverter = Newtonsoft.Json.JsonConverter;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace IngressController.Tests;
@@ -46,6 +45,7 @@ public class IngressControllerTests
     [InlineData("multiple-ingresses")]
     [InlineData("multiple-ingresses-one-svc")]
     [InlineData("multiple-namespaces")]
+    [InlineData("route-metadata")]
     public async Task ParsingTests(string name)
     {
         var cache = await GetKubernetesInfo(name).ConfigureAwait(false);

--- a/test/Kubernetes.Tests/testassets/route-metadata/clusters.json
+++ b/test/Kubernetes.Tests/testassets/route-metadata/clusters.json
@@ -1,0 +1,18 @@
+[
+  {
+    "ClusterId": "frontend.default:80",
+    "LoadBalancingPolicy": null,
+    "SessionAffinity": null,
+    "HealthCheck": null,
+    "HttpClient": null,
+    "HttpRequest": null,
+    "Destinations": {
+      "http://10.244.2.38:80": {
+        "Address": "http://10.244.2.38:80",
+        "Health": null,
+        "Metadata": null
+      }
+    },
+    "Metadata": null
+  }
+]

--- a/test/Kubernetes.Tests/testassets/route-metadata/ingress.yaml
+++ b/test/Kubernetes.Tests/testassets/route-metadata/ingress.yaml
@@ -1,0 +1,47 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minimal-ingress
+  namespace: default
+  annotations:
+    yarp.ingress.kubernetes.io/metadata: |
+      foo: bar
+      another-key: another-value
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /foo
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend
+            port:
+              number: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: default
+spec:
+  selector:
+    app: frontend
+  ports:
+  - name: https
+    port: 80
+    targetPort: 80
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: frontend
+  namespace: default
+subsets:
+  - addresses:
+    - ip: 10.244.2.38
+    ports:
+    - name: https
+      port: 80
+      protocol: TCP

--- a/test/Kubernetes.Tests/testassets/route-metadata/ingress.yaml
+++ b/test/Kubernetes.Tests/testassets/route-metadata/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: minimal-ingress
   namespace: default
   annotations:
-    yarp.ingress.kubernetes.io/metadata: |
+    yarp.ingress.kubernetes.io/route-metadata: |
       foo: bar
       another-key: another-value
 spec:

--- a/test/Kubernetes.Tests/testassets/route-metadata/routes.json
+++ b/test/Kubernetes.Tests/testassets/route-metadata/routes.json
@@ -1,0 +1,21 @@
+[
+  {
+    "RouteId": "minimal-ingress.default:/foo",
+    "Match": {
+      "Methods": null,
+      "Hosts": [],
+      "Path": "/foo/{**catch-all}",
+      "Headers": null,
+      "QueryParameters": null
+    },
+    "Order": null,
+    "ClusterId": "frontend.default:80",
+    "AuthorizationPolicy": null,
+    "CorsPolicy": null,
+    "Metadata": {
+      "foo": "bar",
+      "another-key": "another-value"
+    },
+    "Transforms": null
+  }
+]


### PR DESCRIPTION
Add support for Route Metadata in Kubernetes via annotations #1479.

A change similar to #1263.