### PR TITLE
Expose IConfigChangeListener callback service

### DIFF
--- a/src/Kubernetes.Controller/ConfigProvider/KubernetesConfigProvider.cs
+++ b/src/Kubernetes.Controller/ConfigProvider/KubernetesConfigProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -36,11 +37,18 @@ internal class KubernetesConfigProvider : IProxyConfigProvider, IUpdateConfig
         private readonly CancellationTokenSource _cts = new CancellationTokenSource();
 
         public MessageConfig(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters)
+            : this(routes, clusters, Guid.NewGuid().ToString())
+        { }
+
+        public MessageConfig(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters, string revisionId)
         {
+            RevisionId = revisionId ?? throw new ArgumentNullException(nameof(revisionId));
             Routes = routes;
             Clusters = clusters;
             ChangeToken = new CancellationChangeToken(_cts.Token);
         }
+
+        public string RevisionId { get; }
 
         public IReadOnlyList<RouteConfig> Routes { get; }
 

--- a/src/ReverseProxy/Configuration/IConfigChangeListener.cs
+++ b/src/ReverseProxy/Configuration/IConfigChangeListener.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Yarp.ReverseProxy.Configuration;
+
+/// <summary>
+/// Allows subscribing to events notifying you when the configuration is loaded and applied, or when those actions fail.
+/// </summary>
+public interface IConfigChangeListener
+{
+    /// <summary>
+    /// Invoked when an error occurs while loading the configuration.
+    /// </summary>
+    /// <param name="configProvider">The instance of the configuration provider that failed to provide the configuration.</param>
+    /// <param name="exception">The thrown exception.</param>
+    void ConfigurationLoadingFailed(IProxyConfigProvider configProvider, Exception exception);
+
+    /// <summary>
+    /// Invoked once the configuration have been successfully loaded.
+    /// </summary>
+    /// <param name="proxyConfigs">The list of instances that have been loaded.</param>
+    void ConfigurationLoaded(IReadOnlyList<IProxyConfig> proxyConfigs);
+
+    /// <summary>
+    /// Invoked when an error occurs while applying the configuration.
+    /// </summary>
+    /// <param name="proxyConfigs">The list of instances that were being processed.</param>
+    /// <param name="exception">The thrown exception.</param>
+    void ConfigurationApplyingFailed(IReadOnlyList<IProxyConfig> proxyConfigs, Exception exception);
+
+    /// <summary>
+    /// Invoked once the configuration has been successfully applied.
+    /// </summary>
+    /// <param name="proxyConfigs">The list of instances that have been applied.</param>
+    void ConfigurationApplied(IReadOnlyList<IProxyConfig> proxyConfigs);
+}

--- a/src/ReverseProxy/Configuration/IProxyConfig.cs
+++ b/src/ReverseProxy/Configuration/IProxyConfig.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Primitives;
 
 namespace Yarp.ReverseProxy.Configuration;
