### PR TITLE
Lazily allocate the QueryTransformContext

### DIFF
--- a/src/ReverseProxy/Transforms/RequestTransformContext.cs
+++ b/src/ReverseProxy/Transforms/RequestTransformContext.cs
@@ -39,10 +39,16 @@ public class RequestTransformContext
     /// </remarks>
     public PathString Path { get; set; }
 
+    internal QueryTransformContext? MaybeQuery { get; private set; }
+
     /// <summary>
     /// The query used for the proxy request.
     /// </summary>
-    public QueryTransformContext Query { get; set; } = default!;
+    public QueryTransformContext Query
+    {
+        get => MaybeQuery ??= new QueryTransformContext(HttpContext.Request);
+        set => MaybeQuery = value;
+    }
 
     /// <summary>
     /// The URI prefix for the proxy request. This includes the scheme and host and can optionally include a


### PR DESCRIPTION
40 bytes of allocation we can avoid on every request if the transforms don't touch the query.