### PR TITLE
Support multiple configuration sources

### DIFF
--- a/docs/docfx/articles/config-files.md
+++ b/docs/docfx/articles/config-files.md
@@ -37,6 +37,22 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 } 
 ```
 
+## Multiple Configuration Sources
+As of 1.1, YARP supports loading the proxy configuration from multiple sources. LoadFromConfig may be called multiple times referencing different IConfiguration sections or may be combine with a different config source like InMemory. Routes can reference clusters from other sources. Note merging partial config from different sources for a given route or cluster is not supported.
+
+```
+    services.AddReverseProxy()
+        .LoadFromConfig(Configuration.GetSection("ReverseProxy1"))
+        .LoadFromConfig(Configuration.GetSection("ReverseProxy2"));
+```
+or
+```
+
+    services.AddReverseProxy()
+        .LoadFromMemory(routes, clusters)
+        .LoadFromConfig(Configuration.GetSection("ReverseProxy"));
+```
+
 ## Configuration contract
 File-based configuration is dynamically mapped to the types in [Yarp.ReverseProxy.Configuration](xref:Yarp.ReverseProxy.Configuration) namespace by an [IProxyConfigProvider](xref:Yarp.ReverseProxy.Configuration.IProxyConfigProvider) implementation converts at application start and each time the configuration changes.
 

--- a/docs/docfx/articles/config-providers.md
+++ b/docs/docfx/articles/config-providers.md
@@ -40,7 +40,7 @@ The proxy will validate the given configuration and if it's invalid, an exceptio
 The configuration objects and collections supplied to the proxy should be read-only and not modified once they have been handed to the proxy via `GetConfig()`. 
 
 ### Reload
-If the `IChangeToken` supports `ActiveChangeCallbacks`, once the proxy has processed the initial set of configuration it will register a callback with this token. Note the proxy does not support polling for changes.
+If the `IChangeToken` supports `ActiveChangeCallbacks`, once the proxy has processed the initial set of configuration it will register a callback with this token. If the provider does not support callbacks then `HasChanged` will be polled every 5 minutes.
 
 When the provider wants to provide new configuration to the proxy it should:
 - load that configuration in the background. 

--- a/docs/docfx/articles/config-providers.md
+++ b/docs/docfx/articles/config-providers.md
@@ -55,6 +55,23 @@ There are important differences when reloading configuration vs the first config
 
 Once the new configuration has been validated and applied, the proxy will register a callback with the new `IChangeToken`. Note if there are multiple reloads signaled in close succession, the proxy may skip some and load the next available configuration as soon as it's ready. Each `IProxyConfig` contains the full configuration state so nothing will be lost.
 
+## Multiple Configuration Sources
+As of 1.1, YARP supports loading the proxy configuration from multiple sources. Multiple `IProxyConfigProvider`'s can be registered as singleton services and all will be resolved and combine. The sources may be the same or different types such as IConfiguration or InMemory. Routes can reference clusters from other sources. Note merging partial config from different sources for a given route or cluster is not supported.
+
+```
+    services.AddReverseProxy()
+        .LoadFromConfig(Configuration.GetSection("ReverseProxy1"))
+        .LoadFromConfig(Configuration.GetSection("ReverseProxy2"));
+```
+or
+```
+
+    services.AddReverseProxy()
+        .LoadFromMemory(routes, clusters)
+        .LoadFromConfig(Configuration.GetSection("ReverseProxy"));
+```
+
+
 ## Example
 The following is an example `IProxyConfigProvider` that has routes and clusters manually loaded into it.
 

--- a/src/ReverseProxy/Configuration/IProxyConfig.cs
+++ b/src/ReverseProxy/Configuration/IProxyConfig.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Primitives;
 namespace Yarp.ReverseProxy.Configuration;
 
 /// <summary>
-/// Represents a snapshot of proxy configuration data.
+/// Represents a snapshot of proxy configuration data. These properties may be accessed multiple times and should not be modified.
 /// </summary>
 public interface IProxyConfig
 {

--- a/test/ReverseProxy.Tests/Management/ProxyConfigManagerTests.cs
+++ b/test/ReverseProxy.Tests/Management/ProxyConfigManagerTests.cs
@@ -26,10 +26,6 @@ using Yarp.ReverseProxy.Routing;
 
 namespace Yarp.ReverseProxy.Management.Tests;
 
-// TODO:
-// Two sources with errors in one.
-// Two sources with errors in both.
-// Duplicate route/cluster id across configs
 // Active source changes
 // Polling, passive source changes
 // Reload errors
@@ -222,7 +218,8 @@ public class ProxyConfigManagerTests
         var endpoints = dataSource.Endpoints;
         Assert.Equal(2, endpoints.Count);
 
-        var routeConfig = endpoints[0].Metadata.GetMetadata<RouteModel>();
+        // The order is unstable because routes are stored in a dictionary.
+        var routeConfig = endpoints.Single(e => string.Equals(e.DisplayName, "route1")).Metadata.GetMetadata<RouteModel>();
         Assert.NotNull(routeConfig);
         Assert.Equal("route1", routeConfig.Config.RouteId);
 
@@ -241,7 +238,7 @@ public class ProxyConfigManagerTests
         Assert.NotNull(destination.Model);
         Assert.Equal(TestAddress, destination.Model.Config.Address);
 
-        routeConfig = endpoints[1].Metadata.GetMetadata<RouteModel>();
+        routeConfig = endpoints.Single(e => string.Equals(e.DisplayName, "route2")).Metadata.GetMetadata<RouteModel>();
         Assert.NotNull(routeConfig);
         Assert.Equal("route2", routeConfig.Config.RouteId);
 
@@ -308,7 +305,8 @@ public class ProxyConfigManagerTests
         var endpoints = dataSource.Endpoints;
         Assert.Equal(2, endpoints.Count);
 
-        var routeConfig = endpoints[0].Metadata.GetMetadata<RouteModel>();
+        // The order is unstable because routes are stored in a dictionary.
+        var routeConfig = endpoints.Single(e => string.Equals(e.DisplayName, "route1")).Metadata.GetMetadata<RouteModel>();
         Assert.NotNull(routeConfig);
         Assert.Equal("route1", routeConfig.Config.RouteId);
 
@@ -327,7 +325,7 @@ public class ProxyConfigManagerTests
         Assert.NotNull(destination.Model);
         Assert.Equal(TestAddress, destination.Model.Config.Address);
 
-        routeConfig = endpoints[1].Metadata.GetMetadata<RouteModel>();
+        routeConfig = endpoints.Single(e => string.Equals(e.DisplayName, "route2")).Metadata.GetMetadata<RouteModel>();
         Assert.NotNull(routeConfig);
         Assert.Equal("route2", routeConfig.Config.RouteId);
 

--- a/testassets/ReverseProxy.Config/Startup.cs
+++ b/testassets/ReverseProxy.Config/Startup.cs
@@ -31,6 +31,7 @@ public class Startup
         services.AddControllers();
         services.AddReverseProxy()
             .LoadFromConfig(_configuration.GetSection("ReverseProxy"))
+            .LoadFromConfig(_configuration.GetSection("ReverseProxy2"))
             .AddConfigFilter<CustomConfigFilter>();
     }
 

--- a/testassets/ReverseProxy.Config/appsettings.json
+++ b/testassets/ReverseProxy.Config/appsettings.json
@@ -120,5 +120,53 @@
         ]
       }
     }
+  },
+  "ReverseProxy2": {
+    "Clusters": {
+      "cluster3": {
+        "LoadBalancingPolicy": "Random",
+        "SessionAffinity": {
+          "Enabled": "true",
+          "Policy": "Cookie",
+          "AffinityKeyName": ".Yarp.Affinity"
+        },
+        "HealthCheck": {
+          "Active": {
+            "Enabled": "true",
+            "Interval": "00:00:10",
+            "Timeout": "00:00:10",
+            "Policy": "ConsecutiveFailures",
+            "Path": "/api/health"
+          },
+          "Passive": {
+            "Enabled": "true",
+            "Policy": "TransportFailureRate",
+            "ReactivationPeriod": "00:05:00"
+          }
+        },
+        "Metadata": {
+          "ConsecutiveFailuresHealthPolicy.Threshold": "3",
+          "TransportFailureRateHealthPolicy.RateLimit": "0.5"
+        },
+        "Destinations": {
+          "cluster1/destination1": {
+            "Address": "https://localhost:10000/"
+          },
+          "cluster1/destination2": {
+            "Address": "http://localhost:10010/"
+          }
+        }
+      }
+    },
+    "Routes": {
+      "route3": {
+        "ClusterId": "cluster3",
+        "Match": {
+          "Methods": [ "GET", "POST" ],
+          "Hosts": [ "localhost" ],
+          "Path": "/api2/{action}"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes #979
Contributes to #368

Customers want to be able to do more advanced things with config like:
- Load it from multiple places: JSON, in memory, k8, etc.
- Be able to mix and match across those sources. E.g. routes are defined in memory and clusters in json.

Design:
- Multiple LoadFromX calls can now be made. No new APIs are needed, but we will want to ensure the existing ones behave as expected if called multiple times. I've only verified LoadFromConfig so far. Others might not make sense to call multiple times but could still be mixed and matched.
- The config manager will resolve all IProxyConfigProvider's from the DI container, concatenate their contents, run validation, and update the internal state.
- RouteConfig and ClusterConfig are the smallest units supported. Duplicates are an error and will not be merged.
- Changes in any provider trigger a reload. I tried only reloading routes/clusters from the modified provider but it was much harder to support mixing clusters and routes across sources that way. We still diff each route and cluster and only update them if modified.
- Errors in any config source will prevent all from loading/being applied. If this happens at startup the proxy will crash (as before). If it happens on reload then the proxy will continue to function using the last know good config as before. I've added a little extra logic to retry reload errors after 5 minutes.