### PR TITLE
Handle distributed context headers in custom propagator

### DIFF
--- a/docs/docfx/articles/direct-forwarding.md
+++ b/docs/docfx/articles/direct-forwarding.md
@@ -53,7 +53,7 @@ public void Configure(IApplicationBuilder app, IHttpForwarder forwarder)
         UseProxy = false,
         AllowAutoRedirect = false,
         AutomaticDecompression = DecompressionMethods.None,
-        UseCookies = false
+        UseCookies = false,
         ActivityHeadersPropagator = new ReverseProxyPropagator(DistributedContextPropagator.Current)
     });
     var transformer = new CustomTransformer(); // or HttpTransformer.Default;

--- a/docs/docfx/articles/direct-forwarding.md
+++ b/docs/docfx/articles/direct-forwarding.md
@@ -54,6 +54,7 @@ public void Configure(IApplicationBuilder app, IHttpForwarder forwarder)
         AllowAutoRedirect = false,
         AutomaticDecompression = DecompressionMethods.None,
         UseCookies = false
+        ActivityHeadersPropagator = new ReverseProxyPropagator(DistributedContextPropagator.Current)
     });
     var transformer = new CustomTransformer(); // or HttpTransformer.Default;
     var requestConfig = new ForwarderRequestConfig { ActivityTimeout = TimeSpan.FromSeconds(100) };

--- a/docs/docfx/articles/direct-forwarding.md
+++ b/docs/docfx/articles/direct-forwarding.md
@@ -65,11 +65,11 @@ public void Configure(IApplicationBuilder app, IHttpForwarder forwarder)
         endpoints.Map("/{**catch-all}", async httpContext =>
         {
             var error = await forwarder.SendAsync(httpContext, "https://localhost:10000/",
-                httpClient, requestOptions, transformer);
+                httpClient, requestConfig, transformer);
             // Check if the operation was successful
             if (error != ForwarderError.None)
             {
-                var errorFeature = httpContext.Features.Get<IForwarderErrorFeature>();
+                var errorFeature = httpContext.GetForwarderErrorFeature();
                 var exception = errorFeature.Exception;
             }
         });

--- a/docs/docfx/articles/header-guidelines.md
+++ b/docs/docfx/articles/header-guidelines.md
@@ -37,7 +37,10 @@ This response header is used with HTTP/3 upgrades and only applies to the immedi
 
 ### TraceParent, Request-Id, TraceState, Baggage, Correlation-Context
 
-These headers relate to distributed tracing. They are automatically removed on .NET 6 or later so that the forwarding HttpClient can replace them with updated values.
+These headers relate to distributed tracing. They are automatically removed on .NET 6 or later so that the forwarding HttpClient can replace them with updated values. You can turn header removal off by calling:
+```C#
+.ConfigureHttpHandler((_, handler) => handler.ActivityHeadersPropagator = null)
+```
 
 ## Other Header Guidelines
 

--- a/docs/docfx/articles/header-guidelines.md
+++ b/docs/docfx/articles/header-guidelines.md
@@ -37,9 +37,11 @@ This response header is used with HTTP/3 upgrades and only applies to the immedi
 
 ### TraceParent, Request-Id, TraceState, Baggage, Correlation-Context
 
-These headers relate to distributed tracing. They are automatically removed on .NET 6 or later so that the forwarding HttpClient can replace them with updated values. You can turn header removal off by calling:
+These headers relate to distributed tracing. They are automatically removed on .NET 6 or later so that the forwarding HttpClient can replace them with updated values.
+You can opt out of modifying these headers by setting `SocketsHttpHandler.ActivityHeadersPropagator ` to `null`:
 ```C#
-.ConfigureHttpHandler((_, handler) => handler.ActivityHeadersPropagator = null)
+services.AddReverseProxy()
+    .ConfigureHttpClient((_, handler) => handler.ActivityHeadersPropagator = null);
 ```
 
 ## Other Header Guidelines

--- a/samples/ReverseProxy.Direct.Sample/Startup.cs
+++ b/samples/ReverseProxy.Direct.Sample/Startup.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -38,7 +39,10 @@ namespace Yarp.Sample
                 UseProxy = false,
                 AllowAutoRedirect = false,
                 AutomaticDecompression = DecompressionMethods.None,
-                UseCookies = false
+                UseCookies = false,
+#if NET6_0_OR_GREATER
+                ActivityHeadersPropagator = new ReverseProxyPropagator(DistributedContextPropagator.Current)
+#endif
             });
 
             // Setup our own request transform class

--- a/src/ReverseProxy/Forwarder/ForwarderHttpClientFactory.cs
+++ b/src/ReverseProxy/Forwarder/ForwarderHttpClientFactory.cs
@@ -71,15 +71,6 @@ public class ForwarderHttpClientFactory : IForwarderHttpClientFactory
     {
         return context.OldClient != null && context.NewConfig == context.OldConfig;
     }
-#if NET6_0_OR_GREATER
-    /// <summary>
-    /// Wraps custom propagator and keeps header removal logic by default.
-    /// </summary>
-    protected virtual DistributedContextPropagator? Propagator
-    {
-        get => new ReverseProxyPropagator(DistributedContextPropagator.CreateDefaultPropagator());
-    }
-#endif
 
     /// <summary>
     /// Allows configuring the <see cref="SocketsHttpHandler"/> instance. The base implementation

