### PR TITLE
Close WebSockets gracefully

### DIFF
--- a/samples/SampleServer/Controllers/WebSocketsController.cs
+++ b/samples/SampleServer/Controllers/WebSocketsController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -36,7 +36,9 @@ namespace SampleServer.Controllers
         {
             if (!HttpContext.WebSockets.IsWebSocketRequest)
             {
-                HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                HttpContext.Response.ContentType = "text/html";
+                await HttpContext.Response.SendFileAsync("./wwwroot/index.html");
+                return;
             }
 
             using (var webSocket = await HttpContext.WebSockets.AcceptWebSocketAsync())

--- a/samples/SampleServer/wwwroot/index.html
+++ b/samples/SampleServer/wwwroot/index.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+    <style>
+        table { border: 0 }
+        .commslog-data { font-family: Consolas, Courier New, Courier, monospace; }
+        .commslog-server { background-color: red; color: white }
+        .commslog-client { background-color: green; color: white }
+    </style>
+</head>
+<body>
+    <h1>WebSocket Test Page</h1>
+    <p id="stateLabel">Ready to connect...</p>
+    <div>
+        <label for="connectionUrl">WebSocket Server URL:</label>
+        <input id="connectionUrl" />
+        <button id="connectButton" type="submit">Connect</button>
+    </div>
+    <div>
+        <label for="sendMessage">Message to send:</label>
+        <input id="sendMessage" disabled />
+        <button id="sendButton" type="submit" disabled>Send</button>
+        <button id="closeButton" disabled>Close Socket</button>
+    </div>
+
+    <p>Note: When connected to the default server (i.e. the server in the address bar ;)), the message "ServerClose" will cause the server to close the connection. Similarly, the message "ServerAbort" will cause the server to forcibly terminate the connection without a closing handshake</p>
+
+    <h2>Communication Log</h2>
+    <table style="width: 800px">
+        <thead>
+            <tr>
+                <td style="width: 100px">From</td>
+                <td style="width: 100px">To</td>
+                <td>Data</td>
+            </tr>
+        </thead>
+        <tbody id="commsLog">
+        </tbody>
+    </table>
+
+    <script>
+        var connectionForm = document.getElementById("connectionForm");
+        var connectionUrl = document.getElementById("connectionUrl");
+        var connectButton = document.getElementById("connectButton");
+        var stateLabel = document.getElementById("stateLabel");
+        var sendMessage = document.getElementById("sendMessage");
+        var sendButton = document.getElementById("sendButton");
+        var sendForm = document.getElementById("sendForm");
+        var commsLog = document.getElementById("commsLog");
+
+        var socket;
+
+        var scheme = document.location.protocol == "https:" ? "wss" : "ws";
+        var port = document.location.port ? (":" + document.location.port) : "";
+
+        connectionUrl.value = scheme + "://" + document.location.hostname + port + "/api/websockets";
+
+        function updateState() {
+            function disable() {
+                sendMessage.disabled = true;
+                sendButton.disabled = true;
+                closeButton.disabled = true;
+            }
+            function enable() {
+                sendMessage.disabled = false;
+                sendButton.disabled = false;
+                closeButton.disabled = false;
+            }
+
+            connectionUrl.disabled = true;
+            connectButton.disabled = true;
+
+            if (!socket) {
+                disable();
+            } else {
+                switch (socket.readyState) {
+                    case WebSocket.CLOSED:
+                        stateLabel.innerHTML = "Closed";
+                        disable();
+                        connectionUrl.disabled = false;
+                        connectButton.disabled = false;
+                        break;
+                    case WebSocket.CLOSING:
+                        stateLabel.innerHTML = "Closing...";
+                        disable();
+                        break;
+                    case WebSocket.CONNECTING:
+                        stateLabel.innerHTML = "Connecting...";
+                        disable();
+                        break;
+                    case WebSocket.OPEN:
+                        stateLabel.innerHTML = "Open";
+                        enable();
+                        break;
+                    default:
+                        stateLabel.innerHTML = "Unknown WebSocket State: " + socket.readyState;
+                        disable();
+                        break;
+                }
+            }
+        }
+
+        closeButton.onclick = function () {
+            if (!socket || socket.readyState != WebSocket.OPEN) {
+                alert("socket not connected");
+            }
+            socket.close(1000, "Closing from client");
+        }
+
+        sendButton.onclick = function () {
+            if (!socket || socket.readyState != WebSocket.OPEN) {
+                alert("socket not connected");
+            }
+            var data = sendMessage.value;
+            socket.send(data);
+            commsLog.innerHTML += '<tr>' +
+                '<td class="commslog-client">Client</td>' +
+                '<td class="commslog-server">Server</td>' +
+                '<td class="commslog-data">' + data + '</td>'
+            '</tr>';
+        }
+
+        connectButton.onclick = function() {
+            stateLabel.innerHTML = "Connecting";
+            socket = new WebSocket(connectionUrl.value);
+            socket.onopen = function (event) {
+                updateState();
+                commsLog.innerHTML += '<tr>' +
+                    '<td colspan="3" class="commslog-data">Connection opened</td>' +
+                '</tr>';
+            };
+            socket.onclose = function (event) {
+                updateState();
+                commsLog.innerHTML += '<tr>' +
+                    '<td colspan="3" class="commslog-data">Connection closed. Code: ' + event.code + '. Reason: ' + event.reason + '</td>' +
+                '</tr>';
+            };
+            socket.onerror = updateState;
+            socket.onmessage = function (event) {
+                commsLog.innerHTML += '<tr>' +
+                    '<td class="commslog-server">Server</td>' +
+                    '<td class="commslog-client">Client</td>' +
+                    '<td class="commslog-data">' + event.data + '</td>'
+                '</tr>';
+            };
+        };
+    </script>
+</body>
+</html>

