### PR TITLE
#1667 Fix watcher for Kubernetes resources

### DIFF
--- a/src/OperatorFramework/src/Controller/Informers/HttpOperationResponseExtensions.cs
+++ b/src/OperatorFramework/src/Controller/Informers/HttpOperationResponseExtensions.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using k8s;
+using k8s.Exceptions;
+using Microsoft.Rest;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Microsoft.Kubernetes.Controller.Informers
+{
+    internal static class HttpOperationResponseExtensions
+    {
+        public static Watcher<T> CustomWatch<T, L>(
+            this Task<HttpOperationResponse<L>> responseTask,
+            Action<WatchEventType, T> onEvent,
+            Action<Exception> onError = null,
+            Action onClosed = null)
+        {
+            return new Watcher<T>(MakeStreamReaderCreator<T, L>(responseTask), onEvent, onError, onClosed);
+        }
+
+        private static Func<Task<TextReader>> MakeStreamReaderCreator<T, L>(Task<HttpOperationResponse<L>> responseTask)
+        {
+            return async () =>
+            {
+                var response = await responseTask.ConfigureAwait(false);
+
+                if (!(response.Response.Content is Microsoft.Kubernetes.Client.LineSeparatedHttpContent content))
+                {
+                    throw new KubernetesClientException("not a watchable request or failed response");
+                }
+
+                return content.StreamReader;
+            };
+        }
+    }
+}

--- a/src/OperatorFramework/src/Controller/Informers/ResourceInformer.cs
+++ b/src/OperatorFramework/src/Controller/Informers/ResourceInformer.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Kubernetes.Controller.Informers
                 cancellationToken: cancellationToken);
 
             DateTime lastEventUtc = DateTime.UtcNow;
