### PR TITLE
Fix trailing comma in appsettings.json

### DIFF
--- a/docs/docfx/articles/getting-started.md
+++ b/docs/docfx/articles/getting-started.md
@@ -152,7 +152,7 @@ You can find out more about the available configuration options by looking at [R
         "ClusterId": "cluster1",
         "Match": {
           "Path": "{**catch-all}"
-        },
+        }
       }
     },
     "Clusters": {


### PR DESCRIPTION
Getting Started guide has invalid JSON with a trailing comma. Verified in sample project and JSON lint.