--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -590,8 +590,15 @@ internal sealed class HttpForwarder : IHttpForwarder
         }
         else
         {
+            var cancelReads = !requestFinishedFirst && !secondTask.IsCompleted;
+            if (cancelReads)
+            {
+                // The response is finished, unblock the incoming reads
+                activityCancellationSource.Cancel();
+            }
+
             var (secondResult, secondException) = await secondTask;
-            if (secondResult != StreamCopyResult.Success)
+            if (!cancelReads && secondResult != StreamCopyResult.Success)
             {
                 error = ReportResult(context, !requestFinishedFirst, secondResult, secondException!);
             }
@@ -603,13 +610,13 @@ internal sealed class HttpForwarder : IHttpForwarder
 
         return error;
 
-        ForwarderError ReportResult(HttpContext context, bool reqeuest, StreamCopyResult result, Exception exception)
+        ForwarderError ReportResult(HttpContext context, bool request, StreamCopyResult result, Exception exception)
         {
             var error = result switch
             {
-                StreamCopyResult.InputError => reqeuest ? ForwarderError.UpgradeRequestClient : ForwarderError.UpgradeResponseDestination,
-                StreamCopyResult.OutputError => reqeuest ? ForwarderError.UpgradeRequestDestination : ForwarderError.UpgradeResponseClient,
-                StreamCopyResult.Canceled => reqeuest ? ForwarderError.UpgradeRequestCanceled : ForwarderError.UpgradeResponseCanceled,
+                StreamCopyResult.InputError => request ? ForwarderError.UpgradeRequestClient : ForwarderError.UpgradeResponseDestination,
+                StreamCopyResult.OutputError => request ? ForwarderError.UpgradeRequestDestination : ForwarderError.UpgradeResponseClient,
+                StreamCopyResult.Canceled => request ? ForwarderError.UpgradeRequestCanceled : ForwarderError.UpgradeResponseCanceled,
                 _ => throw new NotImplementedException(result.ToString()),
             };
             ReportProxyError(context, error, exception);

--- a/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetryStream.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetryStream.cs
@@ -59,9 +59,9 @@ internal sealed class WebSocketsTelemetryStream : DelegatingStream
             ForwarderError.UpgradeRequestDestination => WebSocketCloseReason.ServerDisconnect,
             ForwarderError.UpgradeResponseDestination => WebSocketCloseReason.ServerDisconnect,
 
-            // Both sides gracefully closed the underlying connection without sending a WebSocket close
-            // Neither side is doing what we recognize as WebSockets ¯\_(ツ)_/¯
-            null => WebSocketCloseReason.Unknown,
+            // Both sides gracefully closed the underlying connection without sending a WebSocket close,
+            // or the server closed the connection and we canceled the client and suppressed the errors.
+            null => WebSocketCloseReason.ServerDisconnect,
 
             // We are not expecting any other error from HttpForwarder after a successful connection upgrade
             // Technically, a user could overwrite the IForwarderErrorFeature, in which case we don't know what's going on

--- a/test/ReverseProxy.FunctionalTests/WebSocketTests.cs
+++ b/test/ReverseProxy.FunctionalTests/WebSocketTests.cs
@@ -90,17 +90,19 @@ public class WebSocketTests
 
             using var rawStream = await response.Content.ReadAsStreamAsync(cts.Token);
 
-            var buffer = new byte[1];
+            var buffer = new byte[5];
             for (var i = 0; i <= 255; i++)
             {
                 buffer[0] = (byte)i;
-                await rawStream.WriteAsync(buffer, 0, 1, cts.Token);
+                await rawStream.WriteAsync(buffer, 0, buffer.Length, cts.Token);
                 var read = await rawStream.ReadAsync(buffer, cts.Token);
 
-                Assert.Equal(1, read);
+                Assert.Equal(buffer.Length, read);
                 Assert.Equal(i, buffer[0]);
             }
 
+            await rawStream.WriteAsync(Encoding.UTF8.GetBytes("close"));
+            while (await rawStream.ReadAsync(buffer, cts.Token) != 0) { }
             rawStream.Dispose();
         }, cts.Token);
     }
@@ -204,11 +206,16 @@ public class WebSocketTests
             }
 
             await using var stream = await upgradeFeature.UpgradeAsync();
-            var buffer = new byte[1];
+            var buffer = new byte[5];
             int read;
             while ((read = await stream.ReadAsync(buffer, httpContext.RequestAborted)) != 0)
             {
                 await stream.WriteAsync(buffer, 0, read, httpContext.RequestAborted);
+
+                if (string.Equals("close", Encoding.UTF8.GetString(buffer, 0, read), StringComparison.Ordinal))
+                {
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
Forward port of #1773 into main. Contributes to #1770.

TODO: I'm seeing some failures in WebSocketTelemetryTests that didn't show up in the original PR, but are now showing up locally in both 1.1 and main. 🤷 
- I partially understand now. Before a server graceful disconnect presented as a client timeout. Now YARP cancels the reads and suppresses the error, causing the telemetry to report Unknown.
- The telemetry can track reads and know when read returns 0, but it can't know when the write stream is closed unless it tries to write to it.

The test changes should be backported to 1.1.