### PR TITLE
Add HeaderMatchMode.NotExists, enable matchers that only match if the…

### DIFF
--- a/src/ReverseProxy/Configuration/ConfigValidator.cs
+++ b/src/ReverseProxy/Configuration/ConfigValidator.cs
@@ -199,15 +199,15 @@ internal sealed class ConfigValidator : IConfigValidator
                 errors.Add(new ArgumentException($"A null or empty route header name has been set for route '{routeId}'."));
             }
 
-            if (header.Mode != HeaderMatchMode.Exists
+            if ((header.Mode != HeaderMatchMode.Exists && header.Mode != HeaderMatchMode.NotExists)
                 && (header.Values is null || header.Values.Count == 0))
             {
                 errors.Add(new ArgumentException($"No header values were set on route header '{header.Name}' for route '{routeId}'."));
             }
 
-            if (header.Mode == HeaderMatchMode.Exists && header.Values?.Count > 0)
+            if ((header.Mode == HeaderMatchMode.Exists || header.Mode == HeaderMatchMode.NotExists) && header.Values?.Count > 0)
             {
-                errors.Add(new ArgumentException($"Header values where set when using mode '{nameof(HeaderMatchMode.Exists)}' on route header '{header.Name}' for route '{routeId}'."));
+                errors.Add(new ArgumentException($"Header values were set when using mode '{header.Mode}' on route header '{header.Name}' for route '{routeId}'."));
             }
         }
     }

--- a/src/ReverseProxy/Configuration/HeaderMatchMode.cs
+++ b/src/ReverseProxy/Configuration/HeaderMatchMode.cs
@@ -44,7 +44,7 @@ public enum HeaderMatchMode
     Exists,
 
     /// <summary>
-    /// The header must not exist
+    /// The header must not exist.
     /// </summary>
-    NotExists
+    NotExists,
 }

--- a/src/ReverseProxy/Configuration/HeaderMatchMode.cs
+++ b/src/ReverseProxy/Configuration/HeaderMatchMode.cs
@@ -42,4 +42,9 @@ public enum HeaderMatchMode
     /// The header must exist and contain any non-empty value.
     /// </summary>
     Exists,
+
+    /// <summary>
+    /// The header must not exist
+    /// </summary>
+    NotExists
 }

--- a/src/ReverseProxy/Configuration/RouteHeader.cs
+++ b/src/ReverseProxy/Configuration/RouteHeader.cs
@@ -20,7 +20,7 @@ public sealed record RouteHeader
 
     /// <summary>
     /// A collection of acceptable header values used during routing. Only one value must match.
-    /// The list must not be empty unless using <see cref="HeaderMatchMode.Exists"/>.
+    /// The list must not be empty unless using <see cref="HeaderMatchMode.Exists"/> or <see cref="HeaderMatchMode.NotExists"/>.
     /// </summary>
     public IReadOnlyList<string>? Values { get; init; }
 

--- a/src/ReverseProxy/Routing/HeaderMatcher.cs
+++ b/src/ReverseProxy/Routing/HeaderMatcher.cs
@@ -23,14 +23,14 @@ internal sealed class HeaderMatcher
         {
             throw new ArgumentException("A header name is required.", nameof(name));
         }
