### PR TITLE
Drop the Strict-Transport-Security response header 

### DIFF
--- a/docs/docfx/articles/header-guidelines.md
+++ b/docs/docfx/articles/header-guidelines.md
@@ -9,7 +9,7 @@ Headers are a very important part of processing HTTP requests and each have thei
 
 ## YARP header filtering
 
-YARP automatically removes request and response headers that could impact its ability to forward a request correctly, or that may be used maliciously to bypass features of the proxy. A complete list can be found [here](https://github.com/microsoft/reverse-proxy/blob/b0a24521b269c030c50617f9fc56be9b8a3fe247/src/ReverseProxy/Forwarder/RequestUtilities.cs#L65-L81), with some highlights described below.
+YARP automatically removes request and response headers that could impact its ability to forward a request correctly, or that may be used maliciously to bypass features of the proxy. A complete list can be found [here](https://github.com/microsoft/reverse-proxy/blob/main/src/ReverseProxy/Forwarder/RequestUtilities.cs#L63), with some highlights described below.
 
 ### Connection, KeepAlive, Close
 

--- a/src/ReverseProxy/Forwarder/RequestUtilities.cs
+++ b/src/ReverseProxy/Forwarder/RequestUtilities.cs
@@ -79,6 +79,7 @@ public static class RequestUtilities
         HeaderNames.UpgradeInsecureRequests,
         HeaderNames.TE,
         HeaderNames.AltSvc,
+        HeaderNames.StrictTransportSecurity,
     };
 
     // Headers marked as HttpHeaderType.Content in

--- a/src/ReverseProxy/Forwarder/RequestUtilities.cs
+++ b/src/ReverseProxy/Forwarder/RequestUtilities.cs
@@ -60,7 +60,7 @@ public static class RequestUtilities
         return _headersToExclude.Contains(headerName);
     }
 
-    private static readonly HashSet<string> _headersToExclude = new(17, StringComparer.OrdinalIgnoreCase)
+    private static readonly HashSet<string> _headersToExclude = new(18, StringComparer.OrdinalIgnoreCase)
     {
         HeaderNames.Connection,
         HeaderNames.TransferEncoding,

--- a/test/ReverseProxy.Tests/Forwarder/HttpTransformerTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/HttpTransformerTests.cs
@@ -33,6 +33,7 @@ public class HttpTransformerTests
         HeaderNames.UpgradeInsecureRequests,
         HeaderNames.TE,
         HeaderNames.AltSvc,
+        HeaderNames.StrictTransportSecurity,
     };
 
     [Fact]


### PR DESCRIPTION
Fixes #1862

Strict-Transport-Security is a per-hop response header. Since we terminate TLS, we should not proxy this header.