### PR TITLE
Enable direct cancellation for IHttpForwarder 

### DIFF
--- a/src/ReverseProxy/Forwarder/ForwarderRequestConfig.cs
+++ b/src/ReverseProxy/Forwarder/ForwarderRequestConfig.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.Net.Http;
+using System.Threading;
+using Microsoft.AspNetCore.Http;
 
 namespace Yarp.ReverseProxy.Forwarder;
 
 /// <summary>
-/// Config for <see cref="IHttpForwarder.SendAsync"/>
+/// Config for <see cref="IHttpForwarder.SendAsync(HttpContext, string, HttpMessageInvoker, ForwarderRequestConfig, HttpTransformer, CancellationToken)"/>
 /// </summary>
 public sealed record ForwarderRequestConfig
 {

--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -419,6 +419,9 @@ internal sealed class HttpForwarder : IHttpForwarder
             return (destinationRequest, requestContent, false);
         }
 
+        // Transforms may have taken a while, especially if they buffered the body, they count as forward progress.
+        activityToken.ResetTimeout();
+
         FixupUpgradeRequestHeaders(context, destinationRequest, outgoingUpgrade, outgoingConnect);
 
         // Allow someone to custom build the request uri, otherwise provide a default for them.

--- a/src/ReverseProxy/Forwarder/IHttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/IHttpForwarder.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
@@ -24,4 +25,19 @@ public interface IHttpForwarder
     /// <returns>The result of forwarding the request and response.</returns>
     ValueTask<ForwarderError> SendAsync(HttpContext context, string destinationPrefix, HttpMessageInvoker httpClient,
         ForwarderRequestConfig requestConfig, HttpTransformer transformer);
+
+    /// <summary>
+    /// Forwards the incoming request to the destination server, and the response back to the client.
+    /// </summary>
+    /// <param name="context">The HttpContext to forward.</param>
+    /// <param name="destinationPrefix">The url prefix for where to forward the request to.</param>
+    /// <param name="httpClient">The HTTP client used to forward the request.</param>
+    /// <param name="requestConfig">Config for the outgoing request.</param>
+    /// <param name="transformer">Request and response transforms. Use <see cref="HttpTransformer.Default"/> if
+    /// custom transformations are not needed.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to abort the request.</param>
+    /// <returns>The result of forwarding the request and response.</returns>
+    ValueTask<ForwarderError> SendAsync(HttpContext context, string destinationPrefix, HttpMessageInvoker httpClient,
+        ForwarderRequestConfig requestConfig, HttpTransformer transformer, CancellationToken cancellationToken)
+        => SendAsync(context, destinationPrefix, httpClient, requestConfig, transformer);
 }

--- a/src/ReverseProxy/Transforms/Builder/StructuredTransformer.cs
+++ b/src/ReverseProxy/Transforms/Builder/StructuredTransformer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -63,11 +64,11 @@ internal sealed class StructuredTransformer : HttpTransformer
     /// </summary>
     internal ResponseTrailersTransform[] ResponseTrailerTransforms { get; }
 
-    public override async ValueTask TransformRequestAsync(HttpContext httpContext, HttpRequestMessage proxyRequest, string destinationPrefix)
+    public override async ValueTask TransformRequestAsync(HttpContext httpContext, HttpRequestMessage proxyRequest, string destinationPrefix, CancellationToken cancellationToken)
     {
         if (ShouldCopyRequestHeaders.GetValueOrDefault(true))
         {
-            await base.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix);
+            await base.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix, cancellationToken);
         }
 
         if (RequestTransforms.Length == 0)
@@ -83,6 +84,7 @@ internal sealed class StructuredTransformer : HttpTransformer
             Path = httpContext.Request.Path,
             Query = new QueryTransformContext(httpContext.Request),
             HeadersCopied = ShouldCopyRequestHeaders.GetValueOrDefault(true),
+            CancellationToken = cancellationToken,
         };
 
         foreach (var requestTransform in RequestTransforms)
