### PR TITLE
Don't restore the upgrade header if there is no corresponding Connection entry

### DIFF
--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -515,13 +515,12 @@ internal sealed class HttpForwarder : IHttpForwarder
         if (RequestUtilities.TryGetValues(response.Headers, HeaderNames.Upgrade, out var upgradeValues)
             && response.Headers.TryGetValues(HeaderNames.Connection, out var connectionValues))
         {
-            context.Response.Headers.TryAdd(HeaderNames.Upgrade, upgradeValues);
-
             foreach (var value in connectionValues)
             {
                 if (value.Equals("upgrade", StringComparison.OrdinalIgnoreCase))
                 {
                     context.Response.Headers.TryAdd(HeaderNames.Connection, value);
+                    context.Response.Headers.TryAdd(HeaderNames.Upgrade, upgradeValues);
                     break;
                 }
             }

--- a/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
@@ -2247,6 +2247,7 @@ public class HttpForwarderTests
     [InlineData("1.1", false, "Connection: keep-alive; Keep-Alive: timeout=100", null, "Connection; Keep-Alive")]
     [InlineData("1.1", true, "Connection: upgrade; Upgrade: websocket", "Connection: upgrade; Upgrade: websocket", null)]
     [InlineData("1.1", true, "Connection: upgrade, keep-alive; Upgrade: websocket; Keep-Alive: timeout=100", "Connection: upgrade; Upgrade: websocket", "Keep-Alive")]
+    [InlineData("1.1", true, "Connection: keep-alive; Upgrade: websocket; Keep-Alive: timeout=100", null, "Connection; Upgrade; Keep-Alive")]
     [InlineData("1.1", true, "Foo: bar; Upgrade: websocket", "Foo: bar", "Upgrade")]
     [InlineData("1.1", true, "Foo: bar; Connection: upgrade", "Foo: bar", "Connection")]
     [InlineData("1.1", false, "Foo: bar", "Foo: bar", null)]


### PR DESCRIPTION
Matches the behavior used on the request side to only add the "Upgrade" header if the connection header contains an entry for it: https://github.com/microsoft/reverse-proxy/blob/94bd1273d223a37ab078a19d3173f5686543a68e/src/ReverseProxy/Forwarder/HttpForwarder.cs#L305-L323