### PR TITLE
Remove dotnet-install CRLF workaround

### DIFF
--- a/samples/KubernetesIngress.Sample/Combined/Dockerfile
+++ b/samples/KubernetesIngress.Sample/Combined/Dockerfile
@@ -8,8 +8,7 @@ EXPOSE 443
 FROM amd64/buildpack-deps:jammy-curl AS publish
 WORKDIR /src
 COPY ["global.json", ""]
-RUN sed 's/\r$//' global.json > global-lf.json
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --jsonfile global-lf.json
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --jsonfile global.json
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT 1
 
 # Copy csproj files and other files needed for restoring (to build a nuget cache layer to speed up rebuilds)

--- a/samples/KubernetesIngress.Sample/Ingress/Dockerfile
+++ b/samples/KubernetesIngress.Sample/Ingress/Dockerfile
@@ -8,8 +8,7 @@ EXPOSE 443
 FROM amd64/buildpack-deps:jammy-curl AS publish
 WORKDIR /src
 COPY ["global.json", ""]
-RUN sed 's/\r$//' global.json > global-lf.json
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --jsonfile global-lf.json
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --jsonfile global.json
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT 1
 
 # Copy csproj files and other files needed for restoring (to build a nuget cache layer to speed up rebuilds)

--- a/samples/KubernetesIngress.Sample/Monitor/Dockerfile
+++ b/samples/KubernetesIngress.Sample/Monitor/Dockerfile
@@ -8,8 +8,7 @@ EXPOSE 443
 FROM amd64/buildpack-deps:jammy-curl AS publish
 WORKDIR /src
 COPY ["global.json", ""]
-RUN sed 's/\r$//' global.json > global-lf.json
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --jsonfile global-lf.json
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --jsonfile global.json
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT 1
 
 # Copy csproj files and other files needed for restoring (to build a nuget cache layer to speed up rebuilds)

--- a/samples/KubernetesIngress.Sample/backend/Dockerfile
+++ b/samples/KubernetesIngress.Sample/backend/Dockerfile
@@ -8,8 +8,7 @@ EXPOSE 443
 FROM amd64/buildpack-deps:jammy-curl AS publish
 WORKDIR /src
 COPY ["global.json", ""]
-RUN sed 's/\r$//' global.json > global-lf.json
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --jsonfile global-lf.json
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --jsonfile global.json
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT 1
 
 COPY ["samples/KubernetesIngress.Sample/backend", "backend"]


### PR DESCRIPTION
https://github.com/dotnet/install-scripts/issues/308 has been fixed so this workaround shouldn't be needed anymore