### PR TITLE
Update package feed

### DIFF
--- a/docs/DailyBuilds.md
+++ b/docs/DailyBuilds.md
@@ -13,7 +13,7 @@ If you want to download the latest daily build and use it in a project, then you
   <configuration>
       <packageSources>
           <clear />
-          <add key="net5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+          <add key=".NET Libraries Daily" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
           <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
       </packageSources>
   </configuration>


### PR DESCRIPTION
I've updated darc to move our rolling builds from dotnet5 to the dotnet-libraries feed. This is recommended for out-of-band projects.

Confirm after the next build passes: https://dev.azure.com/dnceng/internal/_build/results?buildId=1688880&view=results