### PR TITLE
Enable request transforms to reject requests 

### DIFF
--- a/docs/docfx/articles/transforms.md
+++ b/docs/docfx/articles/transforms.md
@@ -959,6 +959,8 @@ Only header1 and header2 are copied from the proxy response.
 
 All request transforms must derive from the abstract base class [RequestTransform](xref:Yarp.ReverseProxy.Transforms.RequestTransform). These can freely modify the proxy `HttpRequestMessage`. Avoid reading or modifying the request body as this may disrupt the proxying flow. Consider also adding a parametrized extension method on `TransformBuilderContext` for discoverability and easy of use.
 
+A request transform may conditionally produce an immediate response such as for error conditions. This prevents any remaining transforms from running and the request from being proxied. This is indicated by setting the `HttpResponse.StatusCode` to a value other than 200, or calling `HttpResponse.StartAsync()`, or writing to the `HttpResponse.Body` or `BodyWriter`.
+
 ### ResponseTransform
 
 All response transforms must derive from the abstract base class [ResponseTransform](xref:Yarp.ReverseProxy.Transforms.ResponseTransform). These can freely modify the client `HttpResponse`. Avoid reading or modifying the response body as this may disrupt the proxying flow. Consider also adding a parametrized extension method on `TransformBuilderContext` for discoverability and easy of use.

--- a/samples/ReverseProxy.Auth.Sample/TokenService.cs
+++ b/samples/ReverseProxy.Auth.Sample/TokenService.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace Yarp.Sample
+{
+    internal class TokenService
+    {
+        internal Task<string> GetAuthTokenAsync(ClaimsPrincipal user)
+        {
+            // we only have tokens for bob
+            if (string.Equals("Bob", user.Identity.Name))
+            {
+                return Task.FromResult("valid");
+            }
+            return Task.FromResult<string>(null);
+        }
+    }
+}

--- a/samples/ReverseProxy.Auth.Sample/TokenService.cs
+++ b/samples/ReverseProxy.Auth.Sample/TokenService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
 
@@ -13,7 +14,7 @@ namespace Yarp.Sample
             // we only have tokens for bob
             if (string.Equals("Bob", user.Identity.Name))
             {
-                return Task.FromResult("valid");
+                return Task.FromResult(Guid.NewGuid().ToString());
             }
             return Task.FromResult<string>(null);
         }

--- a/samples/ReverseProxy.Auth.Sample/Views/Account/Login.cshtml
+++ b/samples/ReverseProxy.Auth.Sample/Views/Account/Login.cshtml
@@ -6,7 +6,7 @@
 
 <form action="Login" method="post">
     <input hidden name="returnurl" type="text" value="@ViewData["ReturnUrl"]" /><br />
-    <input name="Name" type="text" value="My Name" /><br />
+    <input name="Name" type="text" value="Bob" /><br />
     <input name="myClaimValue" type="text" value="green" /><br />
     <input type="submit">
     <div><b>Note:</b>The authorization policy will check for the value of "green", other values should pass authentication, but not authorize for specific routes</div>

