### PR TITLE
Add AddMetricsConsumer helper to TelemetryConsumption

### DIFF
--- a/samples/ReverseProxy.Metrics.Sample/Startup.cs
+++ b/samples/ReverseProxy.Metrics.Sample/Startup.cs
@@ -36,7 +36,7 @@ namespace Yarp.Sample
             services.AddHttpContextAccessor();
 
             // Interface that collects general metrics about the proxy forwarder
-            services.AddSingleton<IMetricsConsumer<ForwarderMetrics>, ForwarderMetricsConsumer>();
+            services.AddMetricsConsumer<ForwarderMetricsConsumer>();
 
             // Registration of a consumer to events for proxy forwarder telemetry
             services.AddTelemetryConsumer<ForwarderTelemetryConsumer>();

--- a/src/TelemetryConsumption/EventListenerService.cs
+++ b/src/TelemetryConsumption/EventListenerService.cs
@@ -98,7 +98,7 @@ internal abstract class EventListenerService<TService, TTelemetryConsumer, TMetr
             return;
         }
 
-        var eventLevel = enableEvents ? EventLevel.Verbose : EventLevel.Critical;
+        var eventLevel = enableEvents ? EventLevel.Informational : EventLevel.Critical;
         var arguments = enableMetrics ? new Dictionary<string, string?> { { "EventCounterIntervalSec", MetricsOptions.Interval.TotalSeconds.ToString() } } : null;
 
         EnableEvents(eventSource, eventLevel, EventKeywords.None, arguments);

--- a/src/TelemetryConsumption/TelemetryConsumptionExtensions.cs
+++ b/src/TelemetryConsumption/TelemetryConsumptionExtensions.cs
@@ -144,4 +144,113 @@ public static class TelemetryConsumptionExtensions
 
         return services;
     }
+
+    /// <summary>
+    /// Registers a consumer singleton for every IMetricsConsumer interface it implements.
+    /// </summary>
+    public static IServiceCollection AddMetricsConsumer(this IServiceCollection services, object consumer)
+    {
+        var implementsAny = false;
+
+        if (consumer is IMetricsConsumer<ForwarderMetrics> forwarderMetricsConsumer)
+        {
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(forwarderMetricsConsumer));
+            implementsAny = true;
+        }
+
+        if (consumer is IMetricsConsumer<KestrelMetrics> kestrelMetricsConsumer)
+        {
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(kestrelMetricsConsumer));
+            implementsAny = true;
+        }
+
+        if (consumer is IMetricsConsumer<HttpMetrics> httpMetricsConsumer)
+        {
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(httpMetricsConsumer));
+            implementsAny = true;
+        }
+
+        if (consumer is IMetricsConsumer<NameResolutionMetrics> nameResolutionMetricsConsumer)
+        {
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(nameResolutionMetricsConsumer));
+            implementsAny = true;
+        }
+
+        if (consumer is IMetricsConsumer<NetSecurityMetrics> netSecurityMetricsConsumer)
+        {
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(netSecurityMetricsConsumer));
+            implementsAny = true;
+        }
+
+        if (consumer is IMetricsConsumer<SocketsMetrics> socketsMetricsConsumer)
+        {
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(socketsMetricsConsumer));
+            implementsAny = true;
+        }
+
+        if (!implementsAny)
+        {
+            throw new ArgumentException("The consumer must implement at least one IMetricsConsumer interface.", nameof(consumer));
+        }
+
+        services.AddTelemetryListeners();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a consumer singleton for every IMetricsConsumer interface it implements.
+    /// </summary>
+    public static IServiceCollection AddMetricsConsumer<TConsumer>(this IServiceCollection services)
+        where TConsumer : class
+    {
+        var implementsAny = false;
+
+        if (typeof(IMetricsConsumer<ForwarderMetrics>).IsAssignableFrom(typeof(TConsumer)))
+        {
+            services.AddSingleton(services => (IMetricsConsumer<ForwarderMetrics>)services.GetRequiredService<TConsumer>());
+            implementsAny = true;
+        }
+
+        if (typeof(IMetricsConsumer<KestrelMetrics>).IsAssignableFrom(typeof(TConsumer)))
+        {
+            services.AddSingleton(services => (IMetricsConsumer<KestrelMetrics>)services.GetRequiredService<TConsumer>());
+            implementsAny = true;
+        }
+
+        if (typeof(IMetricsConsumer<HttpMetrics>).IsAssignableFrom(typeof(TConsumer)))
+        {
+            services.AddSingleton(services => (IMetricsConsumer<HttpMetrics>)services.GetRequiredService<TConsumer>());
+            implementsAny = true;
+        }
+
+        if (typeof(IMetricsConsumer<NameResolutionMetrics>).IsAssignableFrom(typeof(TConsumer)))
+        {
+            services.AddSingleton(services => (IMetricsConsumer<NameResolutionMetrics>)services.GetRequiredService<TConsumer>());
+            implementsAny = true;
+        }
+
+        if (typeof(IMetricsConsumer<NetSecurityMetrics>).IsAssignableFrom(typeof(TConsumer)))
+        {
+            services.AddSingleton(services => (IMetricsConsumer<NetSecurityMetrics>)services.GetRequiredService<TConsumer>());
+            implementsAny = true;
+        }
+
+        if (typeof(IMetricsConsumer<SocketsMetrics>).IsAssignableFrom(typeof(TConsumer)))
+        {
+            services.AddSingleton(services => (IMetricsConsumer<SocketsMetrics>)services.GetRequiredService<TConsumer>());
+            implementsAny = true;
+        }
+
+        if (!implementsAny)
+        {
+            throw new ArgumentException("TConsumer must implement at least one IMetricsConsumer interface.", nameof(TConsumer));
+        }
+
+        services.TryAddSingleton<TConsumer>();
+
+        services.AddTelemetryListeners();
+
+        return services;
+    }
 }


### PR DESCRIPTION
I am writing networking telemetry docs and it bothered me that we have very convenient helpers for `ITelemetryConsumer*`s, but nothing for `IMetricsConsumer<T>`.

So while you can write code like this for events:
```c#
services.AddTelemetryConsumer<MyTelemetryConsumer>();
```
you have to write this for metrics:
```c#
services.AddSingleton<IMetricsConsumer<SocketsMetrics>, MetricsConsumer>();
services.AddTelemetryListeners();
```
or even this if you implement multiple interfaces:
```c#
services.AddSingleton<MetricsConsumer>();
services.AddSingleton(services => (IMetricsConsumer<ForwarderMetrics>)services.GetRequiredService<MetricsConsumer>());
services.AddSingleton(services => (IMetricsConsumer<KestrelMetrics>)services.GetRequiredService<MetricsConsumer>());
services.AddSingleton(services => (IMetricsConsumer<SocketsMetrics>)services.GetRequiredService<MetricsConsumer>());
services.AddTelemetryListeners();
```

This PR adds `AddMetricsConsumer` helpers that do the same for metrics as `AddTelemetryConsumer` does for events.