### PR TITLE
Fix Kubernetes Controller Dockerfile Build

### DIFF
--- a/src/Kubernetes.Controller/Dockerfile
+++ b/src/Kubernetes.Controller/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS publish
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS publish
 WORKDIR /src
 
 # Copy csproj files and other files needed for restoring (to build a nuget cache layer to speed up rebuilds)


### PR DESCRIPTION
global.json specifies 6.0.100 explicitly, however the dockerfile uses the 6.0 sdk tag, which has moved on to 6.0.200. This fixes the build.