### PR TITLE
Refactor functional test environment

### DIFF
--- a/test/ReverseProxy.FunctionalTests/Common/TestEnvironment.cs
+++ b/test/ReverseProxy.FunctionalTests/Common/TestEnvironment.cs
@@ -39,7 +39,7 @@ public class TestEnvironment
 
     public Func<ClusterConfig, RouteConfig, (ClusterConfig Cluster, RouteConfig Route)> ConfigTransformer { get; set; } = (a, b) => (a, b);
 
-    public Version? DestionationHttpVersion { get; set; }
+    public Version DestionationHttpVersion { get; set; }
 
     public HttpVersionPolicy? DestionationHttpVersionPolicy { get; set; }
 

--- a/test/ReverseProxy.FunctionalTests/DistributedTracingTests.cs
+++ b/test/ReverseProxy.FunctionalTests/DistributedTracingTests.cs
@@ -36,9 +36,9 @@ public class DistributedTracingTests
                     downstreamHeaders.Add(header);
                 }
                 await context.Response.Body.WriteAsync(Encoding.UTF8.GetBytes("Hello"));
-            },
-            proxyBuilder => { },
-            proxyApp =>
+            })
+        {
+            ConfigureProxyApp = proxyApp =>
             {
                 proxyApp.Use(next => context =>
                 {
@@ -48,7 +48,8 @@ public class DistributedTracingTests
                     }
                     return next(context);
                 });
-            });
+            },
+        };
 
         var clientActivity = new Activity("Foo");
         clientActivity.SetIdFormat(idFormat);

--- a/test/ReverseProxy.FunctionalTests/Expect100ContinueTests.cs
+++ b/test/ReverseProxy.FunctionalTests/Expect100ContinueTests.cs
@@ -66,16 +66,12 @@ public class Expect100ContinueTests
                 }
 
                 context.Response.StatusCode = destResponseCode;
-            },
-            proxyBuilder =>
-            {
-                proxyBuilder.Services.AddSingleton<IForwarderHttpClientFactory, TestForwarderHttpClientFactory>();
-            },
-            proxyApp => { },
-            proxyProtocol: proxyProtocol,
-            useHttpsOnDestination: true,
-            useHttpsOnProxy: true,
-            configTransformer: (c, r) =>
+            })
+        {
+            ProxyProtocol = proxyProtocol,
+            UseHttpsOnDestination = true,
+            UseHttpsOnProxy = true,
+            ConfigTransformer = (c, r) =>
             {
                 c = c with
                 {
@@ -85,7 +81,12 @@ public class Expect100ContinueTests
                     }
                 };
                 return (c, r);
-            });
+            },
+            ConfigureProxy = proxyBuilder =>
+            {
+                proxyBuilder.Services.AddSingleton<IForwarderHttpClientFactory, TestForwarderHttpClientFactory>();
+            },
+        };
 
         await test.Invoke(async uri =>
         {
@@ -152,16 +153,12 @@ public class Expect100ContinueTests
                 {
                     await context.Response.Body.WriteAsync(responseBody.AsMemory());
                 }
-            },
-            proxyBuilder =>
-            {
-                proxyBuilder.Services.AddSingleton<IForwarderHttpClientFactory, TestForwarderHttpClientFactory>();
-            },
-            proxyApp => { },
-            proxyProtocol: proxyProtocol,
-            useHttpsOnDestination: true,
-            useHttpsOnProxy: true,
-            configTransformer: (c, r) =>
+            })
+        {
+            ProxyProtocol = proxyProtocol,
+            UseHttpsOnDestination = true,
+            UseHttpsOnProxy = true,
+            ConfigTransformer = (c, r) =>
             {
                 c = c with
                 {
@@ -171,7 +168,12 @@ public class Expect100ContinueTests
                     }
                 };
                 return (c, r);
-            });
+            },
+            ConfigureProxy = proxyBuilder =>
+            {
+                proxyBuilder.Services.AddSingleton<IForwarderHttpClientFactory, TestForwarderHttpClientFactory>();
+            },
+        };
 
         await test.Invoke(async uri =>
         {
@@ -213,15 +215,12 @@ public class Expect100ContinueTests
                 }
 
                 await context.Response.Body.WriteAsync(responseBody.AsMemory());
-            },
-            proxyBuilder => {
-                proxyBuilder.Services.AddSingleton<IForwarderHttpClientFactory, TestForwarderHttpClientFactory>();
-            },
-            proxyApp => { },
-            proxyProtocol: proxyProtocol,
-            useHttpsOnDestination: true,
-            useHttpsOnProxy: true,
-            configTransformer: (c, r) =>
+            })
+        {
+            ProxyProtocol = proxyProtocol,
+            UseHttpsOnDestination = true,
+            UseHttpsOnProxy = true,
+            ConfigTransformer = (c, r) =>
             {
                 c = c with
                 {
@@ -231,7 +230,12 @@ public class Expect100ContinueTests
                     }
                 };
                 return (c, r);
-            });
+            },
+            ConfigureProxy = proxyBuilder =>
+            {
+                proxyBuilder.Services.AddSingleton<IForwarderHttpClientFactory, TestForwarderHttpClientFactory>();
+            },
+        };
 
         await test.Invoke(async uri =>
         {

--- a/test/ReverseProxy.FunctionalTests/HeaderTests.cs
+++ b/test/ReverseProxy.FunctionalTests/HeaderTests.cs
@@ -10,6 +10,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
@@ -53,9 +54,10 @@ public class HeaderTests
 
 
                 return Task.CompletedTask;
-            },
-            proxyBuilder => { },
-            proxyApp =>
+            })
+        {
+            ProxyProtocol = HttpProtocols.Http1,
+            ConfigureProxyApp = proxyApp =>
             {
                 proxyApp.Use(async (context, next) =>
                 {
@@ -79,7 +81,7 @@ public class HeaderTests
                     }
                 });
             },
-            proxyProtocol: HttpProtocols.Http1);
+        };
 
         await test.Invoke(async proxyUri =>
         {
@@ -137,9 +139,10 @@ public class HeaderTests
                 context.Response.Headers.Add(HeaderNames.WWWAuthenticate, "");
                 context.Response.Headers.Add("custom", "");
                 return Task.CompletedTask;
-            },
-            proxyBuilder => { },
-            proxyApp =>
+            })
+        {
+            ProxyProtocol = HttpProtocols.Http1,
+            ConfigureProxyApp = proxyApp =>
             {
                 proxyApp.Use(async (context, next) =>
                 {
@@ -164,7 +167,7 @@ public class HeaderTests
                     }
                 });
             },
-            proxyProtocol: HttpProtocols.Http1);
+        };
 
         await test.Invoke(async proxyUri =>
         {
@@ -230,9 +233,11 @@ public class HeaderTests
                     tcs.SetException(new Exception($"Missing '{HeaderNames.Referer}' header in request"));
                 }
                 return Task.CompletedTask;
-            },
-            proxyBuilder => { },
-            proxyApp =>
+            })
+        {
+            ProxyProtocol = HttpProtocols.Http1,
+            HeaderEncoding = encoding,
+            ConfigureProxyApp = proxyApp =>
             {
                 proxyApp.Use(async (context, next) =>
                 {
@@ -252,7 +257,7 @@ public class HeaderTests
                     }
                 });
             },
-            proxyProtocol: HttpProtocols.Http1, headerEncoding: encoding);
+        };
 
         await test.Invoke(async proxyUri =>
         {
@@ -340,10 +345,12 @@ public class HeaderTests
         IForwarderErrorFeature proxyError = null;
         Exception unhandledError = null;
 
-        using var proxy = TestEnvironment.CreateProxy(HttpProtocols.Http1, false, false, encoding, "cluster1", $"http://{tcpListener.LocalEndpoint}",
-            proxyServices => { },
-            proxyBuilder => { },
-            proxyApp =>
+        var proxyTest = new TestEnvironment()
+        {
+            ProxyProtocol = HttpProtocols.Http1,
+            HeaderEncoding = encoding,
+            ClusterId = "cluster1",
+            ConfigureProxyApp = proxyApp =>
             {
                 proxyApp.Use(async (context, next) =>
                 {
@@ -359,7 +366,9 @@ public class HeaderTests
                     }
                 });
             },
-            (c, r) => (c, r));
+        };
+
+        using var proxy = proxyTest.CreateProxy($"http://{tcpListener.LocalEndpoint}");
 
         await proxy.StartAsync();
 
@@ -409,9 +418,10 @@ public class HeaderTests
                     appTcs.SetException(ex);
                 }
                 return Task.CompletedTask;
-            },
-            proxyBuilder => { },
-            proxyApp =>
+            })
+        {
+            ProxyProtocol = HttpProtocols.Http1,
+            ConfigureProxyApp = proxyApp =>
             {
                 proxyApp.Use(async (context, next) =>
                 {
@@ -429,7 +439,7 @@ public class HeaderTests
                     await next();
                 });
             },
-            proxyProtocol: HttpProtocols.Http1);
+        };
 
         await test.Invoke(async proxyUri =>
         {
@@ -489,9 +499,10 @@ public class HeaderTests
                     appTcs.SetException(ex);
                 }
                 return Task.CompletedTask;
-            },
-            proxyBuilder => { },
-            proxyApp =>
+            })
+        {
+            ProxyProtocol = HttpProtocols.Http1,
+            ConfigureProxyApp = proxyApp =>
             {
                 proxyApp.Use(async (context, next) =>
                 {
@@ -513,7 +524,7 @@ public class HeaderTests
                     await next();
                 });
             },
-            proxyProtocol: HttpProtocols.Http1);
+        };
 
         await test.Invoke(async proxyUri =>
         {
@@ -633,9 +644,10 @@ public class HeaderTests
             {
                 Assert.True(context.Response.Headers.TryAdd(headerName, values));
                 return Task.CompletedTask;
-            },
-            proxyBuilder => { },
-            proxyApp =>
+            })
+        {
+            ProxyProtocol = HttpProtocols.Http1,
+            ConfigureProxyApp = proxyApp =>
             {
                 proxyApp.Use(async (context, next) =>
                 {
@@ -659,7 +671,7 @@ public class HeaderTests
                     }
                 });
             },
-            proxyProtocol: HttpProtocols.Http1);
+        };
 
         await test.Invoke(async proxyUri =>
         {

--- a/test/ReverseProxy.FunctionalTests/HttpForwarderCancellationTests.cs
+++ b/test/ReverseProxy.FunctionalTests/HttpForwarderCancellationTests.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Xunit;
 using Yarp.ReverseProxy.Common;
 using Yarp.ReverseProxy.Utilities;
@@ -40,9 +41,11 @@ public class HttpForwarderCancellationTests
                 var resetFeature = context.Features.Get<IHttpResetFeature>();
                 Assert.NotNull(resetFeature);
                 resetFeature.Reset(0); // NO_ERROR
-            },
-            proxyBuilder => { },
-            proxyApp =>
+            })
+        {
+            UseHttpsOnDestination = true,
+            UseHttpsOnProxy = true,
+            ConfigureProxyApp = proxyApp =>
             {
                 proxyApp.Use(next => context =>
                 {
@@ -64,8 +67,7 @@ public class HttpForwarderCancellationTests
                     return next(context);
                 });
             },
-            useHttpsOnDestination: true,
-            useHttpsOnProxy: true);
+        };
 
         await test.Invoke(async uri =>
         {

--- a/test/ReverseProxy.FunctionalTests/HttpProxyCookieTests.cs
+++ b/test/ReverseProxy.FunctionalTests/HttpProxyCookieTests.cs
@@ -47,13 +47,14 @@ public abstract class HttpProxyCookieTests
                     tcs.SetException(new Exception("Missing 'Cookie' header in request"));
                 }
                 return Task.CompletedTask;
-            },
-            proxyBuilder => { },
-            proxyApp =>
+            })
+        {
+            ProxyProtocol = HttpProtocol,
+            ConfigureProxyApp = proxyApp =>
             {
                 proxyApp.UseMiddleware<CheckCookieHeaderMiddleware>();
             },
-            proxyProtocol: HttpProtocol);
+        };
 
         await test.Invoke(async uri =>
         {

--- a/test/ReverseProxy.FunctionalTests/PassiveHealthCheckTests.cs
+++ b/test/ReverseProxy.FunctionalTests/PassiveHealthCheckTests.cs
@@ -57,10 +57,9 @@ public class PassiveHealthCheckTests
             {
                 destinationReached = true;
                 throw new InvalidOperationException();
-            },
-            proxyBuilder => proxyBuilder.Services.AddSingleton<IForwarderHttpClientFactory>(new MockHttpClientFactory((_, _) => throw new IOException())),
-            proxyApp => { },
-            configTransformer: (c, r) =>
+            })
+        {
+            ConfigTransformer = (c, r) =>
             {
                 c = c with
                 {
@@ -74,7 +73,9 @@ public class PassiveHealthCheckTests
                 };
 
                 return (c, r);
-            });
+            },
+            ConfigureProxy = proxyBuilder => proxyBuilder.Services.AddSingleton<IForwarderHttpClientFactory>(new MockHttpClientFactory((_, _) => throw new IOException())),
+        };
 
         await test.Invoke(async uri =>
         {
@@ -122,10 +123,9 @@ public class PassiveHealthCheckTests
             {
                 destinationReached = true;
                 throw new InvalidOperationException();
-            },
-            proxyBuilder => proxyBuilder.Services.AddSingleton<IForwarderHttpClientFactory>(new MockHttpClientFactory(proxySendAsync)),
-            proxyApp => { },
-            configTransformer: (c, r) =>
+            })
+        {
+            ConfigTransformer = (c, r) =>
             {
                 c = c with
                 {
@@ -139,7 +139,9 @@ public class PassiveHealthCheckTests
                 };
 
                 return (c, r);
-            });
+            },
+            ConfigureProxy = proxyBuilder => proxyBuilder.Services.AddSingleton<IForwarderHttpClientFactory>(new MockHttpClientFactory(proxySendAsync)),
+        };
 
         await test.Invoke(async uri =>
         {

--- a/test/ReverseProxy.FunctionalTests/TelemetryConsumptionTests.cs
+++ b/test/ReverseProxy.FunctionalTests/TelemetryConsumptionTests.cs
@@ -106,12 +106,12 @@ public class TelemetryConsumptionTests
     public async Task TelemetryConsumptionWorks(RegistrationApproach registrationApproach)
     {
         var test = new TestEnvironment(
-            async context => await context.Response.WriteAsync("Foo"),
-            proxyBuilder => RegisterTelemetryConsumers(proxyBuilder.Services, registrationApproach),
-            proxyApp => { },
-            useHttpsOnDestination: true);
-
-        test.ClusterId = Guid.NewGuid().ToString();
+            async context => await context.Response.WriteAsync("Foo"))
+        {
+            UseHttpsOnDestination = true,
+            ClusterId = Guid.NewGuid().ToString(),
+            ConfigureProxy = proxyBuilder => RegisterTelemetryConsumers(proxyBuilder.Services, registrationApproach),
+        };
 
         await test.Invoke(async uri =>
         {
@@ -158,11 +158,11 @@ public class TelemetryConsumptionTests
     public async Task NonProxyTelemetryConsumptionWorks(RegistrationApproach registrationApproach)
     {
         var test = new TestEnvironment(
-            async context => await context.Response.WriteAsync("Foo"),
-            proxyBuilder => RegisterTelemetryConsumers(proxyBuilder.Services, registrationApproach),
-            proxyApp => { },
-            useHttpsOnDestination: true);
-
+            async context => await context.Response.WriteAsync("Foo"))
+        {
+            UseHttpsOnDestination = true,
+            ConfigureProxy = proxyBuilder => RegisterTelemetryConsumers(proxyBuilder.Services, registrationApproach),
+        };
         var path = $"/{Guid.NewGuid()}";
 
         await test.Invoke(async uri =>
@@ -265,11 +265,11 @@ public class TelemetryConsumptionTests
         MetricsOptions.Interval = TimeSpan.FromMilliseconds(10);
 
         var test = new TestEnvironment(
-            async context => await context.Response.WriteAsync("Foo"),
-            proxyBuilder => RegisterMetricsConsumers(proxyBuilder.Services, registrationApproach),
-            proxyApp => { },
-            useHttpsOnDestination: true);
-
+            async context => await context.Response.WriteAsync("Foo"))
+        {
+            UseHttpsOnDestination = true,
+            ConfigureProxy = proxyBuilder => RegisterMetricsConsumers(proxyBuilder.Services, registrationApproach),
+        };
         var consumerBox = new MetricsConsumer.MetricsConsumerBox();
         MetricsConsumer.ScopeInstance.Value = consumerBox;
         MetricsConsumer consumer = null;

--- a/test/ReverseProxy.FunctionalTests/WebSocketsTelemetryTests.cs
+++ b/test/ReverseProxy.FunctionalTests/WebSocketsTelemetryTests.cs
@@ -303,9 +303,9 @@ public class WebSocketsTelemetryTests
     {
         var telemetryConsumer = new TelemetryConsumer();
 
-        var test = new TestEnvironment(
-            destinationServies => { },
-            destinationApp =>
+        var test = new TestEnvironment()
+        {
+            ConfigureDestinationApp = destinationApp =>
             {
                 destinationApp.UseWebSockets();
 
@@ -319,21 +319,22 @@ public class WebSocketsTelemetryTests
                     }
                 });
             },
-            proxyServices =>
+            ConfigureProxyServices = proxyServices =>
             {
                 if (clock is not null)
                 {
                     proxyServices.AddSingleton(clock);
                 }
             },
-            proxyBuilder =>
+            ConfigureProxy = proxyBuilder =>
             {
                 proxyBuilder.Services.AddTelemetryConsumer(telemetryConsumer);
             },
-            proxyApp =>
+            ConfigureProxyApp = proxyApp =>
             {
                 proxyApp.UseWebSocketsTelemetry();
-            });
+            },
+        };
 
         await test.Invoke(async uri =>
         {


### PR DESCRIPTION
I was adding new functional tests for H2WS (https://github.com/microsoft/reverse-proxy/issues/1375) but found the structure of the TestEnvironment difficult to add additional properties to due to the complex constructors. I've re-factored it to use properties instead.