### PR TITLE
Fixed Return503Error affinity policy name

### DIFF
--- a/docs/docfx/articles/config-files.md
+++ b/docs/docfx/articles/config-files.md
@@ -181,7 +181,7 @@ For additional fields see [ClusterConfig](xref:Yarp.ReverseProxy.Configuration.C
         "SessionAffinity": {
           "Enabled": true, // Defaults to 'false'
           "Policy": "Cookie", // Default, alternatively "CustomHeader"
-          "FailurePolicy": "Redistribute", // default, Alternatively "Return503"
+          "FailurePolicy": "Redistribute", // default, Alternatively "Return503Error"
           "Settings" : {
               "CustomHeaderName": "MySessionHeaderName" // Defaults to 'X-Yarp-Proxy-Affinity`
           }

--- a/docs/docfx/articles/session-affinity.md
+++ b/docs/docfx/articles/session-affinity.md
@@ -25,7 +25,7 @@ Session affinity is configured per cluster according to the following configurat
             "SessionAffinity": {
                 "Enabled": "(true|false)", // defaults to 'false'
                 "Policy": "(Cookie|CustomHeader)", // defaults to 'Cookie'
-                "FailurePolicy": "(Redistribute|Return503)", // defaults to 'Redistribute'
+                "FailurePolicy": "(Redistribute|Return503Error)", // defaults to 'Redistribute'
                 "AffinityKeyName": "Key1",
                 "Cookie": {
                     "Domain": "localhost",

--- a/samples/ReverseProxy.Config.Sample/appsettings.json
+++ b/samples/ReverseProxy.Config.Sample/appsettings.json
@@ -87,7 +87,7 @@
         "SessionAffinity": { // Ensures subsequent requests from a client go to the same destination server
           "Enabled": true, // Defaults to 'false'
           "Policy": "Cookie", // Default, alternatively "CustomHeader"
-          "FailurePolicy": "Redistribute", // default, alternatively "Return503"
+          "FailurePolicy": "Redistribute", // default, alternatively "Return503Error"
           "AffinityKeyName": "MySessionCookieName" // defaults to ".Yarp.ReverseProxy.Affinity"
         },
         "HealthCheck": { // Ways to determine which destinations should be filtered out due to unhealthy state

--- a/test/ReverseProxy.Tests/SessionAffinity/BaseSessionAffinityPolicyTests.cs
+++ b/test/ReverseProxy.Tests/SessionAffinity/BaseSessionAffinityPolicyTests.cs
@@ -24,7 +24,7 @@ public class BaseSesstionAffinityPolicyTests
     {
         Enabled = true,
         Policy = "Stub",
-        FailurePolicy = "Return503",
+        FailurePolicy = "Return503Error",
         AffinityKeyName = "StubAffinityKey"
     };
 

--- a/test/ReverseProxy.Tests/SessionAffinity/CookieSessionAffinityPolicyTests.cs
+++ b/test/ReverseProxy.Tests/SessionAffinity/CookieSessionAffinityPolicyTests.cs
@@ -17,7 +17,7 @@ public class CookieSessionAffinityPolicyTests
     {
         Enabled = true,
         Policy = "Cookie",
-        FailurePolicy = "Return503",
+        FailurePolicy = "Return503Error",
         AffinityKeyName = "My.Affinity",
         Cookie = new SessionAffinityCookieConfig
         {

--- a/test/ReverseProxy.Tests/SessionAffinity/CustomHeaderSessionAffinityPolicyTests.cs
+++ b/test/ReverseProxy.Tests/SessionAffinity/CustomHeaderSessionAffinityPolicyTests.cs
@@ -16,7 +16,7 @@ public class CustomHeaderSessionAffinityPolicyTests
     {
         Enabled = true,
         Policy = "Cookie",
-        FailurePolicy = "Return503",
+        FailurePolicy = "Return503Error",
         AffinityKeyName = AffinityHeaderName
     };
     private readonly IReadOnlyList<DestinationState> _destinations = new[] { new DestinationState("dest-A"), new DestinationState("dest-B"), new DestinationState("dest-C") };


### PR DESCRIPTION
The name for `Return503ErrorAffinityFailurePolicy` in the documentation is incorrect. Actual policy name is picked from constants: 
[SessionAffinityConstants.cs](https://github.com/microsoft/reverse-proxy/blob/main/src/ReverseProxy/SessionAffinity/SessionAffinityConstants.cs#L22). I've replaced incorrect name in the docs, samples and tests.
Also I've checked actual branches and issues and it does not seem to be fixed yet.
I'm still not sure which branch must be target my small PR ☹.