--- a/src/ReverseProxy/Forwarder/ForwarderHttpClientFactory.cs
+++ b/src/ReverseProxy/Forwarder/ForwarderHttpClientFactory.cs
@@ -48,7 +48,7 @@ public class ForwarderHttpClientFactory : IForwarderHttpClientFactory
             AutomaticDecompression = DecompressionMethods.None,
             UseCookies = false,
 #if NET6_0_OR_GREATER
-            ActivityHeadersPropagator = Propagator
+            ActivityHeadersPropagator = new ReverseProxyPropagator(DistributedContextPropagator.Current)
 #endif
 
             // NOTE: MaxResponseHeadersLength = 64, which means up to 64 KB of headers are allowed by default as of .NET Core 3.1.

--- a/src/ReverseProxy/Forwarder/RequestUtilities.cs
+++ b/src/ReverseProxy/Forwarder/RequestUtilities.cs
@@ -83,15 +83,6 @@ public static class RequestUtilities
 #else
         "Alt-Svc",
 #endif
-
-#if NET6_0_OR_GREATER
-        // Distributed context headers
-        HeaderNames.TraceParent,
-        HeaderNames.RequestId,
-        HeaderNames.TraceState,
-        HeaderNames.Baggage,
-        HeaderNames.CorrelationContext,
-#endif
     };
 
     // Headers marked as HttpHeaderType.Content in

--- a/src/ReverseProxy/Forwarder/ReverseProxyPropagator.cs
+++ b/src/ReverseProxy/Forwarder/ReverseProxyPropagator.cs
@@ -10,11 +10,17 @@ using System.Net.Http;
 
 namespace Yarp.ReverseProxy.Forwarder;
 
+/// <summary>
+/// A default propagator that removes headers.
+/// </summary>
 public sealed class ReverseProxyPropagator : DistributedContextPropagator
 {
     private readonly DistributedContextPropagator _innerPropagator;
     private readonly string[] _headersToRemove;
 
+    /// <summary>
+    /// ReverseProxyPropagator removes headers pointed out in innerPropagator.
+    /// </summary>
     public ReverseProxyPropagator(DistributedContextPropagator innerPropagator)
     {
         _innerPropagator = innerPropagator ?? throw new ArgumentNullException(nameof(innerPropagator));

--- a/src/ReverseProxy/Forwarder/ReverseProxyPropagator.cs
+++ b/src/ReverseProxy/Forwarder/ReverseProxyPropagator.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+
+namespace Yarp.ReverseProxy.Forwarder;
+
+public sealed class ReverseProxyPropagator : DistributedContextPropagator
+{
+    private readonly DistributedContextPropagator _innerPropagator;
+    private readonly string[] _headersToRemove;
+
+    public ReverseProxyPropagator(DistributedContextPropagator innerPropagator)
+    {
+        _innerPropagator = innerPropagator ?? throw new ArgumentNullException(nameof(innerPropagator));
+        _headersToRemove = _innerPropagator.Fields.ToArray();
+    }
+
+    public override void Inject(Activity? activity, object? carrier, PropagatorSetterCallback? setter)
+    {
+        if (carrier is HttpRequestMessage message)
+        {
+            var headers = message.Headers;
+
+            foreach (var header in _headersToRemove)
+            {
+                headers.Remove(header);
+            }
+        }
+
+        _innerPropagator.Inject(activity, carrier, setter);
+    }
+
+    public override void ExtractTraceIdAndState(object? carrier, PropagatorGetterCallback? getter, out string? traceId, out string? traceState) =>
+        _innerPropagator.ExtractTraceIdAndState(carrier, getter, out traceId, out traceState);
+
+    public override IEnumerable<KeyValuePair<string, string?>>? ExtractBaggage(object? carrier, PropagatorGetterCallback? getter) =>
+        _innerPropagator.ExtractBaggage(carrier, getter);
+
+    public override IReadOnlyCollection<string> Fields => _innerPropagator.Fields;
+}
+#endif

--- a/src/ReverseProxy/Forwarder/ReverseProxyPropagator.cs
+++ b/src/ReverseProxy/Forwarder/ReverseProxyPropagator.cs
@@ -11,7 +11,7 @@ using System.Net.Http;
 namespace Yarp.ReverseProxy.Forwarder;
 
 /// <summary>
-/// A default propagator that removes headers.
+/// Removes existing headers and then delegates to the inner propagator.
 /// </summary>
 public sealed class ReverseProxyPropagator : DistributedContextPropagator
 {

--- a/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
@@ -2432,13 +2432,6 @@ public class HttpForwarderTests
             "HTTP2-Settings: value",
             "Upgrade-Insecure-Requests: value",
             "Alt-Svc: value",
-#if NET6_0_OR_GREATER
-            "traceparent: value",
-            "Request-Id: value",
-            "tracestate: value",
-            "baggage: value",
-            "Correlation-Context: value",
-#endif
         };
 
         foreach (var header in headers)

--- a/test/ReverseProxy.Tests/Forwarder/HttpTransformerTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/HttpTransformerTests.cs
@@ -36,13 +36,6 @@ public class HttpTransformerTests
 #else
         "Alt-Svc",
 #endif
-#if NET6_0_OR_GREATER
-        HeaderNames.TraceParent,
-        HeaderNames.RequestId,
-        HeaderNames.TraceState,
-        HeaderNames.Baggage,
-        HeaderNames.CorrelationContext,
-#endif
     };
 
     [Fact]


### PR DESCRIPTION
Resolves #1497 

Added `ReverseProxyPropagator` that handles headers removal. Default inner implementation removes distributed context headers. It can be changed by overriding `Propagator` property in `ForwarderHttpClientFactory` which is used to set up `handler.ActivityHeadersPropagator`. 