### PR TITLE
Make MaxRequestBodySize configurable 

### DIFF
--- a/docs/docfx/articles/config-files.md
+++ b/docs/docfx/articles/config-files.md
@@ -130,7 +130,7 @@ For additional fields see [ClusterConfig](xref:Yarp.ReverseProxy.Configuration.C
         // matches /something/* and routes to "allclusterprops"
         "ClusterId": "allclusterprops", // Name of one of the clusters
         "Order" : 100, // Lower numbers have higher precedence
-        "MaxRequestBodySize" : 1000000, // In bytes. An optional override of the server's limit (30MB). Set to -1 to disable.
+        "MaxRequestBodySize" : 1000000, // In bytes. An optional override of the server's limit (30MB default). Set to -1 to disable.
         "Authorization Policy" : "Anonymous", // Name of the policy or "Default", "Anonymous"
         "CorsPolicy" : "Default", // Name of the CorsPolicy to apply to this route or "Default", "Disable"
         "Match": {

--- a/docs/docfx/articles/config-files.md
+++ b/docs/docfx/articles/config-files.md
@@ -130,6 +130,7 @@ For additional fields see [ClusterConfig](xref:Yarp.ReverseProxy.Configuration.C
         // matches /something/* and routes to "allclusterprops"
         "ClusterId": "allclusterprops", // Name of one of the clusters
         "Order" : 100, // Lower numbers have higher precedence
+        "MaxRequestBodySize" : 1000000, // In bytes. An optional override of the server's limit (30MB). Set to -1 to disable.
         "Authorization Policy" : "Anonymous", // Name of the policy or "Default", "Anonymous"
         "CorsPolicy" : "Default", // Name of the CorsPolicy to apply to this route or "Default", "Disable"
         "Match": {

--- a/docs/docfx/articles/middleware.md
+++ b/docs/docfx/articles/middleware.md
@@ -48,7 +48,7 @@ endpoints.MapReverseProxy(proxyPipeline =>
 });
 ```
 
-By default this overload of `MapReverseProxy` only includes the minimal setup and proxying logic at the start and end of its pipeline. Middleware for session affinity, load balancing, and passive health checks are not included by default so that you can exclude, replace, or control their ordering with any additional middleware.
+By default this overload of `MapReverseProxy` only includes the minimal setup, proxying logic, and limit enforcement at the start and end of its pipeline. Middleware for session affinity, load balancing, and passive health checks are not included by default so that you can exclude, replace, or control their ordering with any additional middleware.
 
 ## Custom Proxy Middleware
 

--- a/src/ReverseProxy/Configuration/ConfigProvider/ConfigurationConfigProvider.cs
+++ b/src/ReverseProxy/Configuration/ConfigProvider/ConfigurationConfigProvider.cs
@@ -144,6 +144,7 @@ internal sealed class ConfigurationConfigProvider : IProxyConfigProvider, IDispo
         {
             RouteId = section.Key,
             Order = section.ReadInt32(nameof(RouteConfig.Order)),
+            MaxRequestBodySize = section.ReadInt64(nameof(RouteConfig.MaxRequestBodySize)),
             ClusterId = section[nameof(RouteConfig.ClusterId)],
             AuthorizationPolicy = section[nameof(RouteConfig.AuthorizationPolicy)],
             CorsPolicy = section[nameof(RouteConfig.CorsPolicy)],

--- a/src/ReverseProxy/Configuration/ConfigProvider/ConfigurationReadingExtensions.cs
+++ b/src/ReverseProxy/Configuration/ConfigProvider/ConfigurationReadingExtensions.cs
@@ -16,6 +16,11 @@ internal static class ConfigurationReadingExtensions
         return configuration[name] is string value ? int.Parse(value, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture) : null;
     }
 
+    internal static long? ReadInt64(this IConfiguration configuration, string name)
+    {
+        return configuration[name] is string value ? long.Parse(value, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture) : null;
+    }
+
     internal static double? ReadDouble(this IConfiguration configuration, string name)
     {
         return configuration[name] is string value ? double.Parse(value, CultureInfo.InvariantCulture) : null;

--- a/src/ReverseProxy/Configuration/RouteConfig.cs
+++ b/src/ReverseProxy/Configuration/RouteConfig.cs
@@ -53,6 +53,12 @@ public sealed record RouteConfig
     public string? CorsPolicy { get; init; }
 
     /// <summary>
+    /// An optional override for how large request bodies can be in bytes. If set, this overrides the server's default (30MB) per request.
+    /// Set to '-1' to disable the limit for this route.
+    /// </summary>
+    public long? MaxRequestBodySize { get; init; }
+
+    /// <summary>
     /// Arbitrary key-value pairs that further describe this route.
     /// </summary>
     public IReadOnlyDictionary<string, string>? Metadata { get; init; }

--- a/src/ReverseProxy/Limits/LimitsMiddleware.cs
+++ b/src/ReverseProxy/Limits/LimitsMiddleware.cs
@@ -11,8 +11,9 @@ namespace Yarp.ReverseProxy.Limits;
 
 /// <summary>
 /// Updates request limits based on route config. This is implemented as middleware at the end of the proxy
-/// pipeline so that apps can call ReassignProxyRequest to move the request to a different route before limits are applied.
-/// This may be replaced in the future by route metadata and an aspnetcore middleware https://github.com/dotnet/aspnetcore/issues/40452.
+/// pipeline so that apps can call ReassignProxyRequest to move the request to a different route before limits are applied. While similar to a proposed aspnetcore feature (https://github.com/dotnet/aspnetcore/issues/40452),
+/// the possibility of reassigning routes means we need to apply this limit very late. Trying to apply it twice could
+/// result in unexpected behavior like being unable to set it back to the server default.
 /// </summary>
 internal sealed class LimitsMiddleware
 {

--- a/src/ReverseProxy/Limits/LimitsMiddleware.cs
+++ b/src/ReverseProxy/Limits/LimitsMiddleware.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging;
+
+namespace Yarp.ReverseProxy.Limits;
+
+/// <summary>
+/// Updates request limits based on route config. This is implemented as middleware at the end of the proxy
+/// pipeline so that apps can call ReassignProxyRequest to move the request to a different route before limits are applied.
+/// This may be replaced in the future by route metadata and an aspnetcore middleware https://github.com/dotnet/aspnetcore/issues/40452.
+/// </summary>
+internal sealed class LimitsMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger _logger;
+
+    public LimitsMiddleware(RequestDelegate next, ILogger<LimitsMiddleware> logger)
+    {
+        _next = next ?? throw new ArgumentNullException(nameof(next));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc/>
+    public Task Invoke(HttpContext context)
+    {
+        _ = context ?? throw new ArgumentNullException(nameof(context));
+
+        var config = context.GetRouteModel().Config;
+
+        if (config.MaxRequestBodySize.HasValue)
+        {
+            var sizeFeature = context.Features.Get<IHttpMaxRequestBodySizeFeature>();
+            if (sizeFeature != null && !sizeFeature.IsReadOnly)
+            {
+                // -1 for disabled
+                var limit = config.MaxRequestBodySize.Value;
+                long? newValue = limit == -1 ? null : limit;
+                sizeFeature.MaxRequestBodySize = newValue;
+                Log.MaxRequestBodySizeSet(_logger, limit);
+            }
+        }
+
+        return _next(context);
+    }
+
+    private static class Log
+    {
+        private static readonly Action<ILogger, long?, Exception?> _maxRequestBodySizeSet = LoggerMessage.Define<long?>(
+            LogLevel.Debug,
+            EventIds.MaxRequestBodySizeSet,
+            "The MaxRequestBodySize has been set to '{limit}'.");
+
+        public static void MaxRequestBodySizeSet(ILogger logger, long? limit)
+        {
+            _maxRequestBodySizeSet(logger, limit, null);
+        }
+    }
+}

--- a/src/ReverseProxy/Routing/ReverseProxyIEndpointRouteBuilderExtensions.cs
+++ b/src/ReverseProxy/Routing/ReverseProxyIEndpointRouteBuilderExtensions.cs
@@ -5,9 +5,10 @@ using System;
 using System.Linq;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Yarp.ReverseProxy.Forwarder;
+using Yarp.ReverseProxy.Limits;
 using Yarp.ReverseProxy.Management;
 using Yarp.ReverseProxy.Model;
-using Yarp.ReverseProxy.Forwarder;
 using Yarp.ReverseProxy.Routing;
 
 namespace Microsoft.AspNetCore.Builder;
@@ -49,6 +50,7 @@ public static class ReverseProxyIEndpointRouteBuilderExtensions
         var proxyAppBuilder = new ReverseProxyApplicationBuilder(endpoints.CreateApplicationBuilder());
         proxyAppBuilder.UseMiddleware<ProxyPipelineInitializerMiddleware>();
         configureApp(proxyAppBuilder);
+        proxyAppBuilder.UseMiddleware<LimitsMiddleware>();
         proxyAppBuilder.UseMiddleware<ForwarderMiddleware>();
         var app = proxyAppBuilder.Build();
 

--- a/src/ReverseProxy/Utilities/EventIds.cs
+++ b/src/ReverseProxy/Utilities/EventIds.cs
@@ -63,4 +63,5 @@ internal static class EventIds
     public static readonly EventId DelegationQueueReset = new EventId(57, "DelegationQueueReset");
     public static readonly EventId Http10RequestVersionDetected = new EventId(58, "Http10RequestVersionDetected");
     public static readonly EventId NotForwarding = new EventId(59, "NotForwarding");
+    public static readonly EventId MaxRequestBodySizeSet = new EventId(60, "MaxRequestBodySizeSet");
 }

--- a/test/ReverseProxy.Tests/Configuration/ConfigProvider/ConfigurationConfigProviderTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigProvider/ConfigurationConfigProviderTests.cs
@@ -129,6 +129,7 @@ public class ConfigurationConfigProviderTests
                 AuthorizationPolicy = "Default",
                 CorsPolicy = "Default",
                 Order = -1,
+                MaxRequestBodySize = -1,
                 Match = new RouteMatch
                 {
                     Hosts = new List<string> { "host-A" },
@@ -166,6 +167,7 @@ public class ConfigurationConfigProviderTests
                 RouteId = "routeB",
                 ClusterId = "cluster2",
                 Order = 2,
+                MaxRequestBodySize = 1,
                 Match = new RouteMatch
                 {
                     Hosts = new List<string> { "host-B" },
@@ -327,6 +329,7 @@ public class ConfigurationConfigProviderTests
                 ]
             },
             ""Order"": -1,
+            ""MaxRequestBodySize"": -1,
             ""ClusterId"": ""cluster1"",
             ""AuthorizationPolicy"": ""Default"",
             ""CorsPolicy"": ""Default"",
@@ -369,6 +372,7 @@ public class ConfigurationConfigProviderTests
                 ]
             },
             ""Order"": 2,
+            ""MaxRequestBodySize"": 1,
             ""ClusterId"": ""cluster2"",
             ""AuthorizationPolicy"": null,
             ""CorsPolicy"": null,
@@ -560,6 +564,7 @@ public class ConfigurationConfigProviderTests
         var abstractRoute = abstractConfig.Routes.Single(c => c.RouteId == routeId);
         Assert.Equal(route.ClusterId, abstractRoute.ClusterId);
         Assert.Equal(route.Order, abstractRoute.Order);
+        Assert.Equal(route.MaxRequestBodySize, abstractRoute.MaxRequestBodySize);
         Assert.Equal(route.Match.Hosts, abstractRoute.Match.Hosts);
         Assert.Equal(route.Match.Methods, abstractRoute.Match.Methods);
         Assert.Equal(route.Match.Path, abstractRoute.Match.Path);

--- a/test/ReverseProxy.Tests/Limits/LimitsMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Limits/LimitsMiddlewareTests.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using Yarp.ReverseProxy.Configuration;
+using Yarp.ReverseProxy.Forwarder;
+using Yarp.ReverseProxy.Model;
+
+namespace Yarp.ReverseProxy.Limits.Tests;
+
+public class LimitsMiddlewareTests
+{
+    [Fact]
+    public void Constructor_Works()
+    {
+        CreateMiddleware();
+    }
+
+    [Fact]
+    public async Task MissingFeature_NoOps()
+    {
+        var context = CreateContext(10, null);
+
+        var sut = CreateMiddleware();
+
+        await sut.Invoke(context);
+    }
+
+    [Theory]
+    [InlineData(true, null, null, null)]
+    [InlineData(true, 10L, null, 10L)]
+    [InlineData(true, null, 10L, null)]
+    [InlineData(true, 10L, 11L, 10L)]
+    [InlineData(false, null, null, null)]
+    [InlineData(false, 10L, null, 10L)]
+    [InlineData(false, null, 10L, 10L)]
+    [InlineData(false, null, -1L, null)]
+    [InlineData(false, 10L, -1L, null)]
+    [InlineData(false, 10L, 11L, 11L)]
+    public async Task Invoke_CombinationsWork(bool readOnly, long? serverLimit, long? routeLimit, long? expected)
+    {
+        var feature = new FakeBodySizeFeature() { IsReadOnly = readOnly, MaxRequestBodySize = serverLimit };
+        var context = CreateContext(routeLimit, feature);
+
+        var sut = CreateMiddleware();
+
+        await sut.Invoke(context);
+
+        Assert.Equal(expected, feature.MaxRequestBodySize);
+    }
+
+    private static LimitsMiddleware CreateMiddleware()
+    {
+        return new LimitsMiddleware(
+            _ => Task.CompletedTask,
+            NullLogger<LimitsMiddleware>.Instance);
+    }
+
+    private static HttpContext CreateContext(long? bodySizeLimit, IHttpMaxRequestBodySizeFeature feature)
+    {
+        var cluster = new ClusterState("cluster1")
+        {
+            Model = new ClusterModel(new ClusterConfig(),
+                new HttpMessageInvoker(new HttpClientHandler()))
+        };
+
+        var context = new DefaultHttpContext();
+
+        var route = new RouteModel(new RouteConfig() { MaxRequestBodySize = bodySizeLimit }, cluster, HttpTransformer.Default);
+        context.Features.Set<IReverseProxyFeature>(
+            new ReverseProxyFeature()
+            {
+                Route = route,
+                Cluster = cluster.Model
+            });
+        context.Features.Set(cluster);
+
+        var endpoint = new Endpoint(default, new EndpointMetadataCollection(route), string.Empty);
+        context.SetEndpoint(endpoint);
+
+        context.Features.Set(feature);
+
+        return context;
+    }
+
+    private class FakeBodySizeFeature : IHttpMaxRequestBodySizeFeature
+    {
+        public bool IsReadOnly { get; set; }
+
+        public long? MaxRequestBodySize { get; set; }
+    }
+}


### PR DESCRIPTION
Fixes #640

The servers all have a configurable MaxRequestBodySize limit that defaults to ~30MB. This can be overridden per request with a feature. The most common case is to raise it for certain endpoints that upload big files, or to disable it for streaming scenarios. Some scenarios automatically disable it like WebSockets or gRPC streaming. Others need to be configured.

There is .NET 8 work planned to centralize this into endpoint metadata and middleware, but we want to support this for 6 and 7 in the meantime. https://github.com/dotnet/aspnetcore/issues/40452