### PR TITLE
Use MediaTypeHeaderValue.MatchesMediaType for content type check

### DIFF
--- a/src/ReverseProxy/Forwarder/ProtocolHelper.cs
+++ b/src/ReverseProxy/Forwarder/ProtocolHelper.cs
@@ -33,6 +33,8 @@ internal static class ProtocolHelper
     /// Checks whether the provided content type header value represents a gRPC request.
     /// </summary>
     public static bool IsGrpcContentType(string? contentType) =>
-        MediaTypeHeaderValue.TryParse(contentType, out var mediaType)
+        contentType is not null &&
+        && contentType.StartsWith(GrpcContentType, StringComparison.OrdinalIgnoreCase)
+        && MediaTypeHeaderValue.TryParse(contentType, out var mediaType)
         && mediaType.MatchesMediaType(GrpcContentType);
 }

--- a/src/ReverseProxy/Forwarder/ProtocolHelper.cs
+++ b/src/ReverseProxy/Forwarder/ProtocolHelper.cs
@@ -33,7 +33,7 @@ internal static class ProtocolHelper
     /// Checks whether the provided content type header value represents a gRPC request.
     /// </summary>
     public static bool IsGrpcContentType(string? contentType) =>
-        contentType is not null &&
+        contentType is not null
         && contentType.StartsWith(GrpcContentType, StringComparison.OrdinalIgnoreCase)
         && MediaTypeHeaderValue.TryParse(contentType, out var mediaType)
         && mediaType.MatchesMediaType(GrpcContentType);


### PR DESCRIPTION
Noticed this TODO item while looking through the sources. The mentioned aspnetcore issue was addressed nearly two years ago :smile:

Benchmarking indicates that the perf difference here is negligible, but this is definitely cleaner from a maintenance standpoint.