### PR TITLE
Avoid NRE from ProxyConfigManager if the initial load fails

### DIFF
--- a/src/ReverseProxy/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Management/ProxyConfigManager.cs
@@ -718,7 +718,7 @@ internal sealed class ProxyConfigManager : EndpointDataSource, IProxyStateLookup
         _configChangeSource.Dispose();
         foreach (var instance in _configs)
         {
-            instance.CallbackCleanup?.Dispose();
+            instance?.CallbackCleanup?.Dispose();
         }
     }
 


### PR DESCRIPTION
If the initial configuration load fails, `_configs` won't be initialized and `Dispose` hits a `NullReferenceException`.

Failure to load the config on startup is already a critical, non-recoverable error, this PR just removes the NRE from the stack trace.
Given that, I don't think it's needed to restart the official 1.1 RC build for this.

Hit during manual validation of #1596.