-            using var watcher = watchWithHttpMessage.Watch<TResource, KubernetesList<TResource>>(
+            using var watcher = watchWithHttpMessage.CustomWatch<TResource, KubernetesList<TResource>>(
                 (watchEventType, item) =>
                 {
                     if (!watcherCompletionSource.Task.IsCompleted)

--- a/src/OperatorFramework/src/Core/Client/IAnyResourceKind.cs
+++ b/src/OperatorFramework/src/Core/Client/IAnyResourceKind.cs
@@ -106,7 +106,7 @@ public interface IAnyResourceKind
     //
     //   cancellationToken:
     //     The cancellation token.
-    Task<HttpOperationResponse<KubernetesList<TResource>>> ListClusterAnyResourceKindWithHttpMessagesAsync<TResource>(string group, string version, string plural, string continueParameter = null, string fieldSelector = null, string labelSelector = null, int? limit = null, string resourceVersion = null, int? timeoutSeconds = null, bool? watch = null, string pretty = null, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default) where TResource : k8s.IKubernetesObject;
+    Task<HttpOperationResponse<KubernetesList<TResource>>> ListClusterAnyResourceKindWithHttpMessagesAsync<TResource>(string group, string version, string plural, string continueParameter = null, string fieldSelector = null, string labelSelector = null, int? limit = null, string resourceVersion = null, int? timeoutSeconds = null, bool? watch = null, bool? pretty = null, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default) where TResource : k8s.IKubernetesObject;
 
 
     /// <summary>

--- a/src/OperatorFramework/src/Core/Client/LineSeparatedHttpContent.cs
+++ b/src/OperatorFramework/src/Core/Client/LineSeparatedHttpContent.cs
@@ -1,0 +1,213 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Kubernetes.Client;
+
+public class LineSeparatedHttpContent : HttpContent
+{
+    private readonly HttpContent _originContent;
+    private readonly CancellationToken _cancellationToken;
+    private Stream _originStream;
+
+    public LineSeparatedHttpContent(HttpContent originContent, CancellationToken cancellationToken)
+    {
+        _originContent = originContent;
+        _cancellationToken = cancellationToken;
+    }
+
+    public TextReader StreamReader { get; private set; }
+
+    protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+    {
+        _originStream = await _originContent.ReadAsStreamAsync().ConfigureAwait(false);
+
+        var reader = new PeekableStreamReader(new CancelableStream(_originStream, _cancellationToken));
+        StreamReader = reader;
+
+        var firstLine = await reader.PeekLineAsync().ConfigureAwait(false);
+
+        var writer = new StreamWriter(stream);
+
+        await writer.WriteAsync(firstLine).ConfigureAwait(false);
+        await writer.FlushAsync().ConfigureAwait(false);
+    }
+
+    protected override bool TryComputeLength(out long length)
+    {
+        length = 0;
+        return false;
+    }
+
+    internal class CancelableStream : Stream
+    {
+        private readonly Stream _innerStream;
+        private readonly CancellationToken _cancellationToken;
+
+        public CancelableStream(Stream innerStream, CancellationToken cancellationToken)
+        {
+            _innerStream = innerStream;
+            _cancellationToken = cancellationToken;
+        }
+
+        public override void Flush() =>
+            _innerStream.FlushAsync(_cancellationToken).GetAwaiter().GetResult();
+
+        public override async Task FlushAsync(CancellationToken cancellationToken)
+        {
+            using (var cancellationTokenSource = CreateCancellationTokenSource(cancellationToken))
+            {
+                await _innerStream.FlushAsync(cancellationTokenSource.Token).ConfigureAwait(false);
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            _innerStream.ReadAsync(buffer, offset, count, _cancellationToken).GetAwaiter().GetResult();
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count,
+            CancellationToken cancellationToken)
+        {
+            using (var cancellationTokenSource = CreateCancellationTokenSource(cancellationToken))
+            {
+                return await _innerStream.ReadAsync(buffer, offset, count, cancellationTokenSource.Token)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => _innerStream.Seek(offset, origin);
+
+        public override void SetLength(long value) => _innerStream.SetLength(value);
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            _innerStream.WriteAsync(buffer, offset, count, _cancellationToken).GetAwaiter().GetResult();
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int count,
+            CancellationToken cancellationToken)
+        {
+            using (var cancellationTokenSource = CreateCancellationTokenSource(cancellationToken))
+            {
+                await _innerStream.WriteAsync(buffer, offset, count, cancellationTokenSource.Token)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        public override bool CanRead => _innerStream.CanRead;
+
+        public override bool CanSeek => _innerStream.CanSeek;
+
+        public override bool CanWrite => _innerStream.CanWrite;
+
+        public override long Length => _innerStream.Length;
+
+        public override long Position
+        {
+            get => _innerStream.Position;
+            set => _innerStream.Position = value;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _innerStream.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private LinkedCancellationTokenSource CreateCancellationTokenSource(CancellationToken userCancellationToken)
+        {
+            return new LinkedCancellationTokenSource(_cancellationToken, userCancellationToken);
+        }
+
+        private readonly struct LinkedCancellationTokenSource : IDisposable
+        {
+            private readonly CancellationTokenSource _cancellationTokenSource;
+
+            public LinkedCancellationTokenSource(CancellationToken token1, CancellationToken token2)
+            {
+                if (token1.CanBeCanceled && token2.CanBeCanceled)
+                {
+                    _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token1, token2);
+                    Token = _cancellationTokenSource.Token;
+                }
+                else
+                {
+                    _cancellationTokenSource = null;
+                    Token = token1.CanBeCanceled ? token1 : token2;
+                }
+            }
+
+            public CancellationToken Token { get; }
+
+            public void Dispose()
+            {
+                _cancellationTokenSource?.Dispose();
+            }
+        }
+    }
+
+    internal class PeekableStreamReader : TextReader
+    {
+        private readonly Queue<string> _buffer;
+        private readonly StreamReader _inner;
+
+        public PeekableStreamReader(Stream stream)
+        {
+            _buffer = new Queue<string>();
+            _inner = new StreamReader(stream);
+        }
+
+        public override string ReadLine() => throw new NotImplementedException();
+
+        public override Task<string> ReadLineAsync()
+        {
+            if (_buffer.Count > 0)
+            {
+                return Task.FromResult(_buffer.Dequeue());
+            }
+
+            return _inner.ReadLineAsync();
+        }
+
+        public async Task<string> PeekLineAsync()
+        {
+            var line = await ReadLineAsync().ConfigureAwait(false);
+            _buffer.Enqueue(line);
+            return line;
+        }
+
+        public override int Read() => throw new NotImplementedException();
+
+        public override int Read(char[] buffer, int index, int count) => throw new NotImplementedException();
+
+        public override Task<int> ReadAsync(char[] buffer, int index, int count) =>
+            throw new NotImplementedException();
+
+        public override int ReadBlock(char[] buffer, int index, int count) => throw new NotImplementedException();
+
+        public override Task<int> ReadBlockAsync(char[] buffer, int index, int count) =>
+            throw new NotImplementedException();
+
+        public override string ReadToEnd() => throw new NotImplementedException();
+
+        public override Task<string> ReadToEndAsync() => throw new NotImplementedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1667

The v6 `KubernetesClient` library changed the implementation of the watcher - see https://github.com/kubernetes-client/csharp/pull/681.

This change updates the `AnyResourceKind.ListClusterAnyResourceKindWithHttpMessagesAsync()` method to match the change in the `KubernetesClient` library.

Unfortunately, the `LineSeparatedHttpContent` class in the `KubernetesClient` library is inaccessible to us (internal), so has been duplicated here. This change then required the addition of the `HttpOperationResponseExtensions.CustomWatch()` extension method to ensure the correct stream reader was created.