### PR TITLE
internal SetPassiveAsync can't be used

### DIFF
--- a/docs/docfx/articles/dests-health-checks.md
+++ b/docs/docfx/articles/dests-health-checks.md
@@ -314,13 +314,13 @@ public class FirstUnsuccessfulResponseHealthPolicy : IPassiveHealthCheckPolicy
 
     public string Name => "FirstUnsuccessfulResponse";
 
-    public void RequestProxied(ClusterState cluster, DestinationState destination, HttpContext context)
+   public void RequestProxied(HttpContext context, ClusterState cluster, DestinationState destination)
     {
-        var error = context.Features.Get<IProxyErrorFeature>();
+        var error = context.Features.Get<IForwarderErrorFeature>();
         if (error is not null)
         {
-            var reactivationPeriod = cluster.Model.Config.HealthCheck.Passive.ReactivationPeriod ?? _defaultReactivationPeriod;
-            _ = _healthUpdater.SetPassiveAsync(cluster, destination, DestinationHealth.Unhealthy, reactivationPeriod);
+            var reactivationPeriod = cluster.Model.Config.HealthCheck?.Passive?.ReactivationPeriod ?? _defaultReactivationPeriod;
+            _healthUpdater.SetPassive(cluster, destination, DestinationHealth.Unhealthy, reactivationPeriod);
         }
     }
 }


### PR DESCRIPTION
In the example of FirstUnsuccessfulResponseHealthPolicy, there are following issues need to be address with the code:
1. public void RequestProxied function was provided parameters with wrong order
2. SetPassiveAsync is internal function
3. IProxyErrorFeature cannot be found, should be IForwarderErrorFeature