### PR TITLE
Remove doc Introduced tags

### DIFF
--- a/docs/docfx/articles/authn-authz.md
+++ b/docs/docfx/articles/authn-authz.md
@@ -1,7 +1,5 @@
 # Authentication and Authorization
 
-Introduced: preview3
-
 ## Introduction
 The reverse proxy can be used to authenticate and authorize requests before they are proxied to the destination servers. This can reduce load on the destination servers, add a layer of protection, and ensure consistent policies are implemented across your applications.
 

--- a/docs/docfx/articles/config-files.md
+++ b/docs/docfx/articles/config-files.md
@@ -1,8 +1,5 @@
 # Configuration Files
 
-Introduced: preview1
-Updated: preview5
-
 ## Introduction
 The reverse proxy can load configuration for routes and clusters from files using the IConfiguration abstraction from Microsoft.Extensions. The examples given here use JSON, but any IConfiguration source should work. The configuration will also be updated without restarting the proxy if the source file changes.
 

--- a/docs/docfx/articles/config-providers.md
+++ b/docs/docfx/articles/config-providers.md
@@ -1,7 +1,5 @@
 # Extensibility: Configuration Providers
 
-Introduced: preview4
-
 ## Introduction
 The [Basic Yarp Sample](https://github.com/microsoft/reverse-proxy/tree/main/samples/BasicYarpSample) show proxy confuguration being loaded from appsettings.json. Instead proxy configuration can be loaded programmatically from the source of your choosing. You do this by providing a couple of classes implementing [IProxyConfigProvider](xref:Yarp.ReverseProxy.Configuration.IProxyConfigProvider) and [IProxyConfig](xref:Yarp.ReverseProxy.Configuration.IProxyConfig).
 

--- a/docs/docfx/articles/cors.md
+++ b/docs/docfx/articles/cors.md
@@ -1,7 +1,5 @@
 # Cross-Origin Requests (CORS)
 
-Introduced: preview3
-
 ## Introduction
 
 The reverse proxy can handle cross-origin requests before they are proxied to the destination servers. This can reduce load on the destination servers and ensure consistent policies are implemented across your applications.

--- a/docs/docfx/articles/direct-forwarding.md
+++ b/docs/docfx/articles/direct-forwarding.md
@@ -5,8 +5,6 @@ title: Direct Forwarding
 
 # Direct Forwarding
 
-Introduced: preview6
-
 Some applications only need the ability to take a specific request and forward it to a specific destination. These applications do not need, or have addressed in other ways, the other features of the proxy like configuration discovery, routing, load balancing, etc..
 
 ## IHttpForwarder

--- a/docs/docfx/articles/http-client-config.md
+++ b/docs/docfx/articles/http-client-config.md
@@ -1,7 +1,5 @@
 # HTTP Client Configuration
 
-Introduced: preview5
-
 ## Introduction
 
 Each [Cluster](xref:Yarp.ReverseProxy.Configuration.ClusterConfig) has a dedicated [HttpMessageInvoker](https://docs.microsoft.com/dotnet/api/system.net.http.httpmessageinvoker) instance used to forward requests to its [Destination](xref:Yarp.ReverseProxy.Configuration.DestinationConfig)s. The configuration is defined per cluster. On YARP startup, all clusters get new `HttpMessageInvoker` instances, however if later the cluster configuration gets changed the [IForwarderHttpClientFactory](xref:Yarp.ReverseProxy.Forwarder.IForwarderHttpClientFactory) will re-run and decide if it should create a new `HttpMessageInvoker` or keep using the existing one. The default `IForwarderHttpClientFactory` implementation creates a new `HttpMessageInvoker` when there are changes to the [HttpClientConfig](xref:Yarp.ReverseProxy.Configuration.HttpClientConfig).

--- a/docs/docfx/articles/kubernetes-ingress.md
+++ b/docs/docfx/articles/kubernetes-ingress.md
@@ -1,6 +1,6 @@
 # Kubernetes Ingress Controller
 
-Introduced: 1.0.0
+Introduced: Future Preview
 
 YARP can be integrated with Kubernetes as a reverse proxy managing HTTP/HTTPS traffic ingress to a Kubernetes cluster. Currently, the module is shipped as a separate package and is in preview.
 

--- a/docs/docfx/articles/load-balancing.md
+++ b/docs/docfx/articles/load-balancing.md
@@ -1,7 +1,5 @@
 # Load Balancing
 
-Introduced: preview8
-
 ## Introduction
 
 Whenever there are multiple healthy destinations available, YARP has to decide which one to use for a given request.

--- a/docs/docfx/articles/service-fabric-int.md
+++ b/docs/docfx/articles/service-fabric-int.md
@@ -1,6 +1,6 @@
 # Service Fabric Integration
 
-Introduced: preview8
+Note: This functionality has been replaced by https://github.com/microsoft/service-fabric-yarp
 
 YARP can be integrated with Service Fabric as a reverse proxy managing HTTP/HTTPS traffic ingress to a Service Fabric cluster, including support for gRPC and Web Sockets. Currently, the integration module is shipped as a separate package and has a limited support of SF availability and scalability scenarios, but it will be gradually improved over time to support more advanced SF deployment schemes.
 

--- a/docs/docfx/articles/session-affinity.md
+++ b/docs/docfx/articles/session-affinity.md
@@ -1,8 +1,5 @@
 # Session Affinity
 
-Introduced: preview2
-Updated: preview12
-
 ## Concept
 Session affinity is a mechanism to bind (affinitize) a causally related request sequence to the destination that handled the first request when the load is balanced among several destinations. It is useful in scenarios where the most requests in a sequence work with the same data and the cost of data access differs for different nodes (destinations) handling requests. The most common example is a transient caching (e.g. in-memory) where the first request fetches data from a slower persistent storage into a fast local cache and the others work only with the cached data thus increasing throughput.
 

--- a/docs/docfx/articles/transforms.md
+++ b/docs/docfx/articles/transforms.md
@@ -1,7 +1,5 @@
 # Request and Response Transforms
 
-Introduced: preview2
-
 ## Introduction
 When proxying a request it's common to modify parts of the request or response to adapt to the destination server's requirements or to flow additional data such as the client's original IP address. This process is implemented via Transforms. Types of transforms are defined globally for the application and then individual routes supply the parameters to enable and configure those transforms. The original request objects are not modified by these transforms, only the proxy requests.
 


### PR DESCRIPTION
These `Introduced: preview3` tags are no longer relevant now that 1.0 has shipped. We may include some new ones for features added in the future, but expect them to reference full versions, not previews.