### PR TITLE
Add support for multi-value header routing

### DIFF
--- a/src/ReverseProxy/Routing/HeaderMatcher.cs
+++ b/src/ReverseProxy/Routing/HeaderMatcher.cs
@@ -41,8 +41,6 @@ internal sealed class HeaderMatcher
         Values = values?.ToArray() ?? Array.Empty<string>();
         Mode = mode;
         Comparison = isCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
-
-        // Should this extend to Set-Cookie?
         Separator = name.Equals(HeaderNames.Cookie, StringComparison.OrdinalIgnoreCase) ? ';' : ',';
     }
 

--- a/src/ReverseProxy/Routing/HeaderMatcherPolicy.cs
+++ b/src/ReverseProxy/Routing/HeaderMatcherPolicy.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -41,7 +42,7 @@ internal sealed class HeaderMatcherPolicy : MatcherPolicy, IEndpointComparerPoli
         return endpoints.Any(e =>
         {
             var metadata = e.Metadata.GetMetadata<IHeaderMetadata>();
-            return metadata?.Matchers?.Count > 0;
+            return metadata?.Matchers?.Length > 0;
         });
     }
 
@@ -51,6 +52,13 @@ internal sealed class HeaderMatcherPolicy : MatcherPolicy, IEndpointComparerPoli
         _ = httpContext ?? throw new ArgumentNullException(nameof(httpContext));
         _ = candidates ?? throw new ArgumentNullException(nameof(candidates));
 
+        ApplyCore(candidates, httpContext.Request.Headers);
+
+        return Task.CompletedTask;
+    }
+
+    private static void ApplyCore(CandidateSet candidates, IHeaderDictionary headers)
+    {
         for (var i = 0; i < candidates.Count; i++)
         {
             if (!candidates.IsValidCandidate(i))
@@ -65,102 +73,126 @@ internal sealed class HeaderMatcherPolicy : MatcherPolicy, IEndpointComparerPoli
                 continue;
             }
 
-            for (var m = 0; m < matchers.Count; m++)
+            foreach (var matcher in matchers)
             {
-                var matcher = matchers[m];
-                var expectedHeaderName = matcher.Name;
-                var expectedHeaderValues = matcher.Values;
-
-                var matched = false;
-                if (httpContext.Request.Headers.TryGetValue(expectedHeaderName, out var requestHeaderValues))
+                if (headers.TryGetValue(matcher.Name, out var requestHeaderValues) &&
+                    !StringValues.IsNullOrEmpty(requestHeaderValues))
                 {
-                    if (StringValues.IsNullOrEmpty(requestHeaderValues))
+                    if (matcher.Mode is HeaderMatchMode.Exists)
                     {
-                        // A non-empty value is required for a match.
+                        continue;
                     }
-                    else if (matcher.Mode == HeaderMatchMode.Exists)
+
+                    if (matcher.Mode is HeaderMatchMode.ExactHeader or HeaderMatchMode.HeaderPrefix
+                        ? TryMatchExactOrPrefix(matcher, requestHeaderValues)
+                        : TryMatchContainsOrNotContains(matcher, requestHeaderValues))
                     {
-                        // We were asked to match as long as the header exists, and it *does* exist
-                        matched = true;
+                        continue;
                     }
-                    // Multi-value headers are not supported.
-                    // Note a single entry may also contain multiple values, we don't distinguish, we only match on the whole header.
-                    else if (requestHeaderValues.Count == 1)
+                }
+
+                candidates.SetValidity(i, false);
+                break;
+            }
+        }
+    }
+
+    private static bool TryMatchExactOrPrefix(HeaderMatcher matcher, StringValues requestHeaderValues)
+    {
+        var requestHeaderCount = requestHeaderValues.Count;
+
+        for (var i = 0; i < requestHeaderCount; i++)
+        {
+            var requestValue = requestHeaderValues[i].AsSpan();
+
+            while (!requestValue.IsEmpty)
+            {
+                requestValue = requestValue.TrimStart(' ');
+
+                // Find the end of the next value.
+                // Separators inside a quote pair must be ignored as they are a part of the value.
+                var separatorOrQuoteIndex = requestValue.IndexOfAny('"', matcher.Separator);
+                while (separatorOrQuoteIndex != -1 && requestValue[separatorOrQuoteIndex] == '"')
+                {
+                    var closingQuoteIndex = requestValue.Slice(separatorOrQuoteIndex + 1).IndexOf('"');
+                    if (closingQuoteIndex == -1)
                     {
-                        var requestHeaderValue = requestHeaderValues.ToString();
-                        for (var j = 0; j < expectedHeaderValues.Count; j++)
+                        separatorOrQuoteIndex = -1;
+                    }
+                    else
+                    {
+                        var offset = separatorOrQuoteIndex + closingQuoteIndex + 2;
+                        separatorOrQuoteIndex = requestValue.Slice(offset).IndexOfAny('"', matcher.Separator);
+                        if (separatorOrQuoteIndex != -1)
                         {
-                            if (MatchHeader(matcher.Mode, requestHeaderValue, expectedHeaderValues[j], matcher.IsCaseSensitive))
-                            {
-                                if (matcher.Mode == HeaderMatchMode.NotContains)
-                                {
-                                    if (j + 1 == expectedHeaderValues.Count)
-                                    {
-                                        // None of the NotContains values were found
-                                        matched = true;
-                                    }
-                                }
-                                else
-                                {
-                                    matched = true;
-                                    break;
-                                }
-                            }
-                            else if (matcher.Mode == HeaderMatchMode.NotContains)
-                            {
-                                break;
-                            }
+                            separatorOrQuoteIndex += offset;
                         }
                     }
                 }
 
-                // All rules must match
-                if (!matched)
+                ReadOnlySpan<char> value;
+                if (separatorOrQuoteIndex == -1)
                 {
-                    candidates.SetValidity(i, false);
-                    break;
+                    value = requestValue;
+                    requestValue = default;
+                }
+                else
+                {
+                    value = requestValue.Slice(0, separatorOrQuoteIndex);
+                    requestValue = requestValue.Slice(separatorOrQuoteIndex + 1);
+                }
+
+                if (value.Length > 1 && value[0] == '"' && value[^1] == '"')
+                {
+                    value = value.Slice(1, value.Length - 2);
+                }
+
+                foreach (var expectedValue in matcher.Values)
+                {
+                    if (matcher.Mode == HeaderMatchMode.ExactHeader
+                        ? value.Equals(expectedValue, matcher.Comparison)
+                        : value.StartsWith(expectedValue, matcher.Comparison))
+                    {
+                        return true;
+                    }
                 }
             }
         }
 
-        return Task.CompletedTask;
+        return false;
     }
 