@@ -11,6 +13,13 @@ namespace Yarp.ReverseProxy.Configuration;
 /// </summary>
 public interface IProxyConfig
 {
+    private static readonly ConditionalWeakTable<IProxyConfig, string> _revisionIdsTable = new();
+
+    /// <summary>
+    /// A unique identifier for this revision of the configuration.
+    /// </summary>
+    string RevisionId => _revisionIdsTable.GetValue(this, static _ => Guid.NewGuid().ToString());
+
     /// <summary>
     /// Routes matching requests to clusters.
     /// </summary>

--- a/src/ReverseProxy/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Management/ProxyConfigManager.cs
@@ -49,7 +49,7 @@ internal sealed class ProxyConfigManager : EndpointDataSource, IProxyStateLookup
     private readonly List<Action<EndpointBuilder>> _conventions;
     private readonly IActiveHealthCheckMonitor _activeHealthCheckMonitor;
     private readonly IClusterDestinationsUpdater _clusterDestinationsUpdater;
-
+    private readonly IConfigChangeListener[] _configChangeListeners;
     private List<Endpoint>? _endpoints;
     private CancellationTokenSource _endpointsChangeSource = new();
     private IChangeToken _endpointsChangeToken;
@@ -66,7 +66,8 @@ internal sealed class ProxyConfigManager : EndpointDataSource, IProxyStateLookup
         ITransformBuilder transformBuilder,
         IForwarderHttpClientFactory httpClientFactory,
         IActiveHealthCheckMonitor activeHealthCheckMonitor,
-        IClusterDestinationsUpdater clusterDestinationsUpdater)
+        IClusterDestinationsUpdater clusterDestinationsUpdater,
+        IEnumerable<IConfigChangeListener> configChangeListeners)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _providers = providers?.ToArray() ?? throw new ArgumentNullException(nameof(providers));
@@ -79,6 +80,8 @@ internal sealed class ProxyConfigManager : EndpointDataSource, IProxyStateLookup
         _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
         _activeHealthCheckMonitor = activeHealthCheckMonitor ?? throw new ArgumentNullException(nameof(activeHealthCheckMonitor));
         _clusterDestinationsUpdater = clusterDestinationsUpdater ?? throw new ArgumentNullException(nameof(clusterDestinationsUpdater));
+
+        _configChangeListeners = configChangeListeners?.ToArray() ?? Array.Empty<IConfigChangeListener>();
 
         if (_providers.Length == 0)
         {
@@ -141,6 +144,11 @@ internal sealed class ProxyConfigManager : EndpointDataSource, IProxyStateLookup
     /// <inheritdoc/>
     public override IChangeToken GetChangeToken() => Volatile.Read(ref _endpointsChangeToken);
 
+    private static IReadOnlyList<IProxyConfig> ExtractListOfProxyConfigs(IEnumerable<ConfigState> configStates)
+    {
+        return configStates.Select(state => state.LatestConfig).ToList().AsReadOnly();
+    }
+
     internal async Task<EndpointDataSource> InitialLoadAsync()
     {
         // Trigger the first load immediately and throw if it fails.
@@ -160,7 +168,19 @@ internal sealed class ProxyConfigManager : EndpointDataSource, IProxyStateLookup
                 clusters.AddRange(config.Clusters ?? Array.Empty<ClusterConfig>());
             }
 
+            var proxyConfigs = ExtractListOfProxyConfigs(_configs);
+
+            foreach (var configChangeListener in _configChangeListeners)
+            {
+                configChangeListener.ConfigurationLoaded(proxyConfigs);
+            }
+
             await ApplyConfigAsync(routes, clusters);
+
+            foreach (var configChangeListener in _configChangeListeners)
+            {
+                configChangeListener.ConfigurationApplied(proxyConfigs);
+            }
 
             ListenForConfigChanges();
         }
@@ -199,6 +219,11 @@ internal sealed class ProxyConfigManager : EndpointDataSource, IProxyStateLookup
             {
                 instance.LoadFailed = true;
                 Log.ErrorReloadingConfig(_logger, ex);
+
+                foreach (var configChangeListener in _configChangeListeners)
+                {
+                    configChangeListener.ConfigurationLoadingFailed(instance.Provider, ex);
+                }
             }
 
             // If we didn't/couldn't get a new config then re-use the last one.
@@ -206,10 +231,16 @@ internal sealed class ProxyConfigManager : EndpointDataSource, IProxyStateLookup
             clusters.AddRange(instance.LatestConfig.Clusters ?? Array.Empty<ClusterConfig>());
         }
 
-        // Only reload if at least one provider changed.
-        if (sourcesChanged)
+        var proxyConfigs = ExtractListOfProxyConfigs(_configs);
+        foreach (var configChangeListener in _configChangeListeners)
         {
-            try
+            configChangeListener.ConfigurationLoaded(proxyConfigs);
+        }
+
+        try
+        {
+            // Only reload if at least one provider changed.
+            if (sourcesChanged)
             {
                 var hasChanged = await ApplyConfigAsync(routes, clusters);
                 lock (_syncRoot)
@@ -222,9 +253,19 @@ internal sealed class ProxyConfigManager : EndpointDataSource, IProxyStateLookup
                     }
                 }
             }
