### PR TITLE
add Header-based canary routing via ingress annotations

### DIFF
--- a/samples/KubernetesIngress.Sample/README.md
+++ b/samples/KubernetesIngress.Sample/README.md
@@ -81,7 +81,7 @@ The table below lists the available annotations.
 |yarp.ingress.kubernetes.io/route-metadata|Dictionary<string, string>|
 |yarp.ingress.kubernetes.io/session-affinity|[SessionAffinityConfig](https://microsoft.github.io/reverse-proxy/api/Yarp.ReverseProxy.Configuration.SessionAffinityConfig.html)|
 |yarp.ingress.kubernetes.io/transforms|List<Dictionary<string, string>>|
-|yarp.ingress.kubernetes.io/route-headers|List<[RouteHeaderWapper](/src/Kubernetes.Controller/Converters/YarpIngressOptions.cs#L23)>|
+|yarp.ingress.kubernetes.io/route-headers|List<[RouteHeader](https://microsoft.github.io/reverse-proxy/api/Yarp.ReverseProxy.Configuration.RouteHeader.html)>|
 
 #### Authorization Policy
 

--- a/samples/KubernetesIngress.Sample/README.md
+++ b/samples/KubernetesIngress.Sample/README.md
@@ -44,6 +44,17 @@ metadata:
     yarp.ingress.kubernetes.io/authorization-policy: authzpolicy
     yarp.ingress.kubernetes.io/transforms: |
       - PathRemovePrefix: "/apis"
+    yarp.ingress.kubernetes.io/route-headers: |
+      - Name: the-header-key
+        Values: 
+        - the-header-value
+        Mode: Contains
+        IsCaseSensitive: false
+      - Name: another-header-key
+        Values: 
+        - another-header-value
+        Mode: Contains
+        IsCaseSensitive: false
 spec:
   rules:
     - http:
@@ -70,6 +81,7 @@ The table below lists the available annotations.
 |yarp.ingress.kubernetes.io/route-metadata|Dictionary<string, string>|
 |yarp.ingress.kubernetes.io/session-affinity|[SessionAffinityConfig](https://microsoft.github.io/reverse-proxy/api/Yarp.ReverseProxy.Configuration.SessionAffinityConfig.html)|
 |yarp.ingress.kubernetes.io/transforms|List<Dictionary<string, string>>|
+|yarp.ingress.kubernetes.io/route-headers|List<[RouteHeaderWapper](/src/Kubernetes.Controller/Converters/YarpIngressOptions.cs#L23)>|
 
 #### Authorization Policy
 

--- a/src/Kubernetes.Controller/Converters/YarpIngressOptions.cs
+++ b/src/Kubernetes.Controller/Converters/YarpIngressOptions.cs
@@ -22,7 +22,7 @@ internal sealed class YarpIngressOptions
 
 internal sealed class RouteHeaderWapper
 {
-    public string Name { get; init; } = default!;
+    public string Name { get; init; }
     public List<string> Values { get; init; }
     public HeaderMatchMode Mode { get; init; }
     public bool IsCaseSensitive { get; init; }

--- a/src/Kubernetes.Controller/Converters/YarpIngressOptions.cs
+++ b/src/Kubernetes.Controller/Converters/YarpIngressOptions.cs
@@ -17,4 +17,24 @@ internal sealed class YarpIngressOptions
     public string CorsPolicy { get; set; }
     public HealthCheckConfig HealthCheck { get; set; }
     public Dictionary<string, string> RouteMetadata { get; set; }
+    public List<RouteHeader> RouteHeaders { get; set; }
+}
+
+internal sealed class RouteHeaderWapper
+{
+    public string Name { get; init; } = default!;
+    public List<string> Values { get; init; }
+    public HeaderMatchMode Mode { get; init; }
+    public bool IsCaseSensitive { get; init; }
+
+    public RouteHeader ToRouteHeader()
+    {
+        return new RouteHeader
+        {
+            Name = Name,
+            Values = Values,
+            Mode = Mode,
+            IsCaseSensitive = IsCaseSensitive
+        };
+    }
 }

--- a/src/Kubernetes.Controller/Converters/YarpParser.cs
+++ b/src/Kubernetes.Controller/Converters/YarpParser.cs
@@ -205,7 +205,7 @@ internal static class YarpParser
         }
         if (annotations.TryGetValue("yarp.ingress.kubernetes.io/route-headers", out var routeHeaders))
         {
-            //YamlDeserializer does not support IReadOnlyList<string> in RouteHeader for now, so we use RouteHeaderWapper to solve this problem.
+            // YamlDeserializer does not support IReadOnlyList<string> in RouteHeader for now, so we use RouteHeaderWapper to solve this problem.
             options.RouteHeaders = YamlDeserializer.Deserialize<List<RouteHeaderWapper>>(routeHeaders).Select(p => p.ToRouteHeader()).ToList();
         }
         // metadata to support:

--- a/src/Kubernetes.Controller/Converters/YarpParser.cs
+++ b/src/Kubernetes.Controller/Converters/YarpParser.cs
@@ -96,7 +96,8 @@ internal static class YarpParser
                     Match = new RouteMatch()
                     {
                         Hosts = host is not null ? new[] { host } : Array.Empty<string>(),
-                        Path = pathMatch
+                        Path = pathMatch,
+                        Headers = ingressContext.Options.RouteHeaders
                     },
                     ClusterId = cluster.ClusterId,
                     RouteId = $"{ingressContext.Ingress.Metadata.Name}.{ingressContext.Ingress.Metadata.NamespaceProperty}:{path.Path}",
@@ -202,7 +203,11 @@ internal static class YarpParser
         {
             options.RouteMetadata = YamlDeserializer.Deserialize<Dictionary<string, string>>(routeMetadata);
         }
-
+        if (annotations.TryGetValue("yarp.ingress.kubernetes.io/route-headers", out var routeHeaders))
+        {
+            //YamlDeserializer does not support IReadOnlyList<string> in RouteHeader for now, so we use RouteHeaderWapper to solve this problem.
+            options.RouteHeaders = YamlDeserializer.Deserialize<List<RouteHeaderWapper>>(routeHeaders).Select(p => p.ToRouteHeader()).ToList();
+        }
         // metadata to support:
         // rewrite target
         // auth

--- a/test/Kubernetes.Tests/IngressConversionTests.cs
+++ b/test/Kubernetes.Tests/IngressConversionTests.cs
@@ -50,6 +50,7 @@ public class IngressConversionTests
     [InlineData("multiple-ingresses-one-svc")]
     [InlineData("multiple-namespaces")]
     [InlineData("route-metadata")]
+    [InlineData("route-headers")]
     [InlineData("missing-svc")]
     public async Task ParsingTests(string name)
     {

--- a/test/Kubernetes.Tests/testassets/route-headers/clusters.json
+++ b/test/Kubernetes.Tests/testassets/route-headers/clusters.json
@@ -1,0 +1,18 @@
+[
+  {
+    "ClusterId": "frontend.default:80",
+    "LoadBalancingPolicy": null,
+    "SessionAffinity": null,
+    "HealthCheck": null,
+    "HttpClient": null,
+    "HttpRequest": null,
+    "Destinations": {
+      "http://10.244.2.38:80": {
+        "Address": "http://10.244.2.38:80",
+        "Health": null,
+        "Metadata": null
+      }
+    },
+    "Metadata": null
+  }
+]

--- a/test/Kubernetes.Tests/testassets/route-headers/ingress.yaml
+++ b/test/Kubernetes.Tests/testassets/route-headers/ingress.yaml
@@ -8,8 +8,11 @@ metadata:
       foo: bar
       another-key: another-value
     yarp.ingress.kubernetes.io/route-headers: |
-      foo: bar
-      another-key: another-value
+      - Name: the-header-key
+        Values: 
+        - the-header-value
+        Mode: Contains
+        IsCaseSensitive: false
 spec:
   rules:
   - http:

--- a/test/Kubernetes.Tests/testassets/route-headers/ingress.yaml
+++ b/test/Kubernetes.Tests/testassets/route-headers/ingress.yaml
@@ -1,0 +1,50 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minimal-ingress
+  namespace: default
+  annotations:
+    yarp.ingress.kubernetes.io/route-metadata: |
+      foo: bar
+      another-key: another-value
+    yarp.ingress.kubernetes.io/route-headers: |
+      foo: bar
+      another-key: another-value
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /foo
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend
+            port:
+              number: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: default
+spec:
+  selector:
+    app: frontend
+  ports:
+  - name: https
+    port: 80
+    targetPort: 80
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: frontend
+  namespace: default
+subsets:
+  - addresses:
+    - ip: 10.244.2.38
+    ports:
+    - name: https
+      port: 80
+      protocol: TCP

--- a/test/Kubernetes.Tests/testassets/route-headers/routes.json
+++ b/test/Kubernetes.Tests/testassets/route-headers/routes.json
@@ -1,0 +1,34 @@
+[
+  {
+    "RouteId": "minimal-ingress.default:/foo",
+    "Match": {
+      "Methods": null,
+      "Hosts": [],
+      "Path": "/foo/{**catch-all}",
+      "Headers": [
+        {
+          "Name": "headera",
+          "Values": [ "v1" ],
+          "Mode": "Exists",
+          "IsCaseSensitive": true
+        },
+        {
+          "Name": "headerb",
+          "Values": [ "v2" ],
+          "Mode": "Exists",
+          "IsCaseSensitive": false
+        }
+      ],
+      "QueryParameters": null
+    },
+    "Order": null,
+    "ClusterId": "frontend.default:80",
+    "AuthorizationPolicy": null,
+    "CorsPolicy": null,
+    "Metadata": {
+      "foo": "bar",
+      "another-key": "another-value"
+    },
+    "Transforms": null
+  }
+]

--- a/test/Kubernetes.Tests/testassets/route-headers/routes.json
+++ b/test/Kubernetes.Tests/testassets/route-headers/routes.json
@@ -7,15 +7,9 @@
       "Path": "/foo/{**catch-all}",
       "Headers": [
         {
-          "Name": "headera",
-          "Values": [ "v1" ],
-          "Mode": "Exists",
-          "IsCaseSensitive": true
-        },
-        {
-          "Name": "headerb",
-          "Values": [ "v2" ],
-          "Mode": "Exists",
+          "Name": "the-header-key",
+          "Values": [ "the-header-value" ],
+          "Mode": "Contains",
           "IsCaseSensitive": false
         }
       ],


### PR DESCRIPTION
read  RouteHeader from ingress annotations, key: `yarp.ingress.kubernetes.io/route-headers`