-    private static bool MatchHeader(HeaderMatchMode matchMode, string requestHeaderValue, string metadataHeaderValue, bool isCaseSensitive)
+    private static bool TryMatchContainsOrNotContains(HeaderMatcher matcher, StringValues requestHeaderValues)
     {
-        var comparison = isCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
-        return matchMode switch
+        Debug.Assert(matcher.Mode is HeaderMatchMode.Contains or HeaderMatchMode.NotContains, $"{matcher.Mode}");
+
+        var requestHeaderCount = requestHeaderValues.Count;
+
+        for (var i = 0; i < requestHeaderCount; i++)
         {
-            HeaderMatchMode.ExactHeader => MemoryExtensions.Equals(requestHeaderValue, metadataHeaderValue, comparison),
-            HeaderMatchMode.HeaderPrefix => requestHeaderValue is not null && metadataHeaderValue is not null
-                && MemoryExtensions.StartsWith(requestHeaderValue, metadataHeaderValue, comparison),
-            HeaderMatchMode.Contains => requestHeaderValue is not null && metadataHeaderValue is not null
-                && MemoryExtensions.Contains(requestHeaderValue, metadataHeaderValue, comparison),
-            HeaderMatchMode.NotContains => requestHeaderValue is not null && metadataHeaderValue is not null
-                && !MemoryExtensions.Contains(requestHeaderValue, metadataHeaderValue, comparison),
-            _ => throw new NotImplementedException(matchMode.ToString()),
-        };
+            var requestValue = requestHeaderValues[i];
+            if (requestValue is null)
+            {
+                continue;
+            }
+
+            foreach (var expectedValue in matcher.Values)
+            {
+                if (requestValue.Contains(expectedValue, matcher.Comparison))
+                {
+                    return matcher.Mode != HeaderMatchMode.NotContains;
+                }
+            }
+        }
+
+        return matcher.Mode == HeaderMatchMode.NotContains;
     }
 
     private class HeaderMetadataEndpointComparer : EndpointMetadataComparer<IHeaderMetadata>
     {
         protected override int CompareMetadata(IHeaderMetadata? x, IHeaderMetadata? y)
         {
-            var xCount = x?.Matchers?.Count ?? 0;
-            var yCount = y?.Matchers?.Count ?? 0;
-
-            if (xCount > yCount)
-            {
-                // x is more specific
-                return -1;
-            }
-            if (yCount > xCount)
-            {
-                // y is more specific
-                return 1;
-            }
-
-            return 0;
+            return (y?.Matchers?.Length ?? 0).CompareTo(x?.Matchers?.Length ?? 0);
         }
     }
 }

