### PR TITLE
Only add API documentation for released projects

### DIFF
--- a/docs/docfx/docfx.json
+++ b/docs/docfx/docfx.json
@@ -7,6 +7,7 @@
           "files": [
             "ReverseProxy/Yarp.ReverseProxy.csproj",
             "TelemetryConsumption/Yarp.Telemetry.Consumption.csproj"
+            // "**.csproj"
           ]
         }
       ],

--- a/docs/docfx/docfx.json
+++ b/docs/docfx/docfx.json
@@ -5,7 +5,8 @@
         {
           "src": "../../src",
           "files": [
-            "**.csproj"
+            "ReverseProxy/Yarp.ReverseProxy.csproj",
+            "TelemetryConsumption/Yarp.Telemetry.Consumption.csproj"
           ]
         }
       ],


### PR DESCRIPTION
Turns the [API documentation list](https://microsoft.github.io/reverse-proxy/api/index.html) into a much more manageable and relevant data source (avoids all the k8s and SF code from showing up there).

![image](https://user-images.githubusercontent.com/25307628/154310994-a573f932-1e96-44b5-beb2-9c26d88e16b2.png)
