### PR TITLE
Add support for addition of Multiple Host Domains to K8s Ingress Rules

### DIFF
--- a/src/Kubernetes.Controller/Converters/YarpParser.cs
+++ b/src/Kubernetes.Controller/Converters/YarpParser.cs
@@ -101,7 +101,7 @@ internal static class YarpParser
                         Headers = ingressContext.Options.RouteHeaders
                     },
                     ClusterId = cluster.ClusterId,
-                    RouteId = $"{ingressContext.Ingress.Metadata.Name}.{ingressContext.Ingress.Metadata.NamespaceProperty}:{path.Path}",
+                    RouteId = $"{ingressContext.Ingress.Metadata.Name}.{ingressContext.Ingress.Metadata.NamespaceProperty}:{host}{path.Path}",
                     Transforms = ingressContext.Options.Transforms,
                     AuthorizationPolicy = ingressContext.Options.AuthorizationPolicy,
                     CorsPolicy = ingressContext.Options.CorsPolicy,

--- a/test/Kubernetes.Tests/IngressConversionTests.cs
+++ b/test/Kubernetes.Tests/IngressConversionTests.cs
@@ -46,6 +46,7 @@ public class IngressConversionTests
     [InlineData("mapped-port")]
     [InlineData("port-mismatch")]
     [InlineData("hostname-routing")]
+    [InlineData("multiple-hosts")]
     [InlineData("multiple-ingresses")]
     [InlineData("multiple-ingresses-one-svc")]
     [InlineData("multiple-namespaces")]

--- a/test/Kubernetes.Tests/testassets/hostname-routing/routes.json
+++ b/test/Kubernetes.Tests/testassets/hostname-routing/routes.json
@@ -1,6 +1,6 @@
 [
   {
-    "RouteId": "hostname-routing.foo:/",
+    "RouteId": "hostname-routing.foo:foo.bar.com/",
     "Match": {
       "Methods": null,
       "Hosts": [ "foo.bar.com" ],

--- a/test/Kubernetes.Tests/testassets/multiple-hosts/clusters.json
+++ b/test/Kubernetes.Tests/testassets/multiple-hosts/clusters.json
@@ -1,0 +1,34 @@
+[
+  {
+    "ClusterId": "repro-1-service.foo:http",
+    "LoadBalancingPolicy": null,
+    "SessionAffinity": null,
+    "HealthCheck": null,
+    "HttpClient": null,
+    "HttpRequest": null,
+    "Destinations": {
+      "http://10.244.1.11:80": {
+        "Address": "http://10.244.1.11:80",
+        "Health": null,
+        "Metadata": null
+      }
+    },
+    "Metadata": null
+  },
+  {
+    "ClusterId": "repro-2-service.foo:http",
+    "LoadBalancingPolicy": null,
+    "SessionAffinity": null,
+    "HealthCheck": null,
+    "HttpClient": null,
+    "HttpRequest": null,
+    "Destinations": {
+      "http://10.244.2.22:80": {
+        "Address": "http://10.244.2.22:80",
+        "Health": null,
+        "Metadata": null
+      }
+    },
+    "Metadata": null
+  }
+]

--- a/test/Kubernetes.Tests/testassets/multiple-hosts/clusters.json
+++ b/test/Kubernetes.Tests/testassets/multiple-hosts/clusters.json
@@ -30,5 +30,21 @@
       }
     },
     "Metadata": null
+  },
+  {
+    "ClusterId": "repro-3-service.foo:http",
+    "LoadBalancingPolicy": null,
+    "SessionAffinity": null,
+    "HealthCheck": null,
+    "HttpClient": null,
+    "HttpRequest": null,
+    "Destinations": {
+      "http://10.244.3.33:80": {
+        "Address": "http://10.244.3.33:80",
+        "Health": null,
+        "Metadata": null
+      }
+    },
+    "Metadata": null
   }
 ]

--- a/test/Kubernetes.Tests/testassets/multiple-hosts/ingress.yaml
+++ b/test/Kubernetes.Tests/testassets/multiple-hosts/ingress.yaml
@@ -25,6 +25,15 @@ spec:
                 name: repro-2-service
                 port:
                   name: http
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: repro-3-service
+                port:
+                  name: http
 ---
 apiVersion: v1
 kind: Service
@@ -75,6 +84,33 @@ metadata:
 subsets:
   - addresses:
     - ip: 10.244.2.22
+    ports:
+    - name: http
+      port: 80
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: repro-3-service
+  namespace: foo
+spec:
+  selector:
+    app: repro-2
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: repro-3-service
+  namespace: foo
+subsets:
+  - addresses:
+    - ip: 10.244.3.33
     ports:
     - name: http
       port: 80

--- a/test/Kubernetes.Tests/testassets/multiple-hosts/ingress.yaml
+++ b/test/Kubernetes.Tests/testassets/multiple-hosts/ingress.yaml
@@ -1,0 +1,81 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: repro-1-ingress
+  namespace: foo
+spec:
+  rules:
+    - host: 'subdomain1.example.com'
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: repro-1-service
+                port:
+                  name: http
+    - host: 'subdomain2.example.com'
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: repro-2-service
+                port:
+                  name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: repro-1-service
+  namespace: foo
+spec:
+  selector:
+    app: repro-1
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: repro-1-service
+  namespace: foo
+subsets:
+  - addresses:
+    - ip: 10.244.1.11
+    ports:
+    - name: http
+      port: 80
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: repro-2-service
+  namespace: foo
+spec:
+  selector:
+    app: repro-2
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: repro-2-service
+  namespace: foo
+subsets:
+  - addresses:
+    - ip: 10.244.2.22
+    ports:
+    - name: http
+      port: 80
+      protocol: TCP

--- a/test/Kubernetes.Tests/testassets/multiple-hosts/routes.json
+++ b/test/Kubernetes.Tests/testassets/multiple-hosts/routes.json
@@ -9,14 +9,14 @@
       "QueryParameters": null
     },
     "Order": null,
-    "ClusterId": "repro-service.foo:http",
+    "ClusterId": "repro-1-service.foo:http",
     "AuthorizationPolicy": null,
     "CorsPolicy": null,
     "Metadata": null,
     "Transforms": null
   },
   {
-    "RouteId": "repro-2-ingress.foo:subdomain2.example.com/",
+    "RouteId": "repro-1-ingress.foo:subdomain2.example.com/",
     "Match": {
       "Methods": null,
       "Hosts": [ "subdomain2.example.com" ],
@@ -25,7 +25,7 @@
       "QueryParameters": null
     },
     "Order": null,
-    "ClusterId": "repro-service.foo:http",
+    "ClusterId": "repro-2-service.foo:http",
     "AuthorizationPolicy": null,
     "CorsPolicy": null,
     "Metadata": null,

--- a/test/Kubernetes.Tests/testassets/multiple-hosts/routes.json
+++ b/test/Kubernetes.Tests/testassets/multiple-hosts/routes.json
@@ -30,5 +30,21 @@
     "CorsPolicy": null,
     "Metadata": null,
     "Transforms": null
+  },
+  {
+    "RouteId": "repro-1-ingress.foo:/",
+    "Match": {
+      "Methods": null,
+      "Hosts": [],
+      "Path": "/{**catch-all}",
+      "Headers": null,
+      "QueryParameters": null
+    },
+    "Order": null,
+    "ClusterId": "repro-3-service.foo:http",
+    "AuthorizationPolicy": null,
+    "CorsPolicy": null,
+    "Metadata": null,
+    "Transforms": null
   }
 ]

--- a/test/Kubernetes.Tests/testassets/multiple-ingresses/routes.json
+++ b/test/Kubernetes.Tests/testassets/multiple-ingresses/routes.json
@@ -1,6 +1,6 @@
 [
   {
-    "RouteId": "repro-1-ingress.foo:/",
+    "RouteId": "repro-1-ingress.foo:subdomain1.example.com/",
     "Match": {
       "Methods": null,
       "Hosts": [ "subdomain1.example.com" ],
@@ -16,7 +16,7 @@
     "Transforms": null
   },
   {
-    "RouteId": "repro-2-ingress.foo:/",
+    "RouteId": "repro-2-ingress.foo:subdomain2.example.com/",
     "Match": {
       "Methods": null,
       "Hosts": [ "subdomain2.example.com" ],

--- a/test/Kubernetes.Tests/testassets/multiple-namespaces/routes.json
+++ b/test/Kubernetes.Tests/testassets/multiple-namespaces/routes.json
@@ -1,6 +1,6 @@
 [
   {
-    "RouteId": "the-ingress.ns-one:/",
+    "RouteId": "the-ingress.ns-one:subdomain1.example.com/",
     "Match": {
       "Methods": null,
       "Hosts": [ "subdomain1.example.com" ],
@@ -16,7 +16,7 @@
     "Transforms": null
   },
   {
-    "RouteId": "the-ingress.ns-two:/",
+    "RouteId": "the-ingress.ns-two:subdomain2.example.com/",
     "Match": {
       "Methods": null,
       "Hosts": [ "subdomain2.example.com" ],


### PR DESCRIPTION
Include Host name in Yarp Route Id, when parsing Ingress Manifest Rules.

Fixes issue as described in #1950 