--- a/src/ReverseProxy/Routing/HeaderMatcherPolicy.cs
+++ b/src/ReverseProxy/Routing/HeaderMatcherPolicy.cs
@@ -52,13 +52,8 @@ internal sealed class HeaderMatcherPolicy : MatcherPolicy, IEndpointComparerPoli
         _ = httpContext ?? throw new ArgumentNullException(nameof(httpContext));
         _ = candidates ?? throw new ArgumentNullException(nameof(candidates));
 
-        ApplyCore(candidates, httpContext.Request.Headers);
+        var headers = httpContext.Request.Headers;
 
-        return Task.CompletedTask;
-    }
-
-    private static void ApplyCore(CandidateSet candidates, IHeaderDictionary headers)
-    {
         for (var i = 0; i < candidates.Count; i++)
         {
             if (!candidates.IsValidCandidate(i))
@@ -95,6 +90,8 @@ internal sealed class HeaderMatcherPolicy : MatcherPolicy, IEndpointComparerPoli
                 break;
             }
         }
+
+        return Task.CompletedTask;
     }
 
     private static bool TryMatchExactOrPrefix(HeaderMatcher matcher, StringValues requestHeaderValues)

--- a/src/ReverseProxy/Routing/HeaderMetadata.cs
+++ b/src/ReverseProxy/Routing/HeaderMetadata.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Yarp.ReverseProxy.Routing;
 
@@ -13,9 +14,9 @@ internal sealed class HeaderMetadata : IHeaderMetadata
 {
     public HeaderMetadata(IReadOnlyList<HeaderMatcher> matchers)
     {
-        Matchers = matchers ?? throw new ArgumentNullException(nameof(matchers));
+        Matchers = matchers?.ToArray() ?? throw new ArgumentNullException(nameof(matchers));
     }
 
     /// <inheritdoc/>
-    public IReadOnlyList<HeaderMatcher> Matchers { get; }
+    public HeaderMatcher[] Matchers { get; }
 }

--- a/src/ReverseProxy/Routing/IHeaderMetadata.cs
+++ b/src/ReverseProxy/Routing/IHeaderMetadata.cs
@@ -13,5 +13,5 @@ internal interface IHeaderMetadata
     /// <summary>
     /// One or more matchers to apply to the request headers.
     /// </summary>
-    IReadOnlyList<HeaderMatcher> Matchers { get; }
+    HeaderMatcher[] Matchers { get; }
 }

--- a/src/ReverseProxy/Routing/IQueryParameterMetadata.cs
+++ b/src/ReverseProxy/Routing/IQueryParameterMetadata.cs
@@ -13,5 +13,5 @@ internal interface IQueryParameterMetadata
     /// <summary>
     /// One or more matchers to apply to the request query parameters.
     /// </summary>
-    IReadOnlyList<QueryParameterMatcher> Matchers { get; }
+    QueryParameterMatcher[] Matchers { get; }
 }

--- a/src/ReverseProxy/Routing/QueryParameterMatcher.cs
+++ b/src/ReverseProxy/Routing/QueryParameterMatcher.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Yarp.ReverseProxy.Configuration;
 
 namespace Yarp.ReverseProxy.Routing;
