### PR TITLE
Fixed TlsHandshakeType enum label

### DIFF
--- a/src/ReverseProxy/Utilities/TlsFrameHelper.cs
+++ b/src/ReverseProxy/Utilities/TlsFrameHelper.cs
@@ -36,7 +36,7 @@ public enum TlsHandshakeType : byte
     CertificateVerify = 15,
     ClientKeyExchange = 16,
     Finished = 20,
-    KeyEpdate = 24,
+    KeyUpdate = 24,
     MessageHash = 254
 }
 


### PR DESCRIPTION
Fixes #1613

See similar issue and PR in dotnet/runtime:
https://github.com/dotnet/runtime/issues/66781
https://github.com/dotnet/runtime/pull/66786