### PR TITLE
Remove Content-Length: 0 on responses that don't allow bodies

### DIFF
--- a/src/ReverseProxy/Forwarder/HttpTransformer.cs
+++ b/src/ReverseProxy/Forwarder/HttpTransformer.cs
@@ -41,8 +41,7 @@ public class HttpTransformer
             // A 1xx response is terminated by the end of the header section; it cannot contain content
             // or trailers.
             // See https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2-2
-            HttpStatusCode.Continue => true,
-            HttpStatusCode.SwitchingProtocols => true,
+            >= HttpStatusCode.Continue and < HttpStatusCode.OK => true,
             // A 204 response is terminated by the end of the header section; it cannot contain content
             // or trailers.
             // See https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.5-5

--- a/src/ReverseProxy/Forwarder/HttpTransformer.cs
+++ b/src/ReverseProxy/Forwarder/HttpTransformer.cs
@@ -157,8 +157,8 @@ public class HttpTransformer
         // we remove the 'Content-Length: 0' header if one is present.
         if (proxyResponse.Content is not null
             && BodylessStatusCodes.Contains(proxyResponse.StatusCode)
-            && proxyResponse.Content.Headers.NonValidated.TryGetValues(HeaderNames.ContentLength, out var values)
-            && values.ToString() == "0")
+            && proxyResponse.Content.Headers.NonValidated.TryGetValues(HeaderNames.ContentLength, out var contentLengthValue)
+            && contentLengthValue.ToString() == "0")
         {
             httpContext.Response.Headers.Remove(HeaderNames.ContentLength);
         }


### PR DESCRIPTION
Fix https://github.com/microsoft/reverse-proxy/issues/1762