### PR TITLE
Throw an exception in ConfigureHttpClient when custom IForwarderHttpClientFactory is added

### DIFF
--- a/src/ReverseProxy/Management/ReverseProxyServiceCollectionExtensions.cs
+++ b/src/ReverseProxy/Management/ReverseProxyServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Linq;
 using System.Net.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -141,6 +142,15 @@ public static class ReverseProxyServiceCollectionExtensions
         if (configure is null)
         {
             throw new ArgumentNullException(nameof(configure));
+        }
+
+        var service = builder.Services.FirstOrDefault(service => service.ServiceType == typeof(IForwarderHttpClientFactory));
+        if (service is not null)
+        {
+            if (service.ImplementationType != typeof(ForwarderHttpClientFactory))
+            {
+                throw new InvalidOperationException($"ConfigureHttpClient will override the custom IForwarderHttpClientFactory type.");
+            }
         }
 
         builder.Services.AddSingleton<IForwarderHttpClientFactory>(services =>

--- a/src/ReverseProxy/Management/ReverseProxyServiceCollectionExtensions.cs
+++ b/src/ReverseProxy/Management/ReverseProxyServiceCollectionExtensions.cs
@@ -144,6 +144,8 @@ public static class ReverseProxyServiceCollectionExtensions
             throw new ArgumentNullException(nameof(configure));
         }
 
+        // Avoid overriding any other custom factories. This does not handle the case where a IForwarderHttpClientFactory
+        // is registered after this call.
         var service = builder.Services.FirstOrDefault(service => service.ServiceType == typeof(IForwarderHttpClientFactory));
         if (service is not null)
         {

--- a/test/ReverseProxy.Tests/Forwarder/ReverseProxyServiceCollectionTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/ReverseProxyServiceCollectionTests.cs
@@ -2,17 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Net;
 using System.Net.Http;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
-using Moq;
-using Xunit;
-using Yarp.Tests.Common;
-using Yarp.ReverseProxy.Configuration;
-using Yarp.ReverseProxy.Model;
 using Microsoft.Extensions.DependencyInjection;
+using Xunit;
 
 namespace Yarp.ReverseProxy.Forwarder;
 

--- a/test/ReverseProxy.Tests/Forwarder/ReverseProxyServiceCollectionTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/ReverseProxyServiceCollectionTests.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+using Yarp.Tests.Common;
+using Yarp.ReverseProxy.Configuration;
+using Yarp.ReverseProxy.Model;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Yarp.ReverseProxy.Forwarder;
+
+public class ReverseProxyServiceCollectionTests
+{
+
+    [Fact]
+    public void ConfigureHttpClient_Works()
+    {
+        new ServiceCollection()
+            .AddReverseProxy()
+            .ConfigureHttpClient((_, _) => { });
+    }
+
+    [Fact] 
+    public void ConfigureHttpClient_ThrowIfCustomServiceAdded()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            new ServiceCollection()
+                .AddSingleton<IForwarderHttpClientFactory, CustomForwarderHttpClientFactory>()
+                .AddReverseProxy()
+                .ConfigureHttpClient((_, _) => { });
+        });
+    }
+
+    private class CustomForwarderHttpClientFactory : IForwarderHttpClientFactory
+    {
+        public HttpMessageInvoker CreateClient(ForwarderHttpClientContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/reverse-proxy/issues/1799

