### PR TITLE
Bump Docfx to 2.59.4

### DIFF
--- a/docs/docfx/docfx.csproj
+++ b/docs/docfx/docfx.csproj
@@ -11,6 +11,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="docfx.console" Version="2.58.0" />
+        <PackageReference Include="docfx.console" Version="2.59.4" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #1859

A recent update of MSBuild seems to have broken a bunch of stuff, including docfx.
Some discussion on https://github.com/dotnet/docfx/issues/8097 and https://github.com/dotnet/docfx/issues/8136.

Docfx added a workaround https://github.com/dotnet/docfx/pull/8135 that is now released in `2.59.4`.
It solves the issue for me when testing locally.

> [22-09-07 10:52:17.669]Warning:[MetadataCommand.ExtractMetadata](D:/a/reverse-proxy/reverse-proxy/source/src/ReverseProxy/Yarp.ReverseProxy.csproj)Workspace failed with: [Failure] Msbuild failed when processing the file 'D:\a\reverse-proxy\reverse-proxy\source\src\ReverseProxy\Yarp.ReverseProxy.csproj' with message: Method not found: 'System.ReadOnlySpan`1<Char> Microsoft.IO.Path.GetFileName(System.ReadOnlySpan`1<Char>)'.