@@ -30,11 +31,15 @@ internal sealed class QueryParameterMatcher
         {
             throw new ArgumentException($"Query parameter values must not be specified when using '{nameof(QueryParameterMatchMode.Exists)}'.", nameof(values));
         }
+        if (values is not null && values.Any(string.IsNullOrEmpty))
+        {
+            throw new ArgumentNullException(nameof(values), "Query parameter values must not be empty.");
+        }
 
         Name = name;
-        Values = values ?? Array.Empty<string>();
+        Values = values?.ToArray() ?? Array.Empty<string>();
         Mode = mode;
-        IsCaseSensitive = isCaseSensitive;
+        Comparison = isCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
     }
 
     /// <summary>
@@ -46,7 +51,7 @@ internal sealed class QueryParameterMatcher
     /// Returns a read-only collection of acceptable query parameter values used during routing.
     /// At least one value is required unless <see cref="Mode"/> is set to <see cref="QueryParameterMatchMode.Exists"/>.
     /// </summary>
-    public IReadOnlyList<string> Values { get; }
+    public string[] Values { get; }
 
     /// <summary>
     /// Specifies how query parameter values should be compared (e.g. exact matches Vs. contains).
@@ -54,11 +59,5 @@ internal sealed class QueryParameterMatcher
     /// </summary>
     public QueryParameterMatchMode Mode { get; }
 
-    /// <summary>
-    /// Specifies whether query parameter value comparisons should ignore case.
-    /// When <c>true</c>, <see cref="StringComparison.Ordinal" /> is used.
-    /// When <c>false</c>, <see cref="StringComparison.OrdinalIgnoreCase" /> is used.
-    /// Defaults to <c>false</c>.
-    /// </summary>
-    public bool IsCaseSensitive { get; }
+    public StringComparison Comparison { get; }
 }

--- a/src/ReverseProxy/Routing/QueryParameterMatcherPolicy.cs
+++ b/src/ReverseProxy/Routing/QueryParameterMatcherPolicy.cs
@@ -51,13 +51,8 @@ internal sealed class QueryParameterMatcherPolicy : MatcherPolicy, IEndpointComp
         _ = httpContext ?? throw new ArgumentNullException(nameof(httpContext));
         _ = candidates ?? throw new ArgumentNullException(nameof(candidates));
 
-        ApplyCore(candidates, httpContext.Request.Query);
+        var query = httpContext.Request.Query;
 
-        return Task.CompletedTask;
-    }
-
-    private static void ApplyCore(CandidateSet candidates, IQueryCollection query)
-    {
         for (var i = 0; i < candidates.Count; i++)
         {
             if (!candidates.IsValidCandidate(i))
@@ -92,6 +87,8 @@ internal sealed class QueryParameterMatcherPolicy : MatcherPolicy, IEndpointComp
                 break;
             }
         }
+
+        return Task.CompletedTask;
     }
 
     private static bool TryMatch(QueryParameterMatcher matcher, StringValues requestHeaderValues)

--- a/src/ReverseProxy/Routing/QueryParameterMetadata.cs
+++ b/src/ReverseProxy/Routing/QueryParameterMetadata.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Yarp.ReverseProxy.Routing;
 
@@ -13,9 +14,9 @@ internal sealed class QueryParameterMetadata : IQueryParameterMetadata
 {
     public QueryParameterMetadata(IReadOnlyList<QueryParameterMatcher> matchers)
     {
-        Matchers = matchers ?? throw new ArgumentNullException(nameof(matchers));
+        Matchers = matchers?.ToArray() ?? throw new ArgumentNullException(nameof(matchers));
     }
 
     /// <inheritdoc/>
-    public IReadOnlyList<QueryParameterMatcher> Matchers { get; }
+    public QueryParameterMatcher[] Matchers { get; }
 }

--- a/test/ReverseProxy.Tests/Routing/ProxyEndpointFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Routing/ProxyEndpointFactoryTests.cs
@@ -454,7 +454,7 @@ public class ProxyEndpointFactoryTests
         Assert.Equal("header1", matcher.Name);
         Assert.Equal(new[] { "value1" }, matcher.Values);
         Assert.Equal(HeaderMatchMode.HeaderPrefix, matcher.Mode);
