### PR TITLE
log proxy errors as warnings

### DIFF
--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -779,7 +779,7 @@ internal sealed class HttpForwarder : IHttpForwarder
             "Proxying to {targetUrl} {version} {versionPolicy} {isStreaming}");
 
         private static readonly Action<ILogger, ForwarderError, string, Exception> _proxyError = LoggerMessage.Define<ForwarderError, string>(
-            LogLevel.Information,
+            LogLevel.Warning,
             EventIds.ForwardingError,
             "{error}: {message}");
 


### PR DESCRIPTION
Logging proxy errors as warning helps to separate proxy errors from other log informational events. Proxy errors are useful to troubleshoot any errors.