### PR TITLE
Overload ReassignProxyRequest to also accept a route update

### DIFF
--- a/src/ReverseProxy/Model/HttpContextFeaturesExtensions.cs
+++ b/src/ReverseProxy/Model/HttpContextFeaturesExtensions.cs
@@ -62,8 +62,10 @@ public static class HttpContextFeaturesExtensions
     }
 
     // ReassignProxyRequest overload to also replace the route when updating IReverseProxyFeature
-    // See discussion in https://github.com/microsoft/reverse-proxy/discussions/1749
-    // and https://github.com/microsoft/reverse-proxy/issues/1752
+    /// <summary>
+    /// Replaces the assigned route, cluster, and destinations in <see cref="IReverseProxyFeature"/> with the new <see cref="RouteModel"/>
+    /// and new <see cref="ClusterState"/>, causing the request to be sent using the new route to the new cluster.
+    /// </summary>
     public static void ReassignProxyRequest(this HttpContext context, RouteModel route, ClusterState cluster)
     {
         var oldFeature = context.GetReverseProxyFeature();

--- a/src/ReverseProxy/Model/HttpContextFeaturesExtensions.cs
+++ b/src/ReverseProxy/Model/HttpContextFeaturesExtensions.cs
@@ -64,7 +64,7 @@ public static class HttpContextFeaturesExtensions
     // ReassignProxyRequest overload to also replace the route when updating IReverseProxyFeature
     // See discussion in https://github.com/microsoft/reverse-proxy/discussions/1749
     // and https://github.com/microsoft/reverse-proxy/issues/1752
-    public static void ReassignProxyRequest(this HttpContext context, ClusterState cluster, RouteModel route)
+    public static void ReassignProxyRequest(this HttpContext context, RouteModel route, ClusterState cluster)
     {
         var oldFeature = context.GetReverseProxyFeature();
         var destinations = cluster.DestinationsState;

--- a/src/ReverseProxy/Model/HttpContextFeaturesExtensions.cs
+++ b/src/ReverseProxy/Model/HttpContextFeaturesExtensions.cs
@@ -60,4 +60,22 @@ public static class HttpContextFeaturesExtensions
         };
         context.Features.Set<IReverseProxyFeature>(newFeature);
     }
+
+    // ReassignProxyRequest overload to also replace the route when updating IReverseProxyFeature
+    // See discussion in https://github.com/microsoft/reverse-proxy/discussions/1749
+    // and https://github.com/microsoft/reverse-proxy/issues/1752
+    public static void ReassignProxyRequest(this HttpContext context, ClusterState cluster, RouteModel route)
+    {
+        var oldFeature = context.GetReverseProxyFeature();
+        var destinations = cluster.DestinationsState;
+        var newFeature = new ReverseProxyFeature()
+        {
+            Route = route,
+            Cluster = cluster.Model,
+            AllDestinations = destinations.AllDestinations,
+            AvailableDestinations = destinations.AvailableDestinations,
+            ProxiedDestination = oldFeature.ProxiedDestination,
+        };
+        context.Features.Set<IReverseProxyFeature>(newFeature);
+    }
 }

--- a/test/ReverseProxy.Tests/Model/HttpContextFeaturesExtensions.cs
+++ b/test/ReverseProxy.Tests/Model/HttpContextFeaturesExtensions.cs
@@ -61,6 +61,5 @@ public class HttpContextFeaturesExtensions
         Assert.Same(d1, newFeatureOverload.ProxiedDestination); // Unmodified
         Assert.Same(cm2, newFeatureOverload.Cluster); // Unmodified
         Assert.Same(r2, newFeatureOverload.Route); // Asset route update
-        // Assert.Same(r1, newFeatureOverload.Route); // Test should fail
     }
 }

--- a/test/ReverseProxy.Tests/Model/HttpContextFeaturesExtensions.cs
+++ b/test/ReverseProxy.Tests/Model/HttpContextFeaturesExtensions.cs
@@ -49,5 +49,18 @@ public class HttpContextFeaturesExtensions
         Assert.Same(d1, newFeature.ProxiedDestination); // Copied unmodified.
         Assert.Same(cm2, newFeature.Cluster);
         Assert.Same(r1, newFeature.Route);
+
+        // Beging testing ReassignProxyRequest(route, cluster) overload
+        var r2 = new RouteModel(new RouteConfig() { RouteId = "r2" }, cs2, HttpTransformer.Empty);
+        context.ReassignProxyRequest(r2, cs2);
+
+        var newFeatureOverload = context.GetReverseProxyFeature();
+        Assert.NotSame(newFeature, newFeatureOverload);
+        Assert.Same(d2, newFeatureOverload.AllDestinations); // Unmodified
+        Assert.Same(d2, newFeatureOverload.AvailableDestinations); // Unmodified
+        Assert.Same(d1, newFeatureOverload.ProxiedDestination); // Unmodified
+        Assert.Same(cm2, newFeatureOverload.Cluster); // Unmodified
+        Assert.Same(r2, newFeatureOverload.Route); // Asset route update
+        // Assert.Same(r1, newFeatureOverload.Route); // Test should fail
     }
 }

--- a/test/ReverseProxy.Tests/Model/HttpContextFeaturesExtensions.cs
+++ b/test/ReverseProxy.Tests/Model/HttpContextFeaturesExtensions.cs
@@ -50,7 +50,7 @@ public class HttpContextFeaturesExtensions
         Assert.Same(cm2, newFeature.Cluster);
         Assert.Same(r1, newFeature.Route);
 
-        // Beging testing ReassignProxyRequest(route, cluster) overload
+        // Begin testing ReassignProxyRequest(route, cluster) overload
         var r2 = new RouteModel(new RouteConfig() { RouteId = "r2" }, cs2, HttpTransformer.Empty);
         context.ReassignProxyRequest(r2, cs2);
 


### PR DESCRIPTION
Adds an overload for ReassignProxyRequest that assigns both route and cluster when reassigning a proxy request.

See discussions in #1749 and #1752 for more info.