### PR TITLE
Fix Except100Continue test for 7.0

### DIFF
--- a/test/ReverseProxy.FunctionalTests/Expect100ContinueTests.cs
+++ b/test/ReverseProxy.FunctionalTests/Expect100ContinueTests.cs
@@ -315,7 +315,7 @@ public class Expect100ContinueTests
         else
         {
             var exception = await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync(message));
-            Assert.Equal(typeof(IOException), exception.InnerException.GetType());
+            Assert.IsAssignableFrom<IOException>(exception.InnerException);
             Assert.Equal(content.Length, contentStream.Position);
         }
     }


### PR DESCRIPTION
With a recent enough build of 7.0, this test is failing since the exception can now be an [`HttpProtocolException`](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Http/src/System/Net/Http/HttpProtocolException.cs).