-        Assert.True(matcher.IsCaseSensitive);
+        Assert.Equal(StringComparison.Ordinal, matcher.Comparison);
 
         Assert.False(routeConfig.HasConfigChanged(route, cluster, routeState.ClusterRevision));
     }
@@ -497,21 +497,21 @@ public class ProxyEndpointFactoryTests
         Assert.Same(cluster, routeConfig.Cluster);
         Assert.Equal("route1", routeEndpoint.DisplayName);
         var metadata = routeEndpoint.Metadata.GetMetadata<IHeaderMetadata>();
-        Assert.Equal(2, metadata.Matchers.Count);
+        Assert.Equal(2, metadata.Matchers.Length);
 
         var firstMetadata = metadata.Matchers.First();
         Assert.NotNull(firstMetadata);
         Assert.Equal("header1", firstMetadata.Name);
         Assert.Equal(new[] { "value1" }, firstMetadata.Values);
         Assert.Equal(HeaderMatchMode.HeaderPrefix, firstMetadata.Mode);
-        Assert.True(firstMetadata.IsCaseSensitive);
+        Assert.Equal(StringComparison.Ordinal, firstMetadata.Comparison);
 
         var secondMetadata = metadata.Matchers.Skip(1).Single();
         Assert.NotNull(secondMetadata);
         Assert.Equal("header2", secondMetadata.Name);
         Assert.Same(Array.Empty<string>(), secondMetadata.Values);
         Assert.Equal(HeaderMatchMode.Exists, secondMetadata.Mode);
-        Assert.False(secondMetadata.IsCaseSensitive);
+        Assert.Equal(StringComparison.OrdinalIgnoreCase, secondMetadata.Comparison);
 
         Assert.False(routeConfig.HasConfigChanged(route, cluster, routeState.ClusterRevision));
     }


### PR DESCRIPTION
Fixes #1494

Matching now treats multiple values as *OR*s. I.e. `Exact`/`Prefix` must match *any* of the request values.
`NotContains` means the value must *not match any* request header.

Values are further split based on the separator `,` (or `;` for `Cookie`). A single outer pair of quotes is also removed before matching.

This PR is generally slightly faster on simple (single-value) inputs, and (as expected) slower on multi-value ones.
Modes that may observe a perf degradation are `Exact` and `Prefix`.
I don't think the difference is prohibitive to the point that having an opt-out switch is needed.

Benchmark scenarios are defined [here](https://gist.github.com/MihaZupan/ccac2200ff7ba2f509060ee1a061e230#file-headerroutingbenchmark-cs-L30-L64).

| Method |         Scenario |      Mean |    Error |   StdDev | Ratio |
|------- |----------------- |----------:|---------:|---------:|------:|
|    Old |   SimpleContains | 292.78 ns | 0.957 ns | 0.848 ns |  1.00 |
|    New |   SimpleContains | 243.82 ns | 0.823 ns | 0.687 ns |  0.83 |
|        |                  |           |          |          |       |
|    Old |      SimpleExact | 158.98 ns | 0.529 ns | 0.469 ns |  1.00 |
|    New |      SimpleExact | 117.40 ns | 0.236 ns | 0.184 ns |  0.74 |
|        |                  |           |          |          |       |
|    Old |     SimplePrefix | 104.09 ns | 0.284 ns | 0.222 ns |  1.00 |
|    New |     SimplePrefix |  97.69 ns | 0.512 ns | 0.454 ns |  0.94 |
|        |                  |           |          |          |       |
|    Old | MultipleContains | 294.57 ns | 1.679 ns | 1.402 ns |  1.00 |
|    New | MultipleContains | 291.51 ns | 3.079 ns | 2.880 ns |  0.99 |
|        |                  |           |          |          |       |
|    Old |    MultipleExact | 124.28 ns | 0.237 ns | 0.185 ns |  1.00 |
|    New |    MultipleExact | 175.34 ns | 0.626 ns | 0.523 ns |  1.41 |
|        |                  |           |          |          |       |
|    Old |   MultiplePrefix | 130.89 ns | 1.529 ns | 1.431 ns |  1.00 |
|    New |   MultiplePrefix | 176.16 ns | 0.513 ns | 0.428 ns |  1.35 |

ToDo: Updating docs with the new behavior