-            catch (Exception ex)
+
+            foreach (var configChangeListener in _configChangeListeners)
             {
-                Log.ErrorApplyingConfig(_logger, ex);
+                configChangeListener.ConfigurationApplied(proxyConfigs);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.ErrorApplyingConfig(_logger, ex);
+
+            foreach (var configChangeListener in _configChangeListeners)
+            {
+                configChangeListener.ConfigurationApplyingFailed(proxyConfigs, ex);
             }
         }
 

--- a/test/ReverseProxy.Tests/Management/ProxyConfigManagerTests.cs
+++ b/test/ReverseProxy.Tests/Management/ProxyConfigManagerTests.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Primitives;
 using Moq;
 using Xunit;
 using Yarp.ReverseProxy.Configuration;
@@ -29,7 +30,11 @@ namespace Yarp.ReverseProxy.Management.Tests;
 
 public class ProxyConfigManagerTests
 {
-    private static IServiceProvider CreateServices(List<RouteConfig> routes, List<ClusterConfig> clusters, Action<IReverseProxyBuilder> configureProxy = null)
+    private static IServiceProvider CreateServices(
+        List<RouteConfig> routes,
+        List<ClusterConfig> clusters,
+        Action<IReverseProxyBuilder> configureProxy = null,
+        IEnumerable<IConfigChangeListener> configListeners = null)
     {
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddLogging();
@@ -41,13 +46,23 @@ public class ProxyConfigManagerTests
         activeHealthPolicy.SetupGet(p => p.Name).Returns("activePolicyA");
         serviceCollection.AddSingleton(activeHealthPolicy.Object);
         configureProxy?.Invoke(proxyBuilder);
+        if (configListeners is not null)
+        {
+            foreach (var configListener in configListeners)
+            {
+                serviceCollection.AddSingleton(configListener);
+            }
+        }
         var services = serviceCollection.BuildServiceProvider();
         var routeBuilder = services.GetRequiredService<ProxyEndpointFactory>();
         routeBuilder.SetProxyPipeline(context => Task.CompletedTask);
         return services;
     }
 
-    private static IServiceProvider CreateServices(IEnumerable<IProxyConfigProvider> configProviders, Action<IReverseProxyBuilder> configureProxy = null)
+    private static IServiceProvider CreateServices(
+        IEnumerable<IProxyConfigProvider> configProviders,
+        Action<IReverseProxyBuilder> configureProxy = null,
+        IEnumerable<IConfigChangeListener> configListeners = null)
     {
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddLogging();
@@ -63,6 +78,13 @@ public class ProxyConfigManagerTests
         activeHealthPolicy.SetupGet(p => p.Name).Returns("activePolicyA");
         serviceCollection.AddSingleton(activeHealthPolicy.Object);
         configureProxy?.Invoke(proxyBuilder);
+        if (configListeners is not null)
+        {
+            foreach (var configListener in configListeners)
+            {
+                serviceCollection.AddSingleton(configListener);
+            }
+        }
         var services = serviceCollection.BuildServiceProvider();
         var routeBuilder = services.GetRequiredService<ProxyEndpointFactory>();
         routeBuilder.SetProxyPipeline(context => Task.CompletedTask);
@@ -405,6 +427,357 @@ public class ProxyConfigManagerTests
         Assert.Equal("d2", destination.DestinationId);
         Assert.NotNull(destination.Model);
         Assert.Equal(TestAddress, destination.Model.Config.Address);
+    }
+
+    private class FakeConfigChangeListener : IConfigChangeListener
+    {
+        public bool? HasApplyingSucceeded { get; private set; }
+        public bool DidAtLeastOneErrorOccurWhileLoading { get; private set; }
+        public string[] EventuallyLoaded;
+        public string[] SuccessfullyApplied;
+        public string[] FailedApplied;
+
+        public FakeConfigChangeListener()
+        {
+            Reset();
+        }
+
+        public void Reset()
+        {
+            DidAtLeastOneErrorOccurWhileLoading = false;
+            HasApplyingSucceeded = null;
+            EventuallyLoaded = Array.Empty<string>();
+            SuccessfullyApplied = Array.Empty<string>();
+            FailedApplied = Array.Empty<string>();
+        }
+
+        public void ConfigurationLoadingFailed(IProxyConfigProvider configProvider, Exception ex)
+        {
+            DidAtLeastOneErrorOccurWhileLoading = true;
+        }
+
+        public void ConfigurationLoaded(IReadOnlyList<IProxyConfig> proxyConfigs)
+        {
+            EventuallyLoaded = proxyConfigs.Select(c => c.RevisionId).ToArray();
+        }
+
+        public void ConfigurationApplyingFailed(IReadOnlyList<IProxyConfig> proxyConfigs, Exception ex)
+        {
+            HasApplyingSucceeded = false;
+            FailedApplied = proxyConfigs.Select(c => c.RevisionId).ToArray();
+        }
+
+        public void ConfigurationApplied(IReadOnlyList<IProxyConfig> proxyConfigs)
+        {
+            HasApplyingSucceeded = true;
+            SuccessfullyApplied = proxyConfigs.Select(c => c.RevisionId).ToArray();
+        }
+    }
+
+    private class ConfigChangeListenerCounter : IConfigChangeListener
+    {
+        public int NumberOfLoadedConfigurations { get; private set; }
+        public int NumberOfFailedConfigurationLoads { get; private set; }
+        public int NumberOfAppliedConfigurations { get; private set; }
+        public int NumberOfFailedConfigurationApplications { get; private set; }
+
+        public ConfigChangeListenerCounter()
+        {
+            Reset();
+        }
+
+        public void Reset()
+        {
+            NumberOfLoadedConfigurations = 0;
+            NumberOfFailedConfigurationLoads = 0;
+            NumberOfAppliedConfigurations = 0;
+            NumberOfFailedConfigurationApplications = 0;
+        }
+
+        public void ConfigurationLoadingFailed(IProxyConfigProvider configProvider, Exception ex)
+        {
+            NumberOfFailedConfigurationLoads++;
+        }
+
+        public void ConfigurationLoaded(IReadOnlyList<IProxyConfig> proxyConfigs)
+        {
+            NumberOfLoadedConfigurations += proxyConfigs.Count;
+        }
+
+        public void ConfigurationApplyingFailed(IReadOnlyList<IProxyConfig> proxyConfigs, Exception ex)
+        {
+            NumberOfFailedConfigurationApplications += proxyConfigs.Count;
+        }
+
+        public void ConfigurationApplied(IReadOnlyList<IProxyConfig> proxyConfigs)
+        {
+            NumberOfAppliedConfigurations += proxyConfigs.Count;
+        }
+    }
+
+    private class InMemoryConfig : IProxyConfig
+    {
+        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+
+        public InMemoryConfig(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters, string revisionId)
+        {
+            RevisionId = revisionId;
+            Routes = routes;
+            Clusters = clusters;
+            ChangeToken = new CancellationChangeToken(_cts.Token);
+        }
+
+        public string RevisionId { get; }
+
+        public IReadOnlyList<RouteConfig> Routes { get; }
+
+        public IReadOnlyList<ClusterConfig> Clusters { get; }
+
+        public IChangeToken ChangeToken { get; }
+
+        internal void SignalChange()
+        {
+            _cts.Cancel();
+        }
+    }
+
+    private class OnDemandFailingInMemoryConfigProvider : IProxyConfigProvider
+    {
+        private volatile InMemoryConfig _config;
+
+        public OnDemandFailingInMemoryConfigProvider(
+            InMemoryConfig config)
+        {
+            _config = config;
+        }
+
+        public OnDemandFailingInMemoryConfigProvider(
+            IReadOnlyList<RouteConfig> routes,
+            IReadOnlyList<ClusterConfig> clusters,
+            string revisionId) : this(new InMemoryConfig(routes, clusters, revisionId))
+        {
+        }
+
+        public IProxyConfig GetConfig()
+        {
+            if (ShouldConfigLoadingFail)
+            {
+                return null;
+            }
+
+            return _config;
+        }
+
+        public void Update(IReadOnlyList<RouteConfig> routes, IReadOnlyList<ClusterConfig> clusters, string revisionId)
+        {
+            Update(new InMemoryConfig(routes, clusters, revisionId));
+        }
+
+        public void Update(InMemoryConfig config)
+        {
+            var oldConfig = Interlocked.Exchange(ref _config, config);
+            oldConfig.SignalChange();
+        }
+
+        public bool ShouldConfigLoadingFail { get; set; }
+    }
+
+    [Fact]
+    public async Task BuildConfig_CanBeNotifiedOfProxyConfigSuccessfulAndFailedLoading()
+    {
+        var configProviderA = new OnDemandFailingInMemoryConfigProvider(new List<RouteConfig>() { }, new List<ClusterConfig>() { }, "A1");
+        var configProviderB = new OnDemandFailingInMemoryConfigProvider(new List<RouteConfig>() { }, new List<ClusterConfig>() { }, "B1");
+
+        var configChangeListenerCounter = new ConfigChangeListenerCounter();
+        var fakeConfigChangeListener = new FakeConfigChangeListener();
+
+        var services = CreateServices(new[] { configProviderA, configProviderB }, null, new IConfigChangeListener[] { fakeConfigChangeListener, configChangeListenerCounter });
+
+        var manager = services.GetRequiredService<ProxyConfigManager>();
+        await manager.InitialLoadAsync();
+
+        Assert.Equal(2, configChangeListenerCounter.NumberOfLoadedConfigurations);
+        Assert.Equal(0, configChangeListenerCounter.NumberOfFailedConfigurationLoads);
+        Assert.Equal(2, configChangeListenerCounter.NumberOfAppliedConfigurations);
+        Assert.Equal(0, configChangeListenerCounter.NumberOfFailedConfigurationApplications);
+
+        Assert.False(fakeConfigChangeListener.DidAtLeastOneErrorOccurWhileLoading);
+        Assert.Equal(new[] { "A1", "B1" }, fakeConfigChangeListener.EventuallyLoaded);
+        Assert.True(fakeConfigChangeListener.HasApplyingSucceeded);
+        Assert.Equal(new[] { "A1", "B1" }, fakeConfigChangeListener.SuccessfullyApplied);
+        Assert.Empty(fakeConfigChangeListener.FailedApplied);
+
+        const string TestAddress = "https://localhost:123/";
+
+        var cluster1 = new ClusterConfig
+        {
+            ClusterId = "cluster1",
+            Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "d1", new DestinationConfig { Address = TestAddress } }
+            }
+        };
+        var cluster2 = new ClusterConfig
+        {
+            ClusterId = "cluster2",
+            Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "d2", new DestinationConfig { Address = TestAddress } }
+            }
+        };
+
+        var route1 = new RouteConfig
+        {
+            RouteId = "route1",
+            ClusterId = "cluster1",
+            Match = new RouteMatch { Path = "/" }
+        };
+        var route2 = new RouteConfig
+        {
+            RouteId = "route2",
+            ClusterId = "cluster2",
+            Match = new RouteMatch { Path = "/" }
+        };
+
+        fakeConfigChangeListener.Reset();
+        configChangeListenerCounter.Reset();
+
+        configProviderA.Update(new List<RouteConfig>() { route1 }, new List<ClusterConfig>() { cluster1 }, "A2");
+
+        Assert.Equal(2, configChangeListenerCounter.NumberOfLoadedConfigurations);
+        Assert.Equal(0, configChangeListenerCounter.NumberOfFailedConfigurationLoads);
+        Assert.Equal(2, configChangeListenerCounter.NumberOfAppliedConfigurations);
+        Assert.Equal(0, configChangeListenerCounter.NumberOfFailedConfigurationApplications);
+
+        Assert.False(fakeConfigChangeListener.DidAtLeastOneErrorOccurWhileLoading);
+        Assert.Equal(new[] { "A2", "B1" }, fakeConfigChangeListener.EventuallyLoaded);
+        Assert.True(fakeConfigChangeListener.HasApplyingSucceeded);
+        Assert.Equal(new[] { "A2", "B1" }, fakeConfigChangeListener.SuccessfullyApplied);
+        Assert.Empty(fakeConfigChangeListener.FailedApplied);
+
+        configProviderB.ShouldConfigLoadingFail = true;
+
+        fakeConfigChangeListener.Reset();
+        configChangeListenerCounter.Reset();
+
+        configProviderB.Update(new List<RouteConfig>() { route2 }, new List<ClusterConfig>() { cluster2 }, "B2");
+
+        Assert.Equal(2, configChangeListenerCounter.NumberOfLoadedConfigurations);
+        Assert.Equal(1, configChangeListenerCounter.NumberOfFailedConfigurationLoads);
+        Assert.Equal(2, configChangeListenerCounter.NumberOfAppliedConfigurations);
+        Assert.Equal(0, configChangeListenerCounter.NumberOfFailedConfigurationApplications);
+
+        Assert.True(fakeConfigChangeListener.DidAtLeastOneErrorOccurWhileLoading);
+        Assert.Equal(new[] { "A2", "B1" }, fakeConfigChangeListener.EventuallyLoaded);
+        Assert.True(fakeConfigChangeListener.HasApplyingSucceeded);
+        Assert.Equal(new[] { "A2", "B1" }, fakeConfigChangeListener.SuccessfullyApplied);
+        Assert.Empty(fakeConfigChangeListener.FailedApplied);
+    }
+
+    [Fact]
+    public async Task BuildConfig_CanBeNotifiedOfProxyConfigSuccessfulAndFailedUpdating()
+    {
+        var configProviderA = new InMemoryConfigProvider(new List<RouteConfig>() { }, new List<ClusterConfig>() { }, "A1");
+        var configProviderB = new InMemoryConfigProvider(new List<RouteConfig>() { }, new List<ClusterConfig>() { }, "B1");
+
+        var configChangeListenerCounter = new ConfigChangeListenerCounter();
+        var fakeConfigChangeListener = new FakeConfigChangeListener();
+
+        var services = CreateServices(new[] { configProviderA, configProviderB }, null, new IConfigChangeListener[] { fakeConfigChangeListener, configChangeListenerCounter });
+
+        var manager = services.GetRequiredService<ProxyConfigManager>();
+        await manager.InitialLoadAsync();
+
+        Assert.Equal(2, configChangeListenerCounter.NumberOfLoadedConfigurations);
+        Assert.Equal(0, configChangeListenerCounter.NumberOfFailedConfigurationLoads);
+        Assert.Equal(2, configChangeListenerCounter.NumberOfAppliedConfigurations);
+        Assert.Equal(0, configChangeListenerCounter.NumberOfFailedConfigurationApplications);
+
+        Assert.False(fakeConfigChangeListener.DidAtLeastOneErrorOccurWhileLoading);
+        Assert.Equal(new[] { "A1", "B1" }, fakeConfigChangeListener.EventuallyLoaded);
+        Assert.True(fakeConfigChangeListener.HasApplyingSucceeded);
+        Assert.Equal(new[] { "A1", "B1" }, fakeConfigChangeListener.SuccessfullyApplied);
+        Assert.Empty(fakeConfigChangeListener.FailedApplied);
+
+        const string TestAddress = "https://localhost:123/";
+
+        var cluster1 = new ClusterConfig
+        {
+            ClusterId = "cluster1",
+            Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "d1", new DestinationConfig { Address = TestAddress } }
+            }
+        };
+        var cluster2 = new ClusterConfig
+        {
+            ClusterId = "cluster2",
+            Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "d2", new DestinationConfig { Address = TestAddress } }
+            }
+        };
+
+        var route1 = new RouteConfig
+        {
+            RouteId = "route1",
+            ClusterId = "cluster1",
+            Match = new RouteMatch { Path = "/" }
+        };
+        var route2 = new RouteConfig
+        {
+            RouteId = "route2",
+            ClusterId = "cluster2",
+            // Missing Match here will be caught by the analysis
+        };
+
+        fakeConfigChangeListener.Reset();
+        configChangeListenerCounter.Reset();
+
+        configProviderA.Update(new List<RouteConfig>() { route1 }, new List<ClusterConfig>() { cluster1 }, "A2");
+
+        Assert.Equal(2, configChangeListenerCounter.NumberOfLoadedConfigurations);
+        Assert.Equal(0, configChangeListenerCounter.NumberOfFailedConfigurationLoads);
+        Assert.Equal(2, configChangeListenerCounter.NumberOfAppliedConfigurations);
+        Assert.Equal(0, configChangeListenerCounter.NumberOfFailedConfigurationApplications);
+
+        Assert.False(fakeConfigChangeListener.DidAtLeastOneErrorOccurWhileLoading);
+        Assert.Equal(new[] { "A2", "B1" }, fakeConfigChangeListener.EventuallyLoaded);
+        Assert.True(fakeConfigChangeListener.HasApplyingSucceeded);
+        Assert.Equal(new[] { "A2", "B1" }, fakeConfigChangeListener.SuccessfullyApplied);
+        Assert.Empty(fakeConfigChangeListener.FailedApplied);
+
+        fakeConfigChangeListener.Reset();
+        configChangeListenerCounter.Reset();
+
+        configProviderB.Update(new List<RouteConfig>() { route2 }, new List<ClusterConfig>() { cluster2 }, "B2");
+
+        Assert.Equal(2, configChangeListenerCounter.NumberOfLoadedConfigurations);
+        Assert.Equal(0, configChangeListenerCounter.NumberOfFailedConfigurationLoads);
+        Assert.Equal(0, configChangeListenerCounter.NumberOfAppliedConfigurations);
+        Assert.Equal(2, configChangeListenerCounter.NumberOfFailedConfigurationApplications);
+
+        Assert.False(fakeConfigChangeListener.DidAtLeastOneErrorOccurWhileLoading);
+        Assert.Equal(new[] { "A2", "B2" }, fakeConfigChangeListener.EventuallyLoaded);
+        Assert.False(fakeConfigChangeListener.HasApplyingSucceeded);
+        Assert.Empty(fakeConfigChangeListener.SuccessfullyApplied);
+        Assert.Equal(new[] { "A2", "B2" }, fakeConfigChangeListener.FailedApplied);
+    }
+
+    public class DummyProxyConfig : IProxyConfig
+    {
+        public IReadOnlyList<RouteConfig> Routes => throw new NotImplementedException();
+        public IReadOnlyList<ClusterConfig> Clusters => throw new NotImplementedException();
+        public IChangeToken ChangeToken => throw new NotImplementedException();
+    }
+
+    [Fact]
+    public void IProxyConfigDerivedTypes_RevisionIdIsAutomaticallySet()
+    {
+        IProxyConfig config = new DummyProxyConfig();
+        Assert.NotNull(config.RevisionId);
+        Assert.NotEmpty(config.RevisionId);
+        Assert.Same(config.RevisionId, config.RevisionId);
     }
 
     [Fact]


### PR DESCRIPTION
Fix #1619

_From the original issue:_

"When dynamically applying loaded configuration (cf. https://microsoft.github.io/reverse-proxy/articles/config-providers.html) after the initial startup, any validation failure will be logged, then silenced.

We would need a way to get notified of both successful configuration changes and invalid configuration rejection."

This is an attempt to propagate whether or not the loaded configuration has been applied or not.