-        if (mode != HeaderMatchMode.Exists
+        if ((mode != HeaderMatchMode.Exists && mode != HeaderMatchMode.NotExists)
             && (values is null || values.Count == 0))
         {
             throw new ArgumentException("Header values must have at least one value.", nameof(values));
         }
-        if (mode == HeaderMatchMode.Exists && values?.Count > 0)
+        if ((mode == HeaderMatchMode.Exists || mode == HeaderMatchMode.NotExists) && values?.Count > 0)
         {
-            throw new ArgumentException($"Header values must not be specified when using '{nameof(HeaderMatchMode.Exists)}'.", nameof(values));
+            throw new ArgumentException($"Header values must not be specified when using '{mode}'.", nameof(values));
         }
         if (values is not null && values.Any(string.IsNullOrEmpty))
         {
@@ -51,7 +51,8 @@ internal sealed class HeaderMatcher
 
     /// <summary>
     /// Returns a read-only collection of acceptable header values used during routing.
-    /// At least one value is required unless <see cref="Mode"/> is set to <see cref="HeaderMatchMode.Exists"/>.
+    /// At least one value is required unless <see cref="Mode"/> is set to <see cref="HeaderMatchMode.Exists"/>
+    /// or <see cref="HeaderMatchMode.NotExists"/>.
     /// </summary>
     public string[] Values { get; }
 

--- a/src/ReverseProxy/Routing/HeaderMatcherPolicy.cs
+++ b/src/ReverseProxy/Routing/HeaderMatcherPolicy.cs
@@ -70,12 +70,19 @@ internal sealed class HeaderMatcherPolicy : MatcherPolicy, IEndpointComparerPoli
 
             foreach (var matcher in matchers)
             {
-                if (headers.TryGetValue(matcher.Name, out var requestHeaderValues) &&
+                var headerExistsInRequest = headers.TryGetValue(matcher.Name, out var requestHeaderValues);
+                if ( headerExistsInRequest &&
                     !StringValues.IsNullOrEmpty(requestHeaderValues))
                 {
                     if (matcher.Mode is HeaderMatchMode.Exists)
                     {
                         continue;
+                    }
+
+                    if (matcher.Mode is HeaderMatchMode.NotExists)
+                    {
+                        candidates.SetValidity(i, false);
+                        break;
                     }
 
                     if (matcher.Mode is HeaderMatchMode.ExactHeader or HeaderMatchMode.HeaderPrefix
@@ -84,6 +91,10 @@ internal sealed class HeaderMatcherPolicy : MatcherPolicy, IEndpointComparerPoli
                     {
                         continue;
                     }
+                }
+                else if ( matcher.Mode is HeaderMatchMode.NotExists && !headerExistsInRequest)
+                {
+                    continue;
                 }
 
                 candidates.SetValidity(i, false);

--- a/src/ReverseProxy/Routing/HeaderMatcherPolicy.cs
+++ b/src/ReverseProxy/Routing/HeaderMatcherPolicy.cs
@@ -71,8 +71,7 @@ internal sealed class HeaderMatcherPolicy : MatcherPolicy, IEndpointComparerPoli
             foreach (var matcher in matchers)
             {
                 var headerExistsInRequest = headers.TryGetValue(matcher.Name, out var requestHeaderValues);
-                if ( headerExistsInRequest &&
-                    !StringValues.IsNullOrEmpty(requestHeaderValues))
+                if (headerExistsInRequest && !StringValues.IsNullOrEmpty(requestHeaderValues))
                 {
                     if (matcher.Mode is HeaderMatchMode.Exists)
                     {
@@ -92,7 +91,7 @@ internal sealed class HeaderMatcherPolicy : MatcherPolicy, IEndpointComparerPoli
                         continue;
                     }
                 }
-                else if ( matcher.Mode is HeaderMatchMode.NotExists && !headerExistsInRequest)
+                else if (matcher.Mode is HeaderMatchMode.NotExists && !headerExistsInRequest)
                 {
                     continue;
                 }

--- a/test/ReverseProxy.Tests/Configuration/ConfigValidatorTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigValidatorTests.cs
@@ -327,6 +327,35 @@ public class ConfigValidatorTests
     }
 
     [Fact]
+    public async Task Accepts_RouteHeader_NotExistsWithNoValue()
+    {
+        var route = new RouteConfig
+        {
+            RouteId = "route1",
+            Match = new RouteMatch
+            {
+                Path = "/",
+                Headers = new[]
+                {
+                    new RouteHeader()
+                    {
+                        Name = "header1",
+                        Mode = HeaderMatchMode.NotExists
+                    }
+                },
+            },
+            ClusterId = "cluster1",
+        };
+
+        var services = CreateServices();
+        var validator = services.GetRequiredService<IConfigValidator>();
+
+        var result = await validator.ValidateRouteAsync(route);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
     public async Task Accepts_RouteQueryParameter_ExistsWithNoValue()
     {
         var route = new RouteConfig
@@ -404,7 +433,8 @@ public class ConfigValidatorTests
     [Theory]
     [InlineData("", "v1", HeaderMatchMode.ExactHeader, "A null or empty route header name has been set for route")]
     [InlineData("h1", null, HeaderMatchMode.ExactHeader, "No header values were set on route header")]
-    [InlineData("h1", "v1", HeaderMatchMode.Exists, "Header values where set when using mode 'Exists'")]
+    [InlineData("h1", "v1", HeaderMatchMode.Exists, "Header values were set when using mode 'Exists'")]
+    [InlineData("h1", "v1", HeaderMatchMode.NotExists, "Header values were set when using mode 'NotExists'")]
     public async Task Rejects_InvalidRouteHeader(string name, string value, HeaderMatchMode mode, string error)
     {
         var routeHeader = new RouteHeader()

--- a/test/ReverseProxy.Tests/Routing/HeaderMatcherPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Routing/HeaderMatcherPolicyTests.cs
@@ -153,9 +153,9 @@ public class HeaderMatcherPolicyTests
     [InlineData(null, HeaderMatchMode.Exists, false)]
     [InlineData("", HeaderMatchMode.Exists, false)]
     [InlineData("abc", HeaderMatchMode.Exists, true)]
-    [InlineData(null, HeaderMatchMode.NotExists,true)]
+    [InlineData(null, HeaderMatchMode.NotExists, true)]
     [InlineData("", HeaderMatchMode.NotExists, false)]
-    [InlineData("abc", HeaderMatchMode.NotExists,false)]
+    [InlineData("abc", HeaderMatchMode.NotExists, false)]
     public async Task ApplyAsync_MatchingScenarios_AnyHeaderValue(string incomingHeaderValue, HeaderMatchMode mode, bool shouldMatch)
     {
         var context = new DefaultHttpContext();

--- a/test/ReverseProxy.Tests/Routing/HeaderMatcherPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Routing/HeaderMatcherPolicyTests.cs
@@ -150,10 +150,13 @@ public class HeaderMatcherPolicyTests
     }
 
     [Theory]
-    [InlineData(null, false)]
-    [InlineData("", false)]
-    [InlineData("abc", true)]
-    public async Task ApplyAsync_MatchingScenarios_AnyHeaderValue(string incomingHeaderValue, bool shouldMatch)
+    [InlineData(null, HeaderMatchMode.Exists, false)]
+    [InlineData("", HeaderMatchMode.Exists, false)]
+    [InlineData("abc", HeaderMatchMode.Exists, true)]
+    [InlineData(null, HeaderMatchMode.NotExists,true)]
+    [InlineData("", HeaderMatchMode.NotExists, false)]
+    [InlineData("abc", HeaderMatchMode.NotExists,false)]
+    public async Task ApplyAsync_MatchingScenarios_AnyHeaderValue(string incomingHeaderValue, HeaderMatchMode mode, bool shouldMatch)
     {
         var context = new DefaultHttpContext();
         if (incomingHeaderValue is not null)
@@ -161,7 +164,7 @@ public class HeaderMatcherPolicyTests
             context.Request.Headers.Add("org-id", incomingHeaderValue);
         }
 
-        var endpoint = CreateEndpoint("org-id", new string[0], HeaderMatchMode.Exists);
+        var endpoint = CreateEndpoint("org-id", new string[0], mode);
         var candidates = new CandidateSet(new[] { endpoint }, new RouteValueDictionary[1], new int[1]);
         var sut = new HeaderMatcherPolicy();
 


### PR DESCRIPTION
Addresses #1697 by adding HeaderMatchMode.NotExists. Inverse of HeaderMatchMode.Exists, being that it only matches if the header is not present at all.

Have added a few tests, but had trouble deciphering the intent behind some of the tests in HeaderMatcherPolicyTests.cs and so may have missed some cases. Particularly the sortorder and "_AppliesScenarios" tests were not added to as I couldn't figure out what the intent of them was.

One failing test Yarp.ReverseProxy.FunctionalTests.HttpProxyCookieTests_Http2::ProxyAsync_RequestWithCookieHeaders is also failing in main, so I don't think I broke it.

Thanks for a great piece of software.