--- a/samples/ReverseProxy.Transforms.Sample/MyTransformProvider.cs
+++ b/samples/ReverseProxy.Transforms.Sample/MyTransformProvider.cs
@@ -25,8 +25,7 @@ namespace Yarp.Sample
         public void ValidateCluster(TransformClusterValidationContext context)
         {
             // Check all clusters for a custom property and validate the associated transform data.
-            string value = null;
-            if (context.Cluster.Metadata?.TryGetValue("CustomMetadata", out value) ?? false)
+            if (context.Cluster.Metadata?.TryGetValue("CustomMetadata", out var value) ?? false)
             {
                 if (string.IsNullOrEmpty(value))
                 {

--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -9,7 +9,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Features;

--- a/src/ReverseProxy/Forwarder/HttpTransformer.cs
+++ b/src/ReverseProxy/Forwarder/HttpTransformer.cs
@@ -59,6 +59,9 @@ public class HttpTransformer
     /// See <see cref="RequestUtilities.MakeDestinationAddress(string, PathString, QueryString)"/> for constructing a custom request Uri.
     /// The string parameter represents the destination URI prefix that should be used when constructing the RequestUri.
     /// The headers are copied by the base implementation, excluding some protocol headers like HTTP/2 pseudo headers (":authority").
+    /// This method may be overridden to conditionally produce a response, such as for error conditions, and prevent the request from
+    /// being proxied. This is indicated by setting the `HttpResponse.StatusCode` to a value other than 200, or calling `HttpResponse.StartAsync()`,
+    /// or writing to the `HttpResponse.Body` or `BodyWriter`.
     /// </summary>
     /// <param name="httpContext">The incoming request.</param>
     /// <param name="proxyRequest">The outgoing proxy request.</param>

--- a/src/ReverseProxy/Forwarder/RequestUtilities.cs
+++ b/src/ReverseProxy/Forwarder/RequestUtilities.cs
@@ -404,4 +404,10 @@ public static class RequestUtilities
         values = default;
         return false;
     }
+
+    internal static bool IsResponseSet(HttpResponse response)
+    {
+        return response.StatusCode != StatusCodes.Status200OK
+            || response.HasStarted;
+    }
 }

--- a/src/ReverseProxy/Transforms/Builder/StructuredTransformer.cs
+++ b/src/ReverseProxy/Transforms/Builder/StructuredTransformer.cs
@@ -88,6 +88,12 @@ internal sealed class StructuredTransformer : HttpTransformer
         foreach (var requestTransform in RequestTransforms)
         {
             await requestTransform.ApplyAsync(transformContext);
+
+            // The transform generated a response, do not apply further transforms and do not forward.
+            if (httpContext.Response.StatusCode != StatusCodes.Status200OK || httpContext.Response.HasStarted)
+            {
+                return;
+            }
         }
 
         // Allow a transform to directly set a custom RequestUri.

--- a/src/ReverseProxy/Transforms/Builder/StructuredTransformer.cs
+++ b/src/ReverseProxy/Transforms/Builder/StructuredTransformer.cs
@@ -90,7 +90,7 @@ internal sealed class StructuredTransformer : HttpTransformer
             await requestTransform.ApplyAsync(transformContext);
 
             // The transform generated a response, do not apply further transforms and do not forward.
-            if (httpContext.Response.StatusCode != StatusCodes.Status200OK || httpContext.Response.HasStarted)
+            if (RequestUtilities.IsResponseSet(httpContext.Response))
             {
                 return;
             }

--- a/src/ReverseProxy/Utilities/EventIds.cs
+++ b/src/ReverseProxy/Utilities/EventIds.cs
@@ -62,4 +62,5 @@ internal static class EventIds
     public static readonly EventId ResponseReceived = new EventId(56, "ResponseReceived");
     public static readonly EventId DelegationQueueReset = new EventId(57, "DelegationQueueReset");
     public static readonly EventId Http10RequestVersionDetected = new EventId(58, "Http10RequestVersionDetected");
+    public static readonly EventId NotForwarding = new EventId(59, "NotForwarding");
 }

--- a/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
@@ -381,7 +381,7 @@ public class HttpForwarderTests
 
         var sut = CreateProxy();
         var client = MockHttpHandler.CreateClient(
-            async (HttpRequestMessage request, CancellationToken cancellationToken) =>
+            (HttpRequestMessage request, CancellationToken cancellationToken) =>
             {
                 throw new NotImplementedException();
             });


### PR DESCRIPTION
Fixes #1701 @leastprivilege 

If a request transform encounters a problem right now the only thing it can do is throw. A few customers have asked how to generate a response and exit gracefully. Response transforms can already do this by returning false to prevent us from proxying the body.
- https://github.com/microsoft/reverse-proxy/issues/1701
- https://github.com/microsoft/reverse-proxy/issues/1670
- https://github.com/microsoft/reverse-proxy/discussions/1724

`HttpTransformer.TransformRequestAsync` has a signature that can't return any additional information without an API breaking change. Instead, we can detect if a transform generated a response by checking HttpResponse.StatusCode or HasStarted. In this case we'll stop trying to proxy the request and exit gracefully. If someone had modified the StatusCode before this change it would have been overwritten when proxying the response. If they had started the response it would have failed when trying to proxy the response later.

There's a series of related requests that I checked if could be solved in the same way but decided against it. I think these can be handled at the config and routing layer with alternate endpoints, there's no need for them to execute the proxy pipeline / load balancing, session affinity, etc. I'll send a separate PR for those.
- https://github.com/microsoft/reverse-proxy/issues/1893
- https://github.com/microsoft/reverse-proxy/issues/1868
- https://github.com/microsoft/reverse-proxy/issues/187


TODO: Update docs
