### PR TITLE
Add cluster access API, reassignment

### DIFF
--- a/docs/docfx/articles/ab-testing.md
+++ b/docs/docfx/articles/ab-testing.md
@@ -1,0 +1,51 @@
+# A/B Testing and Rolling Upgrades
+
+## Introduction
+
+A/B testing and rolling upgrades require procedures for dynamically assigning incoming traffic to evaluate changes in the destination application. YARP does not have a built in model for this, but it does expose some infrastructure useful for building such a system. See [issue #126](https://github.com/microsoft/reverse-proxy/issues/126) for additional details about this scenario.
+
+## Example
+
+```
+    public void Configure(IApplicationBuilder app, IProxyStateLookup lookup)
+    {
+        app.UseRouting();
+        app.UseEndpoints(endpoints =>
+        {
+            endpoints.MapReverseProxy(proxyPipeline =>
+            {
+                // Custom cluster selection
+                proxyPipeline.Use((context, next) =>
+                {
+                    if (lookup.TryGetCluster(ChooseCluster(context), out var cluster))
+                    {
+                        context.ReassignProxyRequest(cluster);
+                    }
+
+                    return next();
+                });
+                proxyPipeline.UseSessionAffinity();
+                proxyPipeline.UseLoadBalancing();
+            });
+        });
+    }
+
+    private string ChooseCluster(HttpContext context)
+    {
+        // Decide which cluster to use. This could be random, weighted, based on headers, etc.
+        return Random.Shared.Next(2) == 1 ? "cluster1" : "cluster2";
+    }
+```
+
+## Usage
+
+This scenario makes use of two APIs, [IProxyStateLookup](xref:Yarp.ReverseProxy.IProxyStateLookup) and [ReassignProxyRequest](xref:Microsoft.AspNetCore.Http.HttpContextFeaturesExtensions.ReassignProxyRequest).
+
+`IProxyStateLookup` is a service available in the Dependency Injection container that can be used to look up or enumerate the current routes and clusters. Note this data may change if the configuration changes. An A/B orchestration algorithm can examine the request, decide which cluster to send it to, and then retrieve that cluster from `IProxyStateLookup.TryGetCluster`.
+
+Once the cluster is selected, `ReassignProxyRequest` can be called to assign the request to that cluster. This updates the [IReverseProxyFeature](xref:Yarp.ReverseProxy.Model.IReverseProxyFeature) with the new cluster and destination information needed for the rest of the proxy middleware pipeline to handle the request.
+
+## Session affinity
+
+Note that session affinity functionality is split between middleware, which reads it settings from the current cluster, and transforms, which are part of the original route. Clusters used for A/B testing should use the same session affinity configuration to avoid conflicts.
+

--- a/docs/docfx/articles/ab-testing.md
+++ b/docs/docfx/articles/ab-testing.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-A/B testing and rolling upgrades require procedures for dynamically assigning incoming traffic to evaluate changes in the destination application. YARP does not have a built in model for this, but it does expose some infrastructure useful for building such a system. See [issue #126](https://github.com/microsoft/reverse-proxy/issues/126) for additional details about this scenario.
+A/B testing and rolling upgrades require procedures for dynamically assigning incoming traffic to evaluate changes in the destination application. YARP does not have a built-in model for this, but it does expose some infrastructure useful for building such a system. See [issue #126](https://github.com/microsoft/reverse-proxy/issues/126) for additional details about this scenario.
 
 ## Example
 
@@ -39,7 +39,7 @@ A/B testing and rolling upgrades require procedures for dynamically assigning in
 
 ## Usage
 
-This scenario makes use of two APIs, [IProxyStateLookup](xref:Yarp.ReverseProxy.IProxyStateLookup) and [ReassignProxyRequest](xref:Microsoft.AspNetCore.Http.HttpContextFeaturesExtensions.ReassignProxyRequest).
+This scenario makes use of two APIs, [IProxyStateLookup](xref:Yarp.ReverseProxy.IProxyStateLookup) and [ReassignProxyRequest](xref:Microsoft.AspNetCore.Http.HttpContextFeaturesExtensions.ReassignProxyRequest), called from a custom proxy middleware as shown in the sample above.
 
 `IProxyStateLookup` is a service available in the Dependency Injection container that can be used to look up or enumerate the current routes and clusters. Note this data may change if the configuration changes. An A/B orchestration algorithm can examine the request, decide which cluster to send it to, and then retrieve that cluster from `IProxyStateLookup.TryGetCluster`.
 

--- a/docs/docfx/articles/toc.yml
+++ b/docs/docfx/articles/toc.yml
@@ -40,3 +40,5 @@
   href: packages-refs.md
 - name: Diagnosing proxy issues
   href: diagnosing-yarp-issues.md
+- name: AB Testing
+  href: ab-testing.md

--- a/docs/docfx/articles/toc.yml
+++ b/docs/docfx/articles/toc.yml
@@ -40,5 +40,5 @@
   href: packages-refs.md
 - name: Diagnosing proxy issues
   href: diagnosing-yarp-issues.md
-- name: AB Testing
+- name: A/B Testing
   href: ab-testing.md

--- a/src/ReverseProxy/Management/IProxyStateLookup.cs
+++ b/src/ReverseProxy/Management/IProxyStateLookup.cs
@@ -7,13 +7,28 @@ using Yarp.ReverseProxy.Model;
 
 namespace Yarp.ReverseProxy;
 
+/// <summary>
+/// Allows access to the proxy's current set of routes and clusters.
+/// </summary>
 public interface IProxyStateLookup
 {
+    /// <summary>
+    /// Retrieves a specific route by id, if present.
+    /// </summary>
     bool TryGetRoute(string id, [NotNullWhen(true)] out RouteModel? route);
 
+    /// <summary>
+    /// Enumerates all current routes. This is thread safe but the collection may change mid enumeration if the configuration is reloaded.
+    /// </summary>
     IEnumerable<RouteModel> GetRoutes();
 
+    /// <summary>
+    /// Retrieves a specific cluster by id, if present.
+    /// </summary>
     bool TryGetCluster(string id, [NotNullWhen(true)] out ClusterState? cluster);
 
+    /// <summary>
+    /// Enumerates all current clusters. This is thread safe but the collection may change mid enumeration if the configuration is reloaded.
+    /// </summary>
     IEnumerable<ClusterState> GetClusters();
 }

--- a/src/ReverseProxy/Management/IProxyStateLookup.cs
+++ b/src/ReverseProxy/Management/IProxyStateLookup.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Yarp.ReverseProxy.Model;
+
+namespace Yarp.ReverseProxy;
+
+public interface IProxyStateLookup
+{
+    bool TryGetRoute(string id, [NotNullWhen(true)] out RouteModel? route);
+
+    IEnumerable<RouteModel> GetRoutes();
+
+    bool TryGetCluster(string id, [NotNullWhen(true)] out ClusterState? cluster);
+
+    IEnumerable<ClusterState> GetClusters();
+}

--- a/src/ReverseProxy/Management/IReverseProxyBuilderExtensions.cs
+++ b/src/ReverseProxy/Management/IReverseProxyBuilderExtensions.cs
@@ -50,6 +50,7 @@ internal static class IReverseProxyBuilderExtensions
     public static IReverseProxyBuilder AddConfigManager(this IReverseProxyBuilder builder)
     {
         builder.Services.TryAddSingleton<ProxyConfigManager>();
+        builder.Services.TryAddSingleton<IProxyStateLookup>(sp => sp.GetRequiredService<ProxyConfigManager>());
         return builder;
     }
 

--- a/src/ReverseProxy/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Management/ProxyConfigManager.cs
@@ -30,7 +30,7 @@ namespace Yarp.ReverseProxy.Management;
 /// in a thread-safe manner while avoiding locks on the hot path.
 /// </summary>
 // https://github.com/dotnet/aspnetcore/blob/cbe16474ce9db7ff588aed89596ff4df5c3f62e1/src/Mvc/Mvc.Core/src/Routing/ActionEndpointDataSourceBase.cs
-internal sealed class ProxyConfigManager : EndpointDataSource, IDisposable, IProxyStateLookup
+internal sealed class ProxyConfigManager : EndpointDataSource, IProxyStateLookup, IDisposable
 {
     private static readonly IReadOnlyDictionary<string, ClusterConfig> _emptyClusterDictionary = new ReadOnlyDictionary<string, ClusterConfig>(new Dictionary<string, ClusterConfig>());
 

--- a/src/ReverseProxy/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Management/ProxyConfigManager.cs
@@ -30,7 +30,7 @@ namespace Yarp.ReverseProxy.Management;
 /// in a thread-safe manner while avoiding locks on the hot path.
 /// </summary>
 // https://github.com/dotnet/aspnetcore/blob/cbe16474ce9db7ff588aed89596ff4df5c3f62e1/src/Mvc/Mvc.Core/src/Routing/ActionEndpointDataSourceBase.cs
-internal sealed class ProxyConfigManager : EndpointDataSource, IDisposable
+internal sealed class ProxyConfigManager : EndpointDataSource, IDisposable, IProxyStateLookup
 {
     private static readonly IReadOnlyDictionary<string, ClusterConfig> _emptyClusterDictionary = new ReadOnlyDictionary<string, ClusterConfig>(new Dictionary<string, ClusterConfig>());
 
@@ -678,6 +678,39 @@ internal sealed class ProxyConfigManager : EndpointDataSource, IDisposable
         var transforms = _transformBuilder.Build(source, cluster?.Model?.Config);
 
         return new RouteModel(source, cluster, transforms);
+    }
+
+    public bool TryGetRoute(string id, [NotNullWhen(true)] out RouteModel? route)
+    {
+        if (_routes.TryGetValue(id, out var routeState))
+        {
+            route = routeState.Model;
+            return true;
+        }
+
+        route = null;
+        return false;
+    }
+
+    public IEnumerable<RouteModel> GetRoutes()
+    {
+        foreach (var (_, route) in _routes)
+        {
+            yield return route.Model;
+        }
+    }
+
+    public bool TryGetCluster(string id, [NotNullWhen(true)] out ClusterState? cluster)
+    {
+        return _clusters.TryGetValue(id, out cluster!);
+    }
+
+    public IEnumerable<ClusterState> GetClusters()
+    {
+        foreach (var (_, cluster) in _clusters)
+        {
+            yield return cluster;
+        }
     }
 
     public void Dispose()

--- a/src/ReverseProxy/Model/HttpContextFeaturesExtensions.cs
+++ b/src/ReverseProxy/Model/HttpContextFeaturesExtensions.cs
@@ -40,4 +40,24 @@ public static class HttpContextFeaturesExtensions
     {
         return context.Features.Get<IForwarderErrorFeature>();
     }
+
+    // Compare to ProxyPipelineInitializerMiddleware
+    /// <summary>
+    /// Replaces the assigned cluster and destinations in <see cref="IReverseProxyFeature"/> with the new <see cref="ClusterState"/>,
+    /// causing the request to be sent to the new cluster instead.
+    /// </summary>
+    public static void ReassignProxyRequest(this HttpContext context, ClusterState cluster)
+    {
+        var oldFeature = context.GetReverseProxyFeature();
+        var destinations = cluster.DestinationsState;
+        var newFeature = new ReverseProxyFeature()
+        {
+            Route = oldFeature.Route,
+            Cluster = cluster.Model,
+            AllDestinations = destinations.AllDestinations,
+            AvailableDestinations = destinations.AvailableDestinations,
+            ProxiedDestination = oldFeature.ProxiedDestination,
+        };
+        context.Features.Set<IReverseProxyFeature>(newFeature);
+    }
 }

--- a/src/ReverseProxy/SessionAffinity/AffinitizeTransform.cs
+++ b/src/ReverseProxy/SessionAffinity/AffinitizeTransform.cs
@@ -27,7 +27,11 @@ internal sealed class AffinitizeTransform : ResponseTransform
         var proxyFeature = context.HttpContext.GetReverseProxyFeature();
         var options = proxyFeature.Cluster.Config.SessionAffinity;
         // The transform should only be added to routes that have affinity enabled.
-        Debug.Assert(options?.Enabled ?? true, "Session affinity is not enabled");
+        // However, the cluster can be re-assigned dynamically.
+        if (options == null || !options.Enabled.GetValueOrDefault())
+        {
+            return default;
+        }
         var selectedDestination = proxyFeature.ProxiedDestination!;
         _sessionAffinityPolicy.AffinitizeResponse(context.HttpContext, proxyFeature.Route.Cluster!, options!, selectedDestination);
         return default;

--- a/src/ReverseProxy/Utilities/NullableAttributes.cs
+++ b/src/ReverseProxy/Utilities/NullableAttributes.cs
@@ -69,25 +69,6 @@ internal
     public bool ReturnValue { get; }
 }
 
-/// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
-[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-#if INTERNAL_NULLABLE_ATTRIBUTES
-internal
-#else
-    public
-#endif
-        sealed class NotNullWhenAttribute : Attribute
-{
-    /// <summary>Initializes the attribute with the specified return value condition.</summary>
-    /// <param name="returnValue">
-    /// The return value condition. If the method returns this value, the associated parameter will not be null.
-    /// </param>
-    public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
-
-    /// <summary>Gets the return value condition.</summary>
-    public bool ReturnValue { get; }
-}
-
 /// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
 [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
 #if INTERNAL_NULLABLE_ATTRIBUTES

--- a/test/ReverseProxy.Tests/Model/HttpContextFeaturesExtensions.cs
+++ b/test/ReverseProxy.Tests/Model/HttpContextFeaturesExtensions.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net.Http;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+using Yarp.ReverseProxy.Configuration;
+using Yarp.ReverseProxy.Forwarder;
+
+namespace Yarp.ReverseProxy.Model.Tests;
+
+public class HttpContextFeaturesExtensions
+{
+    [Fact]
+    public void ReassignProxyRequest_Success()
+    {
+        var client = new HttpMessageInvoker(new SocketsHttpHandler());
+        var context = new DefaultHttpContext();
+        var d1 = new DestinationState("d1");
+        var d2 = new DestinationState("d2");
+        var cc1 = new ClusterConfig() { ClusterId = "c1" };
+        var cm1 = new ClusterModel(cc1, client);
+        var cs1 = new ClusterState("c1") { Model = cm1 };
+        var r1 = new RouteModel(new RouteConfig() { RouteId = "r1" }, cs1, HttpTransformer.Empty);
+        var feature = new ReverseProxyFeature()
+        {
+            AllDestinations = d1,
+            AvailableDestinations = d1,
+            Cluster = cm1,
+            Route = r1,
+            ProxiedDestination = d1,
+        };
+
+        context.Features.Set<IReverseProxyFeature>(feature);
+
+        var cc2 = new ClusterConfig() { ClusterId = "cc2" };
+        var cm2 = new ClusterModel(cc2, client);
+        var cs2 = new ClusterState("cs2")
+        {
+            DestinationsState = new ClusterDestinationsState(d2, d2),
+            Model = cm2,
+        };
+        context.ReassignProxyRequest(cs2);
+
+        var newFeature = context.GetReverseProxyFeature();
+        Assert.NotSame(feature, newFeature);
+        Assert.Same(d2, newFeature.AllDestinations);
+        Assert.Same(d2, newFeature.AvailableDestinations);
+        Assert.Same(d1, newFeature.ProxiedDestination); // Copied unmodified.
+        Assert.Same(cm2, newFeature.Cluster);
+        Assert.Same(r1, newFeature.Route);
+    }
+}


### PR DESCRIPTION
Contributes to https://github.com/microsoft/reverse-proxy/issues/126#issuecomment-1024494147

This provides the minimal infrastructure necessary to build your own A/B testing or rolling upgrade system.
A) You can now directly look up routes and clusters
B) You can re-assign a request to a new cluster

That should allow a developer to provide their own custom middleware that examines requests, chooses a cluster, and assigns the request accordingly.

Note: Changing the cluster can cause some issues with Session Affinity if the two clusters have different affinity configurations, especially if it's enabled in one and disabled in the other. I've left this as a warning for now, not sure if anyone will need different settings across A/B clusters.