@@ -101,11 +103,11 @@ internal sealed class StructuredTransformer : HttpTransformer
             transformContext.DestinationPrefix, transformContext.Path, transformContext.Query.QueryString);
     }
 
-    public override async ValueTask<bool> TransformResponseAsync(HttpContext httpContext, HttpResponseMessage? proxyResponse)
+    public override async ValueTask<bool> TransformResponseAsync(HttpContext httpContext, HttpResponseMessage? proxyResponse, CancellationToken cancellationToken)
     {
         if (ShouldCopyResponseHeaders.GetValueOrDefault(true))
         {
-            await base.TransformResponseAsync(httpContext, proxyResponse);
+            await base.TransformResponseAsync(httpContext, proxyResponse, cancellationToken);
         }
 
         if (ResponseTransforms.Length == 0)
@@ -118,6 +120,7 @@ internal sealed class StructuredTransformer : HttpTransformer
             HttpContext = httpContext,
             ProxyResponse = proxyResponse,
             HeadersCopied = ShouldCopyResponseHeaders.GetValueOrDefault(true),
+            CancellationToken = cancellationToken,
         };
 
         foreach (var responseTransform in ResponseTransforms)
@@ -128,11 +131,11 @@ internal sealed class StructuredTransformer : HttpTransformer
         return !transformContext.SuppressResponseBody;
     }
 
-    public override async ValueTask TransformResponseTrailersAsync(HttpContext httpContext, HttpResponseMessage proxyResponse)
+    public override async ValueTask TransformResponseTrailersAsync(HttpContext httpContext, HttpResponseMessage proxyResponse, CancellationToken cancellationToken)
     {
         if (ShouldCopyResponseTrailers.GetValueOrDefault(true))
         {
-            await base.TransformResponseTrailersAsync(httpContext, proxyResponse);
+            await base.TransformResponseTrailersAsync(httpContext, proxyResponse, cancellationToken);
         }
 
         if (ResponseTrailerTransforms.Length == 0)
@@ -150,6 +153,7 @@ internal sealed class StructuredTransformer : HttpTransformer
                 HttpContext = httpContext,
                 ProxyResponse = proxyResponse,
                 HeadersCopied = ShouldCopyResponseTrailers.GetValueOrDefault(true),
+                CancellationToken = cancellationToken,
             };
 
             foreach (var responseTrailerTransform in ResponseTrailerTransforms)

--- a/src/ReverseProxy/Transforms/RequestTransformContext.cs
+++ b/src/ReverseProxy/Transforms/RequestTransformContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Net.Http;
+using System.Threading;
 using Microsoft.AspNetCore.Http;
 
 namespace Yarp.ReverseProxy.Transforms;
@@ -48,4 +49,9 @@ public class RequestTransformContext
     /// port and path base. The 'Path' and 'Query' properties will be appended to this after the transforms have run.
     /// </summary>
     public string DestinationPrefix { get; init; } = default!;
+
+    /// <summary>
+    /// A <see cref="CancellationToken"/> indicating that the request is being aborted.
+    /// </summary>
+    public CancellationToken CancellationToken { get; set; }
 }

--- a/src/ReverseProxy/Transforms/ResponseTrailersTransformContext.cs
+++ b/src/ReverseProxy/Transforms/ResponseTrailersTransformContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Net.Http;
+using System.Threading;
 using Microsoft.AspNetCore.Http;
 
 namespace Yarp.ReverseProxy.Transforms;
@@ -27,4 +28,9 @@ public class ResponseTrailersTransformContext
     /// should operate on.
     /// </summary>
     public bool HeadersCopied { get; set; }
+
+    /// <summary>
+    /// A <see cref="CancellationToken"/> indicating that the request is being aborted.
+    /// </summary>
+    public CancellationToken CancellationToken { get; set; }
 }

