### PR TITLE
Fix assert in cancellation test

### DIFF
--- a/test/ReverseProxy.FunctionalTests/HttpForwarderCancellationTests.cs
+++ b/test/ReverseProxy.FunctionalTests/HttpForwarderCancellationTests.cs
@@ -85,7 +85,7 @@ public class HttpForwarderCancellationTests
             var responseString = await response.Content.ReadAsStringAsync();
             Assert.Equal("Hello", responseString);
 
-            await Assert.ThrowsAsync<OperationCanceledException>(() => content.Completion.Task);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => content.Completion.Task);
         });
     }
 


### PR DESCRIPTION
It can also be a `TaskCanceledException`, which is derived from OCE.