### PR TITLE
Fix race condition for concurrent Updates in InMemoryConfigProvider

### DIFF
--- a/docs/docfx/articles/config-providers.md
+++ b/docs/docfx/articles/config-providers.md
@@ -107,8 +107,8 @@ namespace Yarp.ReverseProxy.Configuration
 
         public void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
         {
-            var oldConfig = _config;
-            _config = new InMemoryConfig(routes, clusters);
+            var newConfig = new InMemoryConfig(routes, clusters);
+            var oldConfig = Interlocked.Exchange(ref _config, newConfig);
             oldConfig.SignalChange();
         }
 

--- a/samples/ReverseProxy.Code.Sample/InMemoryConfigProvider.cs
+++ b/samples/ReverseProxy.Code.Sample/InMemoryConfigProvider.cs
@@ -46,8 +46,8 @@ namespace Yarp.Sample
         /// </summary>
         public void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
         {
-            var oldConfig = _config;
-            _config = new InMemoryConfig(routes, clusters);
+            var newConfig = new InMemoryConfig(routes, clusters);
+            var oldConfig = Interlocked.Exchange(ref _config, newConfig);
             oldConfig.SignalChange();
         }
 

--- a/src/Kubernetes.Controller/ConfigProvider/KubernetesConfigProvider.cs
+++ b/src/Kubernetes.Controller/ConfigProvider/KubernetesConfigProvider.cs
@@ -22,8 +22,8 @@ internal class KubernetesConfigProvider : IProxyConfigProvider, IUpdateConfig
 
     public Task UpdateAsync(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters, CancellationToken cancellationToken)
     {
-        var oldConfig = _config;
-        _config = new MessageConfig(routes, clusters);
+        var newConfig = new MessageConfig(routes, clusters);
+        var oldConfig = Interlocked.Exchange(ref _config, newConfig);
         oldConfig.SignalChange();
 
         return Task.CompletedTask;

--- a/test/ReverseProxy.FunctionalTests/Common/InMemoryConfigProvider.cs
+++ b/test/ReverseProxy.FunctionalTests/Common/InMemoryConfigProvider.cs
@@ -33,8 +33,8 @@ namespace Yarp.ReverseProxy.Configuration
 
         public void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
         {
-            var oldConfig = _config;
-            _config = new InMemoryConfig(routes, clusters);
+            var newConfig = new InMemoryConfig(routes, clusters);
+            var oldConfig = Interlocked.Exchange(ref _config, newConfig);
             oldConfig.SignalChange();
         }
 

--- a/test/ReverseProxy.Tests/Common/InMemoryConfigProvider.cs
+++ b/test/ReverseProxy.Tests/Common/InMemoryConfigProvider.cs
@@ -34,8 +34,8 @@ namespace Yarp.ReverseProxy.Configuration.ConfigProvider
 
         public void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
         {
-            var oldConfig = _config;
-            _config = new InMemoryConfig(routes, clusters);
+            var newConfig = new InMemoryConfig(routes, clusters);
+            var oldConfig = Interlocked.Exchange(ref _config, newConfig);
             oldConfig.SignalChange();
         }
 

--- a/testassets/ReverseProxy.Code/InMemoryConfigProvider.cs
+++ b/testassets/ReverseProxy.Code/InMemoryConfigProvider.cs
@@ -33,8 +33,8 @@ namespace Yarp.ReverseProxy.Configuration
 
         public void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
         {
-            var oldConfig = _config;
-            _config = new InMemoryConfig(routes, clusters);
+            var newConfig = new InMemoryConfig(routes, clusters);
+            var oldConfig = Interlocked.Exchange(ref _config, newConfig);
             oldConfig.SignalChange();
         }
 


### PR DESCRIPTION
Not sure if we care about this scenario (multiple concurrent `Update`s), but since we're considering exposing it (#1713) it seems worth doing.

For reference the issue is that multiple `Update` calls may read the same `oldConfig` and one of the new configurations will never be signaled. If the proxy picks up that config object, it will stop responding to config updates.