--- a/src/ReverseProxy/Transforms/ResponseTransformContext.cs
+++ b/src/ReverseProxy/Transforms/ResponseTransformContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Net.Http;
+using System.Threading;
 using Microsoft.AspNetCore.Http;
 
 namespace Yarp.ReverseProxy.Transforms;
@@ -33,4 +34,9 @@ public class ResponseTransformContext
     /// Defaults to false.
     /// </summary>
     public bool SuppressResponseBody { get; set; }
+
+    /// <summary>
+    /// A <see cref="CancellationToken"/> indicating that the request is being aborted.
+    /// </summary>
+    public CancellationToken CancellationToken { get; set; }
 }

--- a/test/ReverseProxy.Tests/Transforms/Builder/TransformBuilderTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/Builder/TransformBuilderTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -307,7 +308,7 @@ public class TransformBuilderTests
         httpContext.Request.Host = new HostString("StartHost");
         var proxyRequest = new HttpRequestMessage();
         var destinationPrefix = "http://destinationhost:9090/path";
-        await results.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix);
+        await results.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix, CancellationToken.None);
 
         if (useOriginalHost.GetValueOrDefault(false))
         {
@@ -373,7 +374,7 @@ public class TransformBuilderTests
         var proxyRequest = new HttpRequestMessage();
         var destinationPrefix = "http://destinationhost:9090/path";
 
-        await results.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix);
+        await results.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix, CancellationToken.None);
 
         Assert.Equal("CustomHost", proxyRequest.Headers.Host);
     }

--- a/test/ReverseProxy.Tests/Utilities/ActivityCancellationTokenSourceTests.cs
+++ b/test/ReverseProxy.Tests/Utilities/ActivityCancellationTokenSourceTests.cs
@@ -45,7 +45,7 @@ public class ActivityCancellationTokenSourceTests
     }
 
     [Fact]
-    public void ActivityCancellationTokenSource_RespectsLinkedToken()
+    public void ActivityCancellationTokenSource_RespectsLinkedToken1()
     {
         var linkedCts = new CancellationTokenSource();
 
@@ -56,14 +56,40 @@ public class ActivityCancellationTokenSourceTests
     }
 
     [Fact]
-    public void ActivityCancellationTokenSource_ClearsRegistrations()
+    public void ActivityCancellationTokenSource_RespectsLinkedToken2()
     {
         var linkedCts = new CancellationTokenSource();
 
-        var cts = ActivityCancellationTokenSource.Rent(TimeSpan.FromSeconds(10), linkedCts.Token);
+        var cts = ActivityCancellationTokenSource.Rent(TimeSpan.FromSeconds(10), default, linkedCts.Token);
+        linkedCts.Cancel();
+
+        Assert.True(cts.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void ActivityCancellationTokenSource_RespectsBothLinkedTokens()
+    {
+        var linkedCts1 = new CancellationTokenSource();
+        var linkedCts2 = new CancellationTokenSource();
+
+        var cts = ActivityCancellationTokenSource.Rent(TimeSpan.FromSeconds(10), linkedCts1.Token, linkedCts2.Token);
+        linkedCts1.Cancel();
+        linkedCts2.Cancel();
+
+        Assert.True(cts.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void ActivityCancellationTokenSource_ClearsRegistrations()
+    {
+        var linkedCts1 = new CancellationTokenSource();
+        var linkedCts2 = new CancellationTokenSource();
+
+        var cts = ActivityCancellationTokenSource.Rent(TimeSpan.FromSeconds(10), linkedCts1.Token, linkedCts2.Token);
         cts.Return();
 
-        linkedCts.Cancel();
+        linkedCts1.Cancel();
+        linkedCts2.Cancel();
 
         Assert.False(cts.IsCancellationRequested);
     }


### PR DESCRIPTION
Fixes #1542

Some customers using IHttpForwarder directly have asked for the ability to pass their own cancellation token. Today they have to replace HttpContext.RequestAborted which can be error prone.

This uses a Default Interface Method to avoid a breaking change.