### PR TITLE
Fix startup race condition in K8s IngressController

### DIFF
--- a/src/Kubernetes.Controller/Caching/ICache.cs
+++ b/src/Kubernetes.Controller/Caching/ICache.cs
@@ -23,4 +23,5 @@ public interface ICache
     bool TryGetReconcileData(NamespacedName key, out ReconcileData data);
     void GetKeys(List<NamespacedName> keys);
     IEnumerable<IngressData> GetIngresses();
+    bool IsYarpIngress(IngressData ingress);
 }

--- a/src/Kubernetes.Controller/Services/Reconciler.cs
+++ b/src/Kubernetes.Controller/Services/Reconciler.cs
@@ -45,6 +45,11 @@ public partial class Reconciler : IReconciler
             {
                 try
                 {
+                    if (!_cache.IsYarpIngress(ingress))
+                    {
+                        continue;
+                    }
+
                     if (_cache.TryGetReconcileData(new NamespacedName(ingress.Metadata.NamespaceProperty, ingress.Metadata.Name), out var data))
                     {
                         var ingressContext = new YarpIngressContext(ingress, data.ServiceList, data.EndpointsList);

--- a/test/Kubernetes.Tests/IngressCacheTests.cs
+++ b/test/Kubernetes.Tests/IngressCacheTests.cs
@@ -61,12 +61,11 @@ public class IngressCacheTests
         var ingress = KubeResourceGenerator.CreateIngress("ingress-with-class", "ns-test", "yarp");
 
         // Act
-        var change = _cacheUnderTest.Update(WatchEventType.Added, ingress);
+        _cacheUnderTest.Update(WatchEventType.Added, ingress);
 
         // Assert
-        var ingresses = _cacheUnderTest.GetIngresses().ToArray();
+        var ingresses = _cacheUnderTest.GetIngresses().Where(_cacheUnderTest.IsYarpIngress).ToArray();
 
-        Assert.Equal(expectedIngressCount != 0, change);
         Assert.Equal(expectedIngressCount, ingresses.Length);
     }
 
@@ -88,12 +87,11 @@ public class IngressCacheTests
         var ingress = KubeResourceGenerator.CreateIngress("ingress-without-class", "ns-test", null);
 
         // Act
-        var change = _cacheUnderTest.Update(WatchEventType.Added, ingress);
+        _cacheUnderTest.Update(WatchEventType.Added, ingress);
 
         // Assert
-        var ingresses = _cacheUnderTest.GetIngresses().ToArray();
+        var ingresses = _cacheUnderTest.GetIngresses().Where(_cacheUnderTest.IsYarpIngress).ToArray();
 
-        Assert.Equal(expectedIngressCount != 0, change);
         Assert.Equal(expectedIngressCount, ingresses.Length);
     }
 
@@ -113,7 +111,7 @@ public class IngressCacheTests
 
         // Assert
         var ingresses = _cacheUnderTest.GetIngresses().ToArray();
-        Assert.Empty(ingresses);
+        Assert.All(ingresses, i => Assert.False(_cacheUnderTest.IsYarpIngress(i)));
     }
 
     [Fact]
@@ -151,7 +149,7 @@ public class IngressCacheTests
 
         // Assert
         var ingresses = _cacheUnderTest.GetIngresses().ToArray();
-        Assert.Empty(ingresses);
+        Assert.All(ingresses, i => Assert.False(_cacheUnderTest.IsYarpIngress(i)));
     }
 
     [Fact]


### PR DESCRIPTION
There is currently a race condition in the loading of K8s resources through the resource informers. If the ingress resources load before the ingress classes, and they have an ingress class name specified, then they are not considered for config generation. Similarly, if you have your yarp ingress class defined as default, but ingresses load first, then they are also not considered because the controller is not yet aware of what the default controller should be.

This fix guarantees the ingress classes will be loaded first prior to loading all other resource types. Please let me know if you would like this done a different way, I am happy to make any changes to help see this contribution through.