### PR TITLE
Fix `QueryValueParameter` example

### DIFF
--- a/docs/docfx/articles/transforms.md
+++ b/docs/docfx/articles/transforms.md
@@ -82,7 +82,7 @@ Here is an example of common transforms:
         "Transforms": [
           { "PathPattern": "/foo/{plugin}/bar/{**remainder}" },
           {
-            "QueryStringParameter": "q",
+            "QueryValueParameter": "q",
             "Append": "plugin"
           }
         ]


### PR DESCRIPTION
The example documentation produces the error `The proxy config is invalid. (Unknown transform: Append;QueryStringParameter)`.