### PR TITLE
Disable zero-byte-reads on 3.1 and 5.0

### DIFF
--- a/src/ReverseProxy/Forwarder/StreamCopier.cs
+++ b/src/ReverseProxy/Forwarder/StreamCopier.cs
@@ -47,6 +47,7 @@ internal static class StreamCopier
             {
                 read = 0;
 
+#if NET6_0_OR_GREATER
                 // Issue a zero-byte read to the input stream to defer buffer allocation until data is available.
                 // Note that if the underlying stream does not supporting blocking on zero byte reads, then this will
                 // complete immediately and won't save any memory, but will still function correctly.
@@ -67,6 +68,7 @@ internal static class StreamCopier
 
                     buffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
                 }
+#endif
 
                 read = await input.ReadAsync(buffer.AsMemory(), cancellation);
                 contentLength += read;


### PR DESCRIPTION
Contributes to #1665 and #1657.

@Tratcher feel free to close this one if you think we need any more changes here.