### PR TITLE
Changing QueryTransformContext query collection to be case insensitive

### DIFF
--- a/src/ReverseProxy/Transforms/QueryTransformContext.cs
+++ b/src/ReverseProxy/Transforms/QueryTransformContext.cs
@@ -52,7 +52,7 @@ public class QueryTransformContext
         {
             if (_modifiedQueryParameters == null)
             {
-                _modifiedQueryParameters = new Dictionary<string, StringValues>(_request.Query);
+                _modifiedQueryParameters = new Dictionary<string, StringValues>(_request.Query, StringComparer.OrdinalIgnoreCase);
             }
 
             return _modifiedQueryParameters;

--- a/test/ReverseProxy.Tests/Transforms/QueryTransformContextTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/QueryTransformContextTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Yarp.ReverseProxy.Transforms.Tests;
+
+public class QueryTransformContextTests
+{
+    [Fact]
+    public void Collection_TryGetValue_CaseInsensitive()
+    {
+        var httpContext = new DefaultHttpContext {Request = {QueryString = new QueryString("?z=1")}};
+        var queryTransformContext = new QueryTransformContext(httpContext.Request);
+        queryTransformContext.Collection.TryGetValue("Z", out var result);
+        Assert.Equal("1", result);
+    }
+
+    [Fact]
+    public void Collection_RemoveKey_CaseInsensitive()
+    {
+        var httpContext = new DefaultHttpContext { Request = { QueryString = new QueryString("?z=1") } };
+        var queryTransformContext = new QueryTransformContext(httpContext.Request);
+        queryTransformContext.Collection.Remove("Z");
+        Assert.False(queryTransformContext.QueryString.HasValue);
+    }
+}

--- a/test/ReverseProxy.Tests/Transforms/QueryTransformContextTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/QueryTransformContextTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.AspNetCore.Http;
 using Xunit;
 
@@ -8,7 +11,7 @@ public class QueryTransformContextTests
     [Fact]
     public void Collection_TryGetValue_CaseInsensitive()
     {
-        var httpContext = new DefaultHttpContext {Request = {QueryString = new QueryString("?z=1")}};
+        var httpContext = new DefaultHttpContext { Request = { QueryString = new QueryString("?z=1") } };
         var queryTransformContext = new QueryTransformContext(httpContext.Request);
         queryTransformContext.Collection.TryGetValue("Z", out var result);
         Assert.Equal("1", result);


### PR DESCRIPTION
This PR will change the query collection of `QueryTransformContext` to be case insensitive which will be consistent with ASP.NET.

This PR fixes the bug mentioned in issue: [1496](https://github.com/microsoft/reverse-proxy/issues/1496)