### PR TITLE
Added support for AspNetCore 7 rate limiting

### DIFF
--- a/docs/docfx/articles/rate-limiting.md
+++ b/docs/docfx/articles/rate-limiting.md
@@ -7,7 +7,12 @@ The reverse proxy can be used to rate-limit requests before they are proxied to 
 
 ## Defaults
 
-No rate limiting is performed on requests unless enabled in the route or application configuration.
+No rate limiting is performed on requests unless enabled in the route or application configuration. However, the Rate Limiting middleware (`app.UseRateLimiter()`) can apply a default limiter applied to all routes, and this doesn't require any opt-in from the config.
+
+Example:
+```
+builder.Services.AddRateLimiter(options => options.GlobalLimiter = globalLimiter);
+```
 
 ## Configuration
 Rate Limiter policies can be specified per route via [RouteConfig.RateLimiterPolicy](xref:Yarp.ReverseProxy.Configuration.RouteConfig) and can be bound from the `Routes` sections of the config file. As with other route properties, this can be modified and reloaded without restarting the proxy. Policy names are case insensitive.

--- a/docs/docfx/articles/rate-limiting.md
+++ b/docs/docfx/articles/rate-limiting.md
@@ -10,7 +10,7 @@ The reverse proxy can be used to rate-limit requests before they are proxied to 
 No rate limiting is performed on requests unless enabled in the route or application configuration. However, the Rate Limiting middleware (`app.UseRateLimiter()`) can apply a default limiter applied to all routes, and this doesn't require any opt-in from the config.
 
 Example:
-```
+```c#
 builder.Services.AddRateLimiter(options => options.GlobalLimiter = globalLimiter);
 ```
 
@@ -46,7 +46,7 @@ Example:
 [RateLimiter policies](https://learn.microsoft.com/aspnet/core/performance/rate-limit) are an ASP.NET Core concept that the proxy utilizes. The proxy provides the above configuration to specify a policy per route and the rest is handled by existing ASP.NET Core rate limiting middleware.
 
 RateLimiter policies can be configured in Startup.ConfigureServices as follows:
-```
+```c#
 public void ConfigureServices(IServiceCollection services)
 {
     services.AddRateLimiter(options =>
@@ -64,7 +64,7 @@ public void ConfigureServices(IServiceCollection services)
 
 In Startup.Configure add the RateLimiter middleware between Routing and Endpoints.
 
-```
+```c#
 public void Configure(IApplicationBuilder app)
 {
     app.UseRouting();

--- a/docs/docfx/articles/rate-limiting.md
+++ b/docs/docfx/articles/rate-limiting.md
@@ -1,0 +1,78 @@
+# Rate Limiting
+
+## Introduction
+The reverse proxy can be used to rate-limit requests before they are proxied to the destination servers. This can reduce load on the destination servers, add a layer of protection, and ensure consistent policies are implemented across your applications.
+
+## Defaults
+
+No rate limiting is performed on requests unless enabled in the route or application configuration.
+
+## Configuration
+Rate Limiter policies can be specified per route via [RouteConfig.RateLimiterPolicy](xref:Yarp.ReverseProxy.Configuration.RouteConfig) and can be bound from the `Routes` sections of the config file. As with other route properties, this can be modified and reloaded without restarting the proxy. Policy names are case insensitive.
+
+Example:
+```JSON
+{
+  "ReverseProxy": {
+    "Routes": {
+      "route1" : {
+        "ClusterId": "cluster1",
+        "RateLimiterPolicy": "customPolicy",
+        "Match": {
+          "Hosts": [ "localhost" ]
+        },
+      }
+    },
+    "Clusters": {
+      "cluster1": {
+        "Destinations": {
+          "cluster1/destination1": {
+            "Address": "https://localhost:10001/"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+[RateLimiter policies](https://learn.microsoft.com/en-us/aspnet/core/performance/rate-limit) are an ASP.NET Core concept that the proxy utilizes. The proxy provides the above configuration to specify a policy per route and the rest is handled by existing ASP.NET Core rate limiting middleware.
+
+RateLimiter policies can be configured in Startup.ConfigureServices as follows:
+```
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddRateLimiter(options =>
+    {
+        options.AddFixedWindowLimiter("customPolicy", opt =>
+        {
+            opt.PermitLimit = 4;
+            opt.Window = TimeSpan.FromSeconds(12);
+            opt.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
+            opt.QueueLimit = 2;
+        });
+    });
+}
+```
+
+In Startup.Configure add the RateLimiter middleware between Routing and Endpoints.
+
+```
+public void Configure(IApplicationBuilder app)
+{
+    app.UseRouting();
+
+    app.UseRateLimiter();
+
+    app.UseEndpoints(endpoints =>
+    {
+        endpoints.MapReverseProxy();
+    });
+}
+```
+
+See the [Rate Limiting](https://learn.microsoft.com/en-us/aspnet/core/performance/rate-limit) docs for setting up your preferred kind of rate limiting.
+
+### Disable CORS
+
+Specifying the value `disable` in a route's `RateLimiterPolicy` parameter means the rate limiter middleware will not rate limit requests.

--- a/docs/docfx/articles/rate-limiting.md
+++ b/docs/docfx/articles/rate-limiting.md
@@ -43,7 +43,7 @@ Example:
 }
 ```
 
-[RateLimiter policies](https://learn.microsoft.com//aspnet/core/performance/rate-limit) are an ASP.NET Core concept that the proxy utilizes. The proxy provides the above configuration to specify a policy per route and the rest is handled by existing ASP.NET Core rate limiting middleware.
+[RateLimiter policies](https://learn.microsoft.com/aspnet/core/performance/rate-limit) are an ASP.NET Core concept that the proxy utilizes. The proxy provides the above configuration to specify a policy per route and the rest is handled by existing ASP.NET Core rate limiting middleware.
 
 RateLimiter policies can be configured in Startup.ConfigureServices as follows:
 ```
@@ -78,7 +78,7 @@ public void Configure(IApplicationBuilder app)
 }
 ```
 
-See the [Rate Limiting](https://learn.microsoft.com//aspnet/core/performance/rate-limit) docs for setting up your preferred kind of rate limiting.
+See the [Rate Limiting](https://learn.microsoft.com/aspnet/core/performance/rate-limit) docs for setting up your preferred kind of rate limiting.
 
 ### Disable Rate Limiting
 

--- a/docs/docfx/articles/rate-limiting.md
+++ b/docs/docfx/articles/rate-limiting.md
@@ -82,4 +82,4 @@ See the [Rate Limiting](https://learn.microsoft.com/aspnet/core/performance/rate
 
 ### Disable Rate Limiting
 
-Specifying the value `disable` in a route's `RateLimiterPolicy` parameter means the rate limiter middleware will not  apply any policies to this route, even the default policy.
+Specifying the value `disable` in a route's `RateLimiterPolicy` parameter means the rate limiter middleware will not apply any policies to this route, even the default policy.

--- a/docs/docfx/articles/rate-limiting.md
+++ b/docs/docfx/articles/rate-limiting.md
@@ -3,6 +3,8 @@
 ## Introduction
 The reverse proxy can be used to rate-limit requests before they are proxied to the destination servers. This can reduce load on the destination servers, add a layer of protection, and ensure consistent policies are implemented across your applications.
 
+> This feature is only available when using .NET 7.0 or later
+
 ## Defaults
 
 No rate limiting is performed on requests unless enabled in the route or application configuration.
@@ -36,7 +38,7 @@ Example:
 }
 ```
 
-[RateLimiter policies](https://learn.microsoft.com/en-us/aspnet/core/performance/rate-limit) are an ASP.NET Core concept that the proxy utilizes. The proxy provides the above configuration to specify a policy per route and the rest is handled by existing ASP.NET Core rate limiting middleware.
+[RateLimiter policies](https://learn.microsoft.com//aspnet/core/performance/rate-limit) are an ASP.NET Core concept that the proxy utilizes. The proxy provides the above configuration to specify a policy per route and the rest is handled by existing ASP.NET Core rate limiting middleware.
 
 RateLimiter policies can be configured in Startup.ConfigureServices as follows:
 ```
@@ -71,8 +73,8 @@ public void Configure(IApplicationBuilder app)
 }
 ```
 
-See the [Rate Limiting](https://learn.microsoft.com/en-us/aspnet/core/performance/rate-limit) docs for setting up your preferred kind of rate limiting.
+See the [Rate Limiting](https://learn.microsoft.com//aspnet/core/performance/rate-limit) docs for setting up your preferred kind of rate limiting.
 
-### Disable CORS
+### Disable Rate Limiting
 
-Specifying the value `disable` in a route's `RateLimiterPolicy` parameter means the rate limiter middleware will not rate limit requests.
+Specifying the value `disable` in a route's `RateLimiterPolicy` parameter means the rate limiter middleware will not  apply any policies to this route, even the default policy.

--- a/docs/docfx/articles/toc.yml
+++ b/docs/docfx/articles/toc.yml
@@ -20,6 +20,8 @@
   href: header-routing.md
 - name: Authentication and Authorization
   href: authn-authz.md
+- name: Rate Limiting
+  href: rate-limiting.md
 - name: Cross-Origin Requests (CORS)
   href: cors.md
 - name: Session Affinity

--- a/samples/KubernetesIngress.Sample/README.md
+++ b/samples/KubernetesIngress.Sample/README.md
@@ -42,6 +42,7 @@ metadata:
   namespace: default
   annotations:
     yarp.ingress.kubernetes.io/authorization-policy: authzpolicy
+    yarp.ingress.kubernetes.io/rate-limiter-policy: ratelimiterpolicy
     yarp.ingress.kubernetes.io/transforms: |
       - PathRemovePrefix: "/apis"
     yarp.ingress.kubernetes.io/route-headers: |
@@ -73,6 +74,7 @@ The table below lists the available annotations.
 |Annotation|Data Type|
 |---|---|
 |yarp.ingress.kubernetes.io/authorization-policy|string|
+|yarp.ingress.kubernetes.io/rate-limiter-policy|string|
 |yarp.ingress.kubernetes.io/backend-protocol|string|
 |yarp.ingress.kubernetes.io/cors-policy|string|
 |yarp.ingress.kubernetes.io/health-check|[ActivateHealthCheckConfig](https://microsoft.github.io/reverse-proxy/api/Yarp.ReverseProxy.Configuration.ActiveHealthCheckConfig.html)|
@@ -89,6 +91,12 @@ The table below lists the available annotations.
 See https://microsoft.github.io/reverse-proxy/articles/authn-authz.html for a list of available policies, or how to add your own custom policies.
 
 `yarp.ingress.kubernetes.io/authorization-policy: anonymous`
+
+#### RateLimiter Policy
+
+See https://microsoft.github.io/reverse-proxy/articles/rate-limiting.html for a list of available policies, or how to add your own custom policies.
+
+`yarp.ingress.kubernetes.io/rate-limiter-policy: mypolicy`
 
 #### Backend Protocol
 

--- a/src/Kubernetes.Controller/Converters/YarpIngressOptions.cs
+++ b/src/Kubernetes.Controller/Converters/YarpIngressOptions.cs
@@ -11,6 +11,7 @@ internal sealed class YarpIngressOptions
     public bool Https { get; set; }
     public List<Dictionary<string, string>> Transforms { get; set; }
     public string AuthorizationPolicy { get; set; }
+    public string RateLimiterPolicy { get; set; }
     public SessionAffinityConfig SessionAffinity { get; set; }
     public HttpClientConfig HttpClientConfig { get; set; }
     public string LoadBalancingPolicy { get; set; }

--- a/src/Kubernetes.Controller/Converters/YarpIngressOptions.cs
+++ b/src/Kubernetes.Controller/Converters/YarpIngressOptions.cs
@@ -11,7 +11,9 @@ internal sealed class YarpIngressOptions
     public bool Https { get; set; }
     public List<Dictionary<string, string>> Transforms { get; set; }
     public string AuthorizationPolicy { get; set; }
+#if NET7_0_OR_GREATER
     public string RateLimiterPolicy { get; set; }
+#endif
     public SessionAffinityConfig SessionAffinity { get; set; }
     public HttpClientConfig HttpClientConfig { get; set; }
     public string LoadBalancingPolicy { get; set; }

--- a/src/Kubernetes.Controller/Converters/YarpParser.cs
+++ b/src/Kubernetes.Controller/Converters/YarpParser.cs
@@ -104,6 +104,7 @@ internal static class YarpParser
                     RouteId = $"{ingressContext.Ingress.Metadata.Name}.{ingressContext.Ingress.Metadata.NamespaceProperty}:{host}{path.Path}",
                     Transforms = ingressContext.Options.Transforms,
                     AuthorizationPolicy = ingressContext.Options.AuthorizationPolicy,
+                    RateLimiterPolicy = ingressContext.Options.RateLimiterPolicy,
                     CorsPolicy = ingressContext.Options.CorsPolicy,
                     Metadata = ingressContext.Options.RouteMetadata,
                     Order = ingressContext.Options.RouteOrder,
@@ -171,15 +172,19 @@ internal static class YarpParser
 
         if (annotations.TryGetValue("yarp.ingress.kubernetes.io/backend-protocol", out var http))
         {
-        	options.Https = http.Equals("https", StringComparison.OrdinalIgnoreCase);
+            options.Https = http.Equals("https", StringComparison.OrdinalIgnoreCase);
         }
         if (annotations.TryGetValue("yarp.ingress.kubernetes.io/transforms", out var transforms))
         {
-            options.Transforms = YamlDeserializer.Deserialize<List<Dictionary<string,string>>>(transforms);
+            options.Transforms = YamlDeserializer.Deserialize<List<Dictionary<string, string>>>(transforms);
         }
         if (annotations.TryGetValue("yarp.ingress.kubernetes.io/authorization-policy", out var authorizationPolicy))
         {
             options.AuthorizationPolicy = authorizationPolicy;
+        }
+        if (annotations.TryGetValue("yarp.ingress.kubernetes.io/rate-limiter-policy", out var rateLimiterPolicy))
+        {
+            options.RateLimiterPolicy = rateLimiterPolicy;
         }
         if (annotations.TryGetValue("yarp.ingress.kubernetes.io/cors-policy", out var corsPolicy))
         {

--- a/src/Kubernetes.Controller/Converters/YarpParser.cs
+++ b/src/Kubernetes.Controller/Converters/YarpParser.cs
@@ -104,7 +104,9 @@ internal static class YarpParser
                     RouteId = $"{ingressContext.Ingress.Metadata.Name}.{ingressContext.Ingress.Metadata.NamespaceProperty}:{host}{path.Path}",
                     Transforms = ingressContext.Options.Transforms,
                     AuthorizationPolicy = ingressContext.Options.AuthorizationPolicy,
+#if NET7_0_OR_GREATER
                     RateLimiterPolicy = ingressContext.Options.RateLimiterPolicy,
+#endif
                     CorsPolicy = ingressContext.Options.CorsPolicy,
                     Metadata = ingressContext.Options.RouteMetadata,
                     Order = ingressContext.Options.RouteOrder,
@@ -182,10 +184,12 @@ internal static class YarpParser
         {
             options.AuthorizationPolicy = authorizationPolicy;
         }
+#if NET7_0_OR_GREATER
         if (annotations.TryGetValue("yarp.ingress.kubernetes.io/rate-limiter-policy", out var rateLimiterPolicy))
         {
             options.RateLimiterPolicy = rateLimiterPolicy;
         }
+#endif
         if (annotations.TryGetValue("yarp.ingress.kubernetes.io/cors-policy", out var corsPolicy))
         {
             options.CorsPolicy = corsPolicy;

--- a/src/ReverseProxy/Configuration/ConfigProvider/ConfigurationConfigProvider.cs
+++ b/src/ReverseProxy/Configuration/ConfigProvider/ConfigurationConfigProvider.cs
@@ -147,7 +147,9 @@ internal sealed class ConfigurationConfigProvider : IProxyConfigProvider, IDispo
             MaxRequestBodySize = section.ReadInt64(nameof(RouteConfig.MaxRequestBodySize)),
             ClusterId = section[nameof(RouteConfig.ClusterId)],
             AuthorizationPolicy = section[nameof(RouteConfig.AuthorizationPolicy)],
+#if NET7_0_OR_GREATER
             RateLimiterPolicy = section[nameof(RouteConfig.RateLimiterPolicy)],
+#endif
             CorsPolicy = section[nameof(RouteConfig.CorsPolicy)],
             Metadata = section.GetSection(nameof(RouteConfig.Metadata)).ReadStringDictionary(),
             Transforms = CreateTransforms(section.GetSection(nameof(RouteConfig.Transforms))),

--- a/src/ReverseProxy/Configuration/ConfigProvider/ConfigurationConfigProvider.cs
+++ b/src/ReverseProxy/Configuration/ConfigProvider/ConfigurationConfigProvider.cs
@@ -147,6 +147,7 @@ internal sealed class ConfigurationConfigProvider : IProxyConfigProvider, IDispo
             MaxRequestBodySize = section.ReadInt64(nameof(RouteConfig.MaxRequestBodySize)),
             ClusterId = section[nameof(RouteConfig.ClusterId)],
             AuthorizationPolicy = section[nameof(RouteConfig.AuthorizationPolicy)],
+            RateLimiterPolicy = section[nameof(RouteConfig.RateLimiterPolicy)],
             CorsPolicy = section[nameof(RouteConfig.CorsPolicy)],
             Metadata = section.GetSection(nameof(RouteConfig.Metadata)).ReadStringDictionary(),
             Transforms = CreateTransforms(section.GetSection(nameof(RouteConfig.Transforms))),

--- a/src/ReverseProxy/Configuration/ConfigValidator.cs
+++ b/src/ReverseProxy/Configuration/ConfigValidator.cs
@@ -72,6 +72,7 @@ internal sealed class ConfigValidator : IConfigValidator
 
         errors.AddRange(_transformBuilder.ValidateRoute(route));
         await ValidateAuthorizationPolicyAsync(errors, route.AuthorizationPolicy, route.RouteId);
+        await ValidateRateLimiterPolicyAsync(errors, route.RateLimiterPolicy, route.RouteId);
         await ValidateCorsPolicyAsync(errors, route.CorsPolicy, route.RouteId);
 
         if (route.Match is null)
@@ -285,6 +286,47 @@ internal sealed class ConfigValidator : IConfigValidator
         {
             errors.Add(new ArgumentException($"Unable to retrieve the authorization policy '{authorizationPolicyName}' for route '{routeId}'.", ex));
         }
+    }
+
+    private ValueTask ValidateRateLimiterPolicyAsync(IList<Exception> errors, string? rateLimiterPolicyName, string routeId)
+    {
+        if (string.IsNullOrEmpty(rateLimiterPolicyName))
+        {
+            //return;
+            return ValueTask.CompletedTask;
+        }
+
+        // TODO: update this once AspNetCore provides a mechanism to validate the RateLimiter policies (maybe .NET8?)
+
+        if (string.Equals(RateLimitingConstants.Disable, rateLimiterPolicyName, StringComparison.OrdinalIgnoreCase))
+        {
+#if NET7_0_OR_GREATER
+            //var policy = await _rateLimiterPolicyProvider.GetPolicyAsync(rateLimiterPolicyName);
+            //if (policy is not null)
+            //{
+            //    errors.Add(new ArgumentException($"The application has registered a RateLimiter policy named '{rateLimiterPolicyName}' that conflicts with the reserved RateLimiter policy name used on this route. The registered policy name needs to be changed for this route to function."));
+            //}
+#endif
+            //return;
+            return ValueTask.CompletedTask;
+        }
+
+        try
+        {
+#if NET7_0_OR_GREATER
+            //var policy = await _rateLimiterPolicyProvider.GetPolicyAsync(rateLimiterPolicyName);
+            //if (policy is null)
+            //{
+            //    errors.Add(new ArgumentException($"RateLimiter policy '{rateLimiterPolicyName}' not found for route '{routeId}'."));
+            //}
+#endif
+        }
+        catch (Exception ex)
+        {
+            errors.Add(new ArgumentException($"Unable to retrieve the RateLimiter policy '{rateLimiterPolicyName}' for route '{routeId}'.", ex));
+        }
+
+        return ValueTask.CompletedTask;
     }
 
     private async ValueTask ValidateCorsPolicyAsync(IList<Exception> errors, string? corsPolicyName, string routeId)

--- a/src/ReverseProxy/Configuration/ConfigValidator.cs
+++ b/src/ReverseProxy/Configuration/ConfigValidator.cs
@@ -298,6 +298,19 @@ internal sealed class ConfigValidator : IConfigValidator
 
         // TODO: update this once AspNetCore provides a mechanism to validate the RateLimiter policies (maybe .NET8?)
 
+        if (string.Equals(RateLimitingConstants.Default, rateLimiterPolicyName, StringComparison.OrdinalIgnoreCase))
+        {
+#if NET7_0_OR_GREATER
+            //var policy = await _rateLimiterPolicyProvider.GetPolicyAsync(rateLimiterPolicyName);
+            //if (policy is not null)
+            //{
+            //    errors.Add(new ArgumentException($"The application has registered a RateLimiter policy named '{rateLimiterPolicyName}' that conflicts with the reserved RateLimiter policy name used on this route. The registered policy name needs to be changed for this route to function."));
+            //}
+#endif
+            //return;
+            return ValueTask.CompletedTask;
+        }
+
         if (string.Equals(RateLimitingConstants.Disable, rateLimiterPolicyName, StringComparison.OrdinalIgnoreCase))
         {
 #if NET7_0_OR_GREATER

--- a/src/ReverseProxy/Configuration/ConfigValidator.cs
+++ b/src/ReverseProxy/Configuration/ConfigValidator.cs
@@ -296,7 +296,7 @@ internal sealed class ConfigValidator : IConfigValidator
             return ValueTask.CompletedTask;
         }
 
-        // TODO: update this once AspNetCore provides a mechanism to validate the RateLimiter policies (maybe .NET8?)
+        // TODO: update this once AspNetCore provides a mechanism to validate the RateLimiter policies https://github.com/dotnet/aspnetcore/issues/45684
 
         if (string.Equals(RateLimitingConstants.Default, rateLimiterPolicyName, StringComparison.OrdinalIgnoreCase))
         {

--- a/src/ReverseProxy/Configuration/IYarpRateLimiterPolicyProvider.cs
+++ b/src/ReverseProxy/Configuration/IYarpRateLimiterPolicyProvider.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+#if NET7_0_OR_GREATER
+using Microsoft.AspNetCore.RateLimiting;
+#endif
+using Microsoft.Extensions.Options;
+
+namespace Yarp.ReverseProxy.Configuration;
+
+// TODO: update this once AspNetCore provides a mechanism to validate the RateLimiter policies https://github.com/dotnet/aspnetcore/issues/45684
+
+#if NET7_0_OR_GREATER
+
+internal interface IYarpRateLimiterPolicyProvider
+{
+    ValueTask<object?> GetPolicyAsync(string policyName);
+}
+
+internal class YarpRateLimiterPolicyProvider : IYarpRateLimiterPolicyProvider
+{
+    private readonly RateLimiterOptions _rateLimiterOptions;
+
+    private readonly System.Collections.IDictionary _policyMap, _unactivatedPolicyMap;
+
+    public YarpRateLimiterPolicyProvider(IOptions<RateLimiterOptions> rateLimiterOptions)
+    {
+        _rateLimiterOptions = rateLimiterOptions?.Value ?? throw new ArgumentNullException(nameof(rateLimiterOptions));
+
+        var type = typeof(RateLimiterOptions);
+        var flags = BindingFlags.Instance | BindingFlags.NonPublic;
+        _policyMap = (System.Collections.IDictionary)type.GetProperty("PolicyMap", flags)!.GetValue(_rateLimiterOptions, null)!;
+        _unactivatedPolicyMap = (System.Collections.IDictionary)type.GetProperty("UnactivatedPolicyMap", flags)!.GetValue(_rateLimiterOptions, null)!;
+    }
+
+    public ValueTask<object?> GetPolicyAsync(string policyName)
+    {
+        return ValueTask.FromResult(_policyMap[policyName] ?? _unactivatedPolicyMap[policyName]);
+    }
+}
+#endif

--- a/src/ReverseProxy/Configuration/RateLimitingConstants.cs
+++ b/src/ReverseProxy/Configuration/RateLimitingConstants.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Yarp.ReverseProxy.Configuration;
+
+internal static class RateLimitingConstants
+{
+    internal const string Disable = "Disable";
+}

--- a/src/ReverseProxy/Configuration/RateLimitingConstants.cs
+++ b/src/ReverseProxy/Configuration/RateLimitingConstants.cs
@@ -5,5 +5,6 @@ namespace Yarp.ReverseProxy.Configuration;
 
 internal static class RateLimitingConstants
 {
+    internal const string Default = "Default";
     internal const string Disable = "Disable";
 }

--- a/src/ReverseProxy/Configuration/RouteConfig.cs
+++ b/src/ReverseProxy/Configuration/RouteConfig.cs
@@ -45,6 +45,13 @@ public sealed record RouteConfig
     public string? AuthorizationPolicy { get; init; }
 
     /// <summary>
+    /// The name of the RateLimiterPolicy to apply to this route.
+    /// If not set then only the GlobalLimiter will apply.
+    /// Set to "Disable" to disable rate limiting for this route.
+    /// </summary>
+    public string? RateLimiterPolicy { get; init; }
+
+    /// <summary>
     /// The name of the CorsPolicy to apply to this route.
     /// If not set then the route won't be automatically matched for cors preflight requests.
     /// Set to "Default" to enable cors with the default policy.
@@ -79,6 +86,7 @@ public sealed record RouteConfig
             && string.Equals(RouteId, other.RouteId, StringComparison.OrdinalIgnoreCase)
             && string.Equals(ClusterId, other.ClusterId, StringComparison.OrdinalIgnoreCase)
             && string.Equals(AuthorizationPolicy, other.AuthorizationPolicy, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(RateLimiterPolicy, other.RateLimiterPolicy, StringComparison.OrdinalIgnoreCase)
             && string.Equals(CorsPolicy, other.CorsPolicy, StringComparison.OrdinalIgnoreCase)
             && Match == other.Match
             && CaseSensitiveEqualHelper.Equals(Metadata, other.Metadata)
@@ -87,13 +95,17 @@ public sealed record RouteConfig
 
     public override int GetHashCode()
     {
-        return HashCode.Combine(Order,
-            RouteId?.GetHashCode(StringComparison.OrdinalIgnoreCase),
-            ClusterId?.GetHashCode(StringComparison.OrdinalIgnoreCase),
-            AuthorizationPolicy?.GetHashCode(StringComparison.OrdinalIgnoreCase),
-            CorsPolicy?.GetHashCode(StringComparison.OrdinalIgnoreCase),
-            Match,
-            CaseSensitiveEqualHelper.GetHashCode(Metadata),
-            CaseSensitiveEqualHelper.GetHashCode(Transforms));
+        // HashCode.Combine(...) takes only 8 arguments
+        var hash = new HashCode();
+        hash.Add(Order);
+        hash.Add(RouteId?.GetHashCode(StringComparison.OrdinalIgnoreCase));
+        hash.Add(ClusterId?.GetHashCode(StringComparison.OrdinalIgnoreCase));
+        hash.Add(AuthorizationPolicy?.GetHashCode(StringComparison.OrdinalIgnoreCase));
+        hash.Add(RateLimiterPolicy?.GetHashCode(StringComparison.OrdinalIgnoreCase));
+        hash.Add(CorsPolicy?.GetHashCode(StringComparison.OrdinalIgnoreCase));
+        hash.Add(Match);
+        hash.Add(CaseSensitiveEqualHelper.GetHashCode(Metadata));
+        hash.Add(CaseSensitiveEqualHelper.GetHashCode(Transforms));
+        return hash.ToHashCode();
     }
 }

--- a/src/ReverseProxy/Configuration/RouteConfig.cs
+++ b/src/ReverseProxy/Configuration/RouteConfig.cs
@@ -43,15 +43,15 @@ public sealed record RouteConfig
     /// Set to "Anonymous" to disable all authorization checks for this route.
     /// </summary>
     public string? AuthorizationPolicy { get; init; }
-
+#if NET7_0_OR_GREATER
     /// <summary>
     /// The name of the RateLimiterPolicy to apply to this route.
     /// If not set then only the GlobalLimiter will apply.
     /// Set to "Disable" to disable rate limiting for this route.
-    /// Set to "Default" or leave empty use the global rate limits, if any.
+    /// Set to "Default" or leave empty to use the global rate limits, if any.
     /// </summary>
     public string? RateLimiterPolicy { get; init; }
-
+#endif
     /// <summary>
     /// The name of the CorsPolicy to apply to this route.
     /// If not set then the route won't be automatically matched for cors preflight requests.
@@ -87,7 +87,9 @@ public sealed record RouteConfig
             && string.Equals(RouteId, other.RouteId, StringComparison.OrdinalIgnoreCase)
             && string.Equals(ClusterId, other.ClusterId, StringComparison.OrdinalIgnoreCase)
             && string.Equals(AuthorizationPolicy, other.AuthorizationPolicy, StringComparison.OrdinalIgnoreCase)
+#if NET7_0_OR_GREATER
             && string.Equals(RateLimiterPolicy, other.RateLimiterPolicy, StringComparison.OrdinalIgnoreCase)
+#endif
             && string.Equals(CorsPolicy, other.CorsPolicy, StringComparison.OrdinalIgnoreCase)
             && Match == other.Match
             && CaseSensitiveEqualHelper.Equals(Metadata, other.Metadata)
@@ -102,7 +104,9 @@ public sealed record RouteConfig
         hash.Add(RouteId?.GetHashCode(StringComparison.OrdinalIgnoreCase));
         hash.Add(ClusterId?.GetHashCode(StringComparison.OrdinalIgnoreCase));
         hash.Add(AuthorizationPolicy?.GetHashCode(StringComparison.OrdinalIgnoreCase));
+#if NET7_0_OR_GREATER
         hash.Add(RateLimiterPolicy?.GetHashCode(StringComparison.OrdinalIgnoreCase));
+#endif
         hash.Add(CorsPolicy?.GetHashCode(StringComparison.OrdinalIgnoreCase));
         hash.Add(Match);
         hash.Add(CaseSensitiveEqualHelper.GetHashCode(Metadata));

--- a/src/ReverseProxy/Configuration/RouteConfig.cs
+++ b/src/ReverseProxy/Configuration/RouteConfig.cs
@@ -48,6 +48,7 @@ public sealed record RouteConfig
     /// The name of the RateLimiterPolicy to apply to this route.
     /// If not set then only the GlobalLimiter will apply.
     /// Set to "Disable" to disable rate limiting for this route.
+    /// Set to "Default" or leave empty use the global rate limits, if any.
     /// </summary>
     public string? RateLimiterPolicy { get; init; }
 

--- a/src/ReverseProxy/Management/IReverseProxyBuilderExtensions.cs
+++ b/src/ReverseProxy/Management/IReverseProxyBuilderExtensions.cs
@@ -22,6 +22,9 @@ internal static class IReverseProxyBuilderExtensions
 {
     public static IReverseProxyBuilder AddConfigBuilder(this IReverseProxyBuilder builder)
     {
+#if NET7_0_OR_GREATER
+        builder.Services.TryAddSingleton<IYarpRateLimiterPolicyProvider, YarpRateLimiterPolicyProvider>();
+#endif
         builder.Services.TryAddSingleton<IConfigValidator, ConfigValidator>();
         builder.Services.TryAddSingleton<IRandomFactory, RandomFactory>();
         builder.AddTransformFactory<ForwardedTransformFactory>();

--- a/src/ReverseProxy/Management/IReverseProxyBuilderExtensions.cs
+++ b/src/ReverseProxy/Management/IReverseProxyBuilderExtensions.cs
@@ -22,9 +22,7 @@ internal static class IReverseProxyBuilderExtensions
 {
     public static IReverseProxyBuilder AddConfigBuilder(this IReverseProxyBuilder builder)
     {
-#if NET7_0_OR_GREATER
         builder.Services.TryAddSingleton<IYarpRateLimiterPolicyProvider, YarpRateLimiterPolicyProvider>();
-#endif
         builder.Services.TryAddSingleton<IConfigValidator, ConfigValidator>();
         builder.Services.TryAddSingleton<IRandomFactory, RandomFactory>();
         builder.AddTransformFactory<ForwardedTransformFactory>();

--- a/src/ReverseProxy/Routing/ProxyEndpointFactory.cs
+++ b/src/ReverseProxy/Routing/ProxyEndpointFactory.cs
@@ -9,17 +9,24 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.AspNetCore.Http;
+#if NET7_0_OR_GREATER
+using Microsoft.AspNetCore.RateLimiting;
+#endif
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Yarp.ReverseProxy.Model;
 using CorsConstants = Yarp.ReverseProxy.Configuration.CorsConstants;
 using AuthorizationConstants = Yarp.ReverseProxy.Configuration.AuthorizationConstants;
+using RateLimitingConstants = Yarp.ReverseProxy.Configuration.RateLimitingConstants;
 
 namespace Yarp.ReverseProxy.Routing;
 
 internal sealed class ProxyEndpointFactory
 {
     private static readonly IAuthorizeData _defaultAuthorization = new AuthorizeAttribute();
+#if NET7_0_OR_GREATER
+    private static readonly DisableRateLimitingAttribute _disableRateLimit = new DisableRateLimitingAttribute();
+#endif
     private static readonly IEnableCorsAttribute _defaultCors = new EnableCorsAttribute();
     private static readonly IDisableCorsAttribute _disableCors = new DisableCorsAttribute();
     private static readonly IAllowAnonymous _allowAnonymous = new AllowAnonymousAttribute();
@@ -109,6 +116,17 @@ internal sealed class ProxyEndpointFactory
         {
             endpointBuilder.Metadata.Add(new AuthorizeAttribute(config.AuthorizationPolicy));
         }
+
+#if NET7_0_OR_GREATER
+        if (string.Equals(RateLimitingConstants.Disable, config.RateLimiterPolicy, StringComparison.OrdinalIgnoreCase))
+        {
+            endpointBuilder.Metadata.Add(_disableRateLimit);
+        }
+        else if (!string.IsNullOrEmpty(config.RateLimiterPolicy))
+        {
+            endpointBuilder.Metadata.Add(new EnableRateLimitingAttribute(config.RateLimiterPolicy));
+        }
+#endif
 
         for (var i = 0; i < conventions.Count; i++)
         {

--- a/src/ReverseProxy/Routing/ProxyEndpointFactory.cs
+++ b/src/ReverseProxy/Routing/ProxyEndpointFactory.cs
@@ -25,7 +25,7 @@ internal sealed class ProxyEndpointFactory
 {
     private static readonly IAuthorizeData _defaultAuthorization = new AuthorizeAttribute();
 #if NET7_0_OR_GREATER
-    private static readonly DisableRateLimitingAttribute _disableRateLimit = new DisableRateLimitingAttribute();
+    private static readonly DisableRateLimitingAttribute _disableRateLimit = new();
 #endif
     private static readonly IEnableCorsAttribute _defaultCors = new EnableCorsAttribute();
     private static readonly IDisableCorsAttribute _disableCors = new DisableCorsAttribute();
@@ -118,7 +118,11 @@ internal sealed class ProxyEndpointFactory
         }
 
 #if NET7_0_OR_GREATER
-        if (string.Equals(RateLimitingConstants.Disable, config.RateLimiterPolicy, StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(RateLimitingConstants.Default, config.RateLimiterPolicy, StringComparison.OrdinalIgnoreCase))
+        {
+            // No-op (middleware applies the default)
+        }
+        else if (string.Equals(RateLimitingConstants.Disable, config.RateLimiterPolicy, StringComparison.OrdinalIgnoreCase))
         {
             endpointBuilder.Metadata.Add(_disableRateLimit);
         }

--- a/test/Kubernetes.Tests/IngressConversionTests.cs
+++ b/test/Kubernetes.Tests/IngressConversionTests.cs
@@ -81,7 +81,12 @@ public class IngressConversionTests
 
     private static void VerifyRoutes(string routesJson, string name)
     {
+#if NET7_0_OR_GREATER
         VerifyJson(routesJson, name, "routes.json");
+#else
+        VerifyJson(routesJson, name,
+            string.Equals("annotations", name, StringComparison.OrdinalIgnoreCase) ? "routes.net6.json" : "routes.json");
+#endif
     }
 
     private static string StripNullProperties(string json)

--- a/test/Kubernetes.Tests/testassets/annotations/ingress.yaml
+++ b/test/Kubernetes.Tests/testassets/annotations/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: default
   annotations:
     yarp.ingress.kubernetes.io/authorization-policy: authzpolicy
+    yarp.ingress.kubernetes.io/rate-limiter-policy: ratelimiterpolicy
     yarp.ingress.kubernetes.io/cors-policy: corspolicy
     yarp.ingress.kubernetes.io/load-balancing: Random
     yarp.ingress.kubernetes.io/health-check: |

--- a/test/Kubernetes.Tests/testassets/annotations/routes.json
+++ b/test/Kubernetes.Tests/testassets/annotations/routes.json
@@ -10,6 +10,7 @@
     "Order": null,
     "ClusterId": "frontend.default:80",
     "AuthorizationPolicy": "authzpolicy",
+    "RateLimiterPolicy": "ratelimiterpolicy",
     "CorsPolicy": "corspolicy",
     "Metadata": null,
     "Transforms": [

--- a/test/Kubernetes.Tests/testassets/annotations/routes.net6.json
+++ b/test/Kubernetes.Tests/testassets/annotations/routes.net6.json
@@ -1,0 +1,23 @@
+[
+  {
+    "RouteId": "minimal-ingress.default:/foo",
+    "Match": {
+      "Methods": null,
+      "Hosts": [],
+      "Path": "/foo/{**catch-all}",
+      "Headers": null
+    },
+    "Order": null,
+    "ClusterId": "frontend.default:80",
+    "AuthorizationPolicy": "authzpolicy",
+    "CorsPolicy": "corspolicy",
+    "Metadata": null,
+    "Transforms": [
+      { "PathPrefix": "/apis" },
+      {
+        "RequestHeader": "header1",
+        "Append": "bar"
+      }
+    ]
+  }
+]

--- a/test/Kubernetes.Tests/testassets/basic-ingress/routes.json
+++ b/test/Kubernetes.Tests/testassets/basic-ingress/routes.json
@@ -11,6 +11,7 @@
     "Order": null,
     "ClusterId": "frontend.default:80",
     "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
     "CorsPolicy": null,
     "Metadata": null,
     "Transforms": null

--- a/test/Kubernetes.Tests/testassets/exact-match/routes.json
+++ b/test/Kubernetes.Tests/testassets/exact-match/routes.json
@@ -11,6 +11,7 @@
     "Order": null,
     "ClusterId": "frontend.default:80",
     "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
     "CorsPolicy": null,
     "Metadata": null,
     "Transforms": null

--- a/test/Kubernetes.Tests/testassets/hostname-routing/routes.json
+++ b/test/Kubernetes.Tests/testassets/hostname-routing/routes.json
@@ -11,6 +11,7 @@
     "Order": null,
     "ClusterId": "frontend.foo:80",
     "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
     "CorsPolicy": null,
     "Metadata": null,
     "Transforms": null

--- a/test/Kubernetes.Tests/testassets/https/routes.json
+++ b/test/Kubernetes.Tests/testassets/https/routes.json
@@ -11,6 +11,7 @@
     "Order": null,
     "ClusterId": "frontend.default:443",
     "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
     "CorsPolicy": null,
     "Metadata": null,
     "Transforms": null

--- a/test/Kubernetes.Tests/testassets/mapped-port/routes.json
+++ b/test/Kubernetes.Tests/testassets/mapped-port/routes.json
@@ -11,6 +11,7 @@
     "Order": null,
     "ClusterId": "backend.default:5011",
     "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
     "CorsPolicy": null,
     "Metadata": null,
     "Transforms": null

--- a/test/Kubernetes.Tests/testassets/multiple-endpoints-ports/routes.json
+++ b/test/Kubernetes.Tests/testassets/multiple-endpoints-ports/routes.json
@@ -11,6 +11,7 @@
     "Order": null,
     "ClusterId": "frontend.default:80",
     "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
     "CorsPolicy": null,
     "Metadata": null,
     "Transforms": null

--- a/test/Kubernetes.Tests/testassets/multiple-hosts/routes.json
+++ b/test/Kubernetes.Tests/testassets/multiple-hosts/routes.json
@@ -11,6 +11,7 @@
     "Order": null,
     "ClusterId": "repro-1-service.foo:http",
     "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
     "CorsPolicy": null,
     "Metadata": null,
     "Transforms": null
@@ -27,6 +28,7 @@
     "Order": null,
     "ClusterId": "repro-2-service.foo:http",
     "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
     "CorsPolicy": null,
     "Metadata": null,
     "Transforms": null
@@ -43,6 +45,7 @@
     "Order": null,
     "ClusterId": "repro-3-service.foo:http",
     "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
     "CorsPolicy": null,
     "Metadata": null,
     "Transforms": null

--- a/test/Kubernetes.Tests/testassets/multiple-ingresses-one-svc/routes.json
+++ b/test/Kubernetes.Tests/testassets/multiple-ingresses-one-svc/routes.json
@@ -11,6 +11,7 @@
     "Order": null,
     "ClusterId": "repro-service.foo:http",
     "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
     "CorsPolicy": null,
     "Metadata": null,
     "Transforms": null
@@ -27,6 +28,7 @@
     "Order": null,
     "ClusterId": "repro-service.foo:http",
     "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
     "CorsPolicy": null,
     "Metadata": null,
     "Transforms": null

--- a/test/Kubernetes.Tests/testassets/multiple-ingresses/routes.json
+++ b/test/Kubernetes.Tests/testassets/multiple-ingresses/routes.json
@@ -11,6 +11,7 @@
     "Order": null,
     "ClusterId": "repro-1-service.foo:http",
     "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
     "CorsPolicy": null,
     "Metadata": null,
     "Transforms": null
@@ -27,6 +28,7 @@
     "Order": null,
     "ClusterId": "repro-2-service.foo:http",
     "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
     "CorsPolicy": null,
     "Metadata": null,
     "Transforms": null

--- a/test/Kubernetes.Tests/testassets/multiple-namespaces/routes.json
+++ b/test/Kubernetes.Tests/testassets/multiple-namespaces/routes.json
@@ -11,6 +11,7 @@
     "Order": null,
     "ClusterId": "the-service.ns-one:http",
     "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
     "CorsPolicy": null,
     "Metadata": null,
     "Transforms": null
@@ -27,6 +28,7 @@
     "Order": null,
     "ClusterId": "the-service.ns-two:http",
     "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
     "CorsPolicy": null,
     "Metadata": null,
     "Transforms": null

--- a/test/Kubernetes.Tests/testassets/route-headers/routes.json
+++ b/test/Kubernetes.Tests/testassets/route-headers/routes.json
@@ -18,6 +18,7 @@
     "Order": null,
     "ClusterId": "frontend.default:80",
     "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
     "CorsPolicy": null,
     "Metadata": {
       "foo": "bar",

--- a/test/Kubernetes.Tests/testassets/route-metadata/routes.json
+++ b/test/Kubernetes.Tests/testassets/route-metadata/routes.json
@@ -11,6 +11,7 @@
     "Order": null,
     "ClusterId": "frontend.default:80",
     "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
     "CorsPolicy": null,
     "Metadata": {
       "foo": "bar",

--- a/test/Kubernetes.Tests/testassets/route-order/routes.json
+++ b/test/Kubernetes.Tests/testassets/route-order/routes.json
@@ -11,6 +11,7 @@
     "Order": 10,
     "ClusterId": "frontend.default:80",
     "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
     "CorsPolicy": null,
     "Metadata": null,
     "Transforms": null

--- a/test/ReverseProxy.Tests/Configuration/ConfigProvider/ConfigurationConfigProviderTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigProvider/ConfigurationConfigProviderTests.cs
@@ -127,7 +127,7 @@ public class ConfigurationConfigProviderTests
                 RouteId = "routeA",
                 ClusterId = "cluster1",
                 AuthorizationPolicy = "Default",
-                RateLimiterPolicy = "mypolicy",
+                RateLimiterPolicy = "Default",
                 CorsPolicy = "Default",
                 Order = -1,
                 MaxRequestBodySize = -1,
@@ -333,7 +333,7 @@ public class ConfigurationConfigProviderTests
             ""MaxRequestBodySize"": -1,
             ""ClusterId"": ""cluster1"",
             ""AuthorizationPolicy"": ""Default"",
-            ""RateLimiterPolicy"": ""mypolicy"",
+            ""RateLimiterPolicy"": ""Default"",
             ""CorsPolicy"": ""Default"",
             ""Metadata"": {
                 ""routeA-K1"": ""routeA-V1"",

--- a/test/ReverseProxy.Tests/Configuration/ConfigProvider/ConfigurationConfigProviderTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigProvider/ConfigurationConfigProviderTests.cs
@@ -127,7 +127,9 @@ public class ConfigurationConfigProviderTests
                 RouteId = "routeA",
                 ClusterId = "cluster1",
                 AuthorizationPolicy = "Default",
+#if NET7_0_OR_GREATER
                 RateLimiterPolicy = "Default",
+#endif
                 CorsPolicy = "Default",
                 Order = -1,
                 MaxRequestBodySize = -1,

--- a/test/ReverseProxy.Tests/Configuration/ConfigProvider/ConfigurationConfigProviderTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigProvider/ConfigurationConfigProviderTests.cs
@@ -127,6 +127,7 @@ public class ConfigurationConfigProviderTests
                 RouteId = "routeA",
                 ClusterId = "cluster1",
                 AuthorizationPolicy = "Default",
+                RateLimiterPolicy = "mypolicy",
                 CorsPolicy = "Default",
                 Order = -1,
                 MaxRequestBodySize = -1,
@@ -332,6 +333,7 @@ public class ConfigurationConfigProviderTests
             ""MaxRequestBodySize"": -1,
             ""ClusterId"": ""cluster1"",
             ""AuthorizationPolicy"": ""Default"",
+            ""RateLimiterPolicy"": ""mypolicy"",
             ""CorsPolicy"": ""Default"",
             ""Metadata"": {
                 ""routeA-K1"": ""routeA-V1"",
@@ -375,6 +377,7 @@ public class ConfigurationConfigProviderTests
             ""MaxRequestBodySize"": 1,
             ""ClusterId"": ""cluster2"",
             ""AuthorizationPolicy"": null,
+            ""RateLimiterPolicy"": null,
             ""CorsPolicy"": null,
             ""Metadata"": null,
             ""Transforms"": null

--- a/test/ReverseProxy.Tests/Configuration/RouteConfigTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/RouteConfigTests.cs
@@ -15,7 +15,9 @@ public class RouteConfigTests
         var a = new RouteConfig()
         {
             AuthorizationPolicy = "a",
+#if NET7_0_OR_GREATER
             RateLimiterPolicy = "rl",
+#endif
             ClusterId = "c",
             CorsPolicy = "co",
             Match = new RouteMatch()
@@ -44,7 +46,9 @@ public class RouteConfigTests
         var b = new RouteConfig()
         {
             AuthorizationPolicy = "A",
+#if NET7_0_OR_GREATER
             RateLimiterPolicy = "RL",
+#endif
             ClusterId = "C",
             CorsPolicy = "Co",
             Match = new RouteMatch()
@@ -84,7 +88,9 @@ public class RouteConfigTests
         var a = new RouteConfig()
         {
             AuthorizationPolicy = "a",
+#if NET7_0_OR_GREATER
             RateLimiterPolicy = "rl",
+#endif
             ClusterId = "c",
             CorsPolicy = "co",
             Match = new RouteMatch()
@@ -117,7 +123,9 @@ public class RouteConfigTests
         var f = a with { Metadata = new Dictionary<string, string>() { { "f", "f1" } } };
         var g = a with { Order = null };
         var h = a with { RouteId = "h" };
+#if NET7_0_OR_GREATER
         var i = a with { RateLimiterPolicy = "i" };
+#endif
 
         Assert.False(a.Equals(b));
         Assert.False(a.Equals(c));
@@ -126,7 +134,9 @@ public class RouteConfigTests
         Assert.False(a.Equals(f));
         Assert.False(a.Equals(g));
         Assert.False(a.Equals(h));
+#if NET7_0_OR_GREATER
         Assert.False(a.Equals(i));
+#endif
     }
 
     [Fact]
@@ -141,7 +151,9 @@ public class RouteConfigTests
         var route1 = new RouteConfig()
         {
             AuthorizationPolicy = "a",
+#if NET7_0_OR_GREATER
             RateLimiterPolicy = "rl",
+#endif
             ClusterId = "c",
             CorsPolicy = "co",
             Match = new RouteMatch()

--- a/test/ReverseProxy.Tests/Configuration/RouteConfigTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/RouteConfigTests.cs
@@ -15,6 +15,7 @@ public class RouteConfigTests
         var a = new RouteConfig()
         {
             AuthorizationPolicy = "a",
+            RateLimiterPolicy = "rl",
             ClusterId = "c",
             CorsPolicy = "co",
             Match = new RouteMatch()
@@ -43,6 +44,7 @@ public class RouteConfigTests
         var b = new RouteConfig()
         {
             AuthorizationPolicy = "A",
+            RateLimiterPolicy = "RL",
             ClusterId = "C",
             CorsPolicy = "Co",
             Match = new RouteMatch()
@@ -82,6 +84,7 @@ public class RouteConfigTests
         var a = new RouteConfig()
         {
             AuthorizationPolicy = "a",
+            RateLimiterPolicy = "rl",
             ClusterId = "c",
             CorsPolicy = "co",
             Match = new RouteMatch()
@@ -114,6 +117,7 @@ public class RouteConfigTests
         var f = a with { Metadata = new Dictionary<string, string>() { { "f", "f1" } } };
         var g = a with { Order = null };
         var h = a with { RouteId = "h" };
+        var i = a with { RateLimiterPolicy = "i" };
 
         Assert.False(a.Equals(b));
         Assert.False(a.Equals(c));
@@ -122,6 +126,7 @@ public class RouteConfigTests
         Assert.False(a.Equals(f));
         Assert.False(a.Equals(g));
         Assert.False(a.Equals(h));
+        Assert.False(a.Equals(i));
     }
 
     [Fact]
@@ -136,6 +141,7 @@ public class RouteConfigTests
         var route1 = new RouteConfig()
         {
             AuthorizationPolicy = "a",
+            RateLimiterPolicy = "rl",
             ClusterId = "c",
             CorsPolicy = "co",
             Match = new RouteMatch()

--- a/test/ReverseProxy.Tests/Configuration/YarpRateLimiterPolicyProviderTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/YarpRateLimiterPolicyProviderTests.cs
@@ -1,12 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if NET7_0_OR_GREATER
 using System;
 using System.Threading.Tasks;
-#if NET7_0_OR_GREATER
 using System.Threading.RateLimiting;
-#endif
 using Microsoft.AspNetCore.Builder;
-#if NET7_0_OR_GREATER
 using Microsoft.AspNetCore.RateLimiting;
-#endif
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -14,7 +14,6 @@ namespace Yarp.ReverseProxy.Configuration;
 
 public class YarpRateLimiterPolicyProviderTests
 {
-#if NET7_0_OR_GREATER
     [Fact]
     public async Task GetPolicyAsync_Works()
     {
@@ -37,5 +36,5 @@ public class YarpRateLimiterPolicyProviderTests
         Assert.Null(await rateLimiterPolicyProvider.GetPolicyAsync("anotherPolicy"));
         Assert.NotNull(await rateLimiterPolicyProvider.GetPolicyAsync("customPolicy"));
     }
-#endif
 }
+#endif

--- a/test/ReverseProxy.Tests/Configuration/YarpRateLimiterPolicyProviderTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/YarpRateLimiterPolicyProviderTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading.Tasks;
+#if NET7_0_OR_GREATER
+using System.Threading.RateLimiting;
+#endif
+using Microsoft.AspNetCore.Builder;
+#if NET7_0_OR_GREATER
+using Microsoft.AspNetCore.RateLimiting;
+#endif
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Yarp.ReverseProxy.Configuration;
+
+public class YarpRateLimiterPolicyProviderTests
+{
+#if NET7_0_OR_GREATER
+    [Fact]
+    public async Task GetPolicyAsync_Works()
+    {
+        var services = new ServiceCollection();
+
+        services.AddRateLimiter(options =>
+        {
+            options.AddFixedWindowLimiter("customPolicy", opt =>
+            {
+                opt.PermitLimit = 4;
+                opt.Window = TimeSpan.FromSeconds(12);
+                opt.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
+                opt.QueueLimit = 2;
+            });
+        });
+
+        services.AddReverseProxy();
+        var provider = services.BuildServiceProvider();
+        var rateLimiterPolicyProvider = provider.GetRequiredService<IYarpRateLimiterPolicyProvider>();
+        Assert.Null(await rateLimiterPolicyProvider.GetPolicyAsync("anotherPolicy"));
+        Assert.NotNull(await rateLimiterPolicyProvider.GetPolicyAsync("customPolicy"));
+    }
+#endif
+}

--- a/test/ReverseProxy.Tests/Routing/ProxyEndpointFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Routing/ProxyEndpointFactoryTests.cs
@@ -326,6 +326,29 @@ public class ProxyEndpointFactoryTests
 
 #if NET7_0_OR_GREATER
     [Fact]
+    public void AddEndpoint_DefaultRateLimiter_Works()
+    {
+        var services = CreateServices();
+        var factory = services.GetRequiredService<ProxyEndpointFactory>();
+        factory.SetProxyPipeline(context => Task.CompletedTask);
+
+        var route = new RouteConfig
+        {
+            RouteId = "route1",
+            RateLimiterPolicy = "defaulT",
+            Order = 12,
+            Match = new RouteMatch(),
+        };
+        var cluster = new ClusterState("cluster1");
+        var routeState = new RouteState("route1");
+
+        var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
+
+        Assert.Null(routeEndpoint.Metadata.GetMetadata<EnableRateLimitingAttribute>());
+        Assert.Null(routeEndpoint.Metadata.GetMetadata<DisableRateLimitingAttribute>());
+    }
+
+    [Fact]
     public void AddEndpoint_CustomRateLimiter_Works()
     {
         var services = CreateServices();

--- a/test/ReverseProxy.Tests/Routing/ProxyEndpointFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Routing/ProxyEndpointFactoryTests.cs
@@ -5,6 +5,9 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Cors.Infrastructure;
+#if NET7_0_OR_GREATER
+using Microsoft.AspNetCore.RateLimiting;
+#endif
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
@@ -320,6 +323,78 @@ public class ProxyEndpointFactoryTests
         Assert.Null(routeEndpoint.Metadata.GetMetadata<IAuthorizeData>());
         Assert.Null(routeEndpoint.Metadata.GetMetadata<IAllowAnonymous>());
     }
+
+#if NET7_0_OR_GREATER
+    [Fact]
+    public void AddEndpoint_CustomRateLimiter_Works()
+    {
+        var services = CreateServices();
+        var factory = services.GetRequiredService<ProxyEndpointFactory>();
+        factory.SetProxyPipeline(context => Task.CompletedTask);
+
+        var route = new RouteConfig
+        {
+            RouteId = "route1",
+            RateLimiterPolicy = "custom",
+            Order = 12,
+            Match = new RouteMatch(),
+        };
+        var cluster = new ClusterState("cluster1");
+        var routeState = new RouteState("route1");
+
+        var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
+
+        var attribute = routeEndpoint.Metadata.GetMetadata<EnableRateLimitingAttribute>();
+        Assert.NotNull(attribute);
+        Assert.Equal("custom", attribute.PolicyName);
+        Assert.Null(routeEndpoint.Metadata.GetMetadata<DisableRateLimitingAttribute>());
+    }
+
+    [Fact]
+    public void AddEndpoint_DisableRateLimiter_Works()
+    {
+        var services = CreateServices();
+        var factory = services.GetRequiredService<ProxyEndpointFactory>();
+        factory.SetProxyPipeline(context => Task.CompletedTask);
+
+        var route = new RouteConfig
+        {
+            RouteId = "route1",
+            RateLimiterPolicy = "disAble",
+            Order = 12,
+            Match = new RouteMatch(),
+        };
+        var cluster = new ClusterState("cluster1");
+        var routeState = new RouteState("route1");
+
+        var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
+
+        Assert.NotNull(routeEndpoint.Metadata.GetMetadata<DisableRateLimitingAttribute>());
+        Assert.Null(routeEndpoint.Metadata.GetMetadata<EnableRateLimitingAttribute>());
+    }
+
+    [Fact]
+    public void AddEndpoint_NoRateLimiter_Works()
+    {
+        var services = CreateServices();
+        var factory = services.GetRequiredService<ProxyEndpointFactory>();
+        factory.SetProxyPipeline(context => Task.CompletedTask);
+
+        var route = new RouteConfig
+        {
+            RouteId = "route1",
+            Order = 12,
+            Match = new RouteMatch(),
+        };
+        var cluster = new ClusterState("cluster1");
+        var routeState = new RouteState("route1");
+
+        var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
+
+        Assert.Null(routeEndpoint.Metadata.GetMetadata<EnableRateLimitingAttribute>());
+        Assert.Null(routeEndpoint.Metadata.GetMetadata<DisableRateLimitingAttribute>());
+    }
+#endif
 
     [Fact]
     public void AddEndpoint_DefaultCors_Works()


### PR DESCRIPTION
Add support for Rate Limiting available from AspNetCore 7.0.

Caveats:
- The repo/libraries support both net6 and net7 using `#if NET7_0_OR_GREATER` which can potentially be a problem for maintenance.
- There is no means to validate the policy actually exists without the prescence of an interface/class similar to `IAuthorizationPolicyProvider` or `ICorsPolicyProvider`. The `RateLimitingMiddleware` uses `RateLimiterOptions.PolicyMap`  but it is internal. Hopefully something will be available in AspNetCore 8 to allow validation. A `TODO` exists in the validation just tracking and as a reminder.
- Not possible to use `default` similar to `AuthorizationPolicy` and `CorsPolicy` because the `EnableRateLimitingAttribute` requires a `policyName`. Default policy would have to be configured in the serivces setup:
    `services.AddRateLimiter(options => { /* conf stuff here */ });`


Fixes: #1776 