### PR TITLE
Fix HttpTransformer-related issues

### DIFF
--- a/docs/docfx/articles/direct-forwarding.md
+++ b/docs/docfx/articles/direct-forwarding.md
@@ -80,10 +80,10 @@ public void Configure(IApplicationBuilder app, IHttpForwarder forwarder)
 private class CustomTransformer : HttpTransformer
 {
     public override async ValueTask TransformRequestAsync(HttpContext httpContext,
-        HttpRequestMessage proxyRequest, string destinationPrefix)
+        HttpRequestMessage proxyRequest, string destinationPrefix, CancellationToken cancellationToken)
     {
         // Copy all request headers
-        await base.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix);
+        await base.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix, cancellationToken);
 
         // Customize the query string:
         var queryContext = new QueryTransformContext(httpContext.Request);

--- a/samples/ReverseProxy.Direct.Sample/Startup.cs
+++ b/samples/ReverseProxy.Direct.Sample/Startup.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -104,10 +105,10 @@ namespace Yarp.Sample
             /// <param name="proxyRequest">The outgoing proxy request.</param>
             /// <param name="destinationPrefix">The uri prefix for the selected destination server which can be used to create
             /// the RequestUri.</param>
-            public override async ValueTask TransformRequestAsync(HttpContext httpContext, HttpRequestMessage proxyRequest, string destinationPrefix)
+            public override async ValueTask TransformRequestAsync(HttpContext httpContext, HttpRequestMessage proxyRequest, string destinationPrefix, CancellationToken cancellationToken)
             {
                 // Copy all request headers
-                await base.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix);
+                await base.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix, cancellationToken);
 
                 // Customize the query string:
                 var queryContext = new QueryTransformContext(httpContext.Request);

--- a/src/ReverseProxy/Forwarder/ForwarderError.cs
+++ b/src/ReverseProxy/Forwarder/ForwarderError.cs
@@ -98,4 +98,9 @@ public enum ForwarderError : int
     /// The configured destinations may have been excluded due to heath or other considerations.
     /// </summary>
     NoAvailableDestinations,
+
+    /// <summary>
+    /// Failed while creating the request message.
+    /// </summary>
+    RequestCreation,
 }

--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -627,7 +627,7 @@ internal sealed class HttpForwarder : IHttpForwarder
         {
             if (requestCancellationSource.CancelledByLinkedToken)
             {
-                // Either the client went away (HttpContext.RequestAborted) or the CancellationToken provided to SendAsync was signaled. 
+                // Either the client went away (HttpContext.RequestAborted) or the CancellationToken provided to SendAsync was signaled.
                 return await ReportErrorAsync(ForwarderError.RequestCanceled, StatusCodes.Status502BadGateway);
             }
             else

--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -625,8 +625,9 @@ internal sealed class HttpForwarder : IHttpForwarder
     {
         if (requestException is OperationCanceledException)
         {
-            if (context.RequestAborted.IsCancellationRequested || requestCancellationSource.CancelledByLinkedToken)
+            if (requestCancellationSource.CancelledByLinkedToken)
             {
+                // Either the client went away (HttpContext.RequestAborted) or the CancellationToken provided to SendAsync was signaled. 
                 return await ReportErrorAsync(ForwarderError.RequestCanceled, StatusCodes.Status502BadGateway);
             }
             else

--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -117,6 +117,12 @@ internal sealed class HttpForwarder : IHttpForwarder
             throw new ArgumentException($"The http client must be of type HttpMessageInvoker, not HttpClient", nameof(httpClient));
         }
 
+        // "http://a".Length = 8
+        if (destinationPrefix is null || destinationPrefix.Length < 8)
+        {
+            throw new ArgumentException("Invalid destination prefix.", nameof(destinationPrefix));
+        }
+
         ForwarderTelemetry.Log.ForwarderStart(destinationPrefix);
 
         var activityCancellationSource = ActivityCancellationTokenSource.Rent(requestConfig?.ActivityTimeout ?? DefaultTimeout, context.RequestAborted, cancellationToken);
@@ -128,23 +134,26 @@ internal sealed class HttpForwarder : IHttpForwarder
             // See https://github.com/microsoft/reverse-proxy/issues/118 for design discussion.
             var isStreamingRequest = isClientHttp2OrGreater && ProtocolHelper.IsGrpcContentType(context.Request.ContentType);
 
-            // :: Step 1-3: Create outgoing HttpRequestMessage
-            var (destinationRequest, requestContent, tryDowngradingH2WsOnFailure) = await CreateRequestMessageAsync(
-                context, destinationPrefix, transformer, requestConfig, isStreamingRequest, activityCancellationSource);
-
-            // Transforms generated a response, do not proxy.
-            if (RequestUtilities.IsResponseSet(context.Response))
-            {
-                Log.NotProxying(_logger, context.Response.StatusCode);
-                return ForwarderError.None;
-            }
-
-            Log.Proxying(_logger, destinationRequest, isStreamingRequest);
-
-            // :: Step 4: Send the outgoing request using HttpClient
+            HttpRequestMessage destinationRequest;
+            StreamCopyHttpContent? requestContent = null;
             HttpResponseMessage destinationResponse;
             try
             {
+                // :: Step 1-3: Create outgoing HttpRequestMessage
+                bool tryDowngradingH2WsOnFailure;
+                (destinationRequest, requestContent, tryDowngradingH2WsOnFailure) = await CreateRequestMessageAsync(
+                    context, destinationPrefix, transformer, requestConfig, isStreamingRequest, activityCancellationSource);
+
+                // Transforms generated a response, do not proxy.
+                if (RequestUtilities.IsResponseSet(context.Response))
+                {
+                    Log.NotProxying(_logger, context.Response.StatusCode);
+                    return ForwarderError.None;
+                }
+
+                Log.Proxying(_logger, destinationRequest, isStreamingRequest);
+
+                // :: Step 4: Send the outgoing request using HttpClient
                 ForwarderTelemetry.Log.ForwarderStage(ForwarderStage.SendAsyncStart);
 
                 try
@@ -320,12 +329,6 @@ internal sealed class HttpForwarder : IHttpForwarder
     private async ValueTask<(HttpRequestMessage, StreamCopyHttpContent?, bool)> CreateRequestMessageAsync(HttpContext context, string destinationPrefix,
         HttpTransformer transformer, ForwarderRequestConfig? requestConfig, bool isStreamingRequest, ActivityCancellationTokenSource activityToken)
     {
-        // "http://a".Length = 8
-        if (destinationPrefix is null || destinationPrefix.Length < 8)
-        {
-            throw new ArgumentException("Invalid destination prefix.", nameof(destinationPrefix));
-        }
-
         var destinationRequest = new HttpRequestMessage();
 
         var upgradeFeature = context.Features.Get<IHttpUpgradeFeature>();
@@ -618,11 +621,11 @@ internal sealed class HttpForwarder : IHttpForwarder
         return requestBodyError;
     }
 
-    private async ValueTask<ForwarderError> HandleRequestFailureAsync(HttpContext context, StreamCopyHttpContent? requestContent, Exception requestException, HttpTransformer transformer, CancellationTokenSource requestCancellationSource)
+    private async ValueTask<ForwarderError> HandleRequestFailureAsync(HttpContext context, StreamCopyHttpContent? requestContent, Exception requestException, HttpTransformer transformer, ActivityCancellationTokenSource requestCancellationSource)
     {
         if (requestException is OperationCanceledException)
         {
-            if (context.RequestAborted.IsCancellationRequested)
+            if (context.RequestAborted.IsCancellationRequested || requestCancellationSource.CancelledByLinkedToken)
             {
                 return await ReportErrorAsync(ForwarderError.RequestCanceled, StatusCodes.Status502BadGateway);
             }
@@ -641,7 +644,7 @@ internal sealed class HttpForwarder : IHttpForwarder
             if (requestBodyCopyResult != StreamCopyResult.Success)
             {
                 var error = HandleRequestBodyFailure(context, requestBodyCopyResult, requestBodyException!, requestException);
-                await transformer.TransformResponseAsync(context, proxyResponse: null);
+                await transformer.TransformResponseAsync(context, proxyResponse: null, requestCancellationSource.Token);
                 return error;
             }
         }
@@ -660,7 +663,7 @@ internal sealed class HttpForwarder : IHttpForwarder
                 await requestContent.ConsumptionTask;
             }
 
-            await transformer.TransformResponseAsync(context, null);
+            await transformer.TransformResponseAsync(context, null, requestCancellationSource.Token);
             return error;
         }
     }

--- a/src/ReverseProxy/Forwarder/HttpTransformer.cs
+++ b/src/ReverseProxy/Forwarder/HttpTransformer.cs
@@ -69,7 +69,9 @@ public class HttpTransformer
     /// <param name="destinationPrefix">The uri prefix for the selected destination server which can be used to create the RequestUri.</param>
     /// <param name="cancellationToken">Indicates that the request is being canceled.</param>
     public virtual ValueTask TransformRequestAsync(HttpContext httpContext, HttpRequestMessage proxyRequest, string destinationPrefix, CancellationToken cancellationToken)
+#pragma warning disable CS0618 // We're calling the overload without the CancellationToken for backwards compatibility.
         => TransformRequestAsync(httpContext, proxyRequest, destinationPrefix);
+#pragma warning restore CS0618
 
     /// <summary>
     /// A callback that is invoked prior to sending the proxied request. All HttpRequestMessage fields are
@@ -84,6 +86,7 @@ public class HttpTransformer
     /// <param name="httpContext">The incoming request.</param>
     /// <param name="proxyRequest">The outgoing proxy request.</param>
     /// <param name="destinationPrefix">The uri prefix for the selected destination server which can be used to create the RequestUri.</param>
+    [Obsolete("This overload of TransformRequestAsync is obsolete. Override and use the overload accepting a CancellationToken instead.")]
     public virtual ValueTask TransformRequestAsync(HttpContext httpContext, HttpRequestMessage proxyRequest, string destinationPrefix)
     {
         foreach (var header in httpContext.Request.Headers)
@@ -149,7 +152,9 @@ public class HttpTransformer
     /// that returns false may send an alternate response inline or return control to the caller for it to retry, respond, 
     /// etc.</returns>
     public virtual ValueTask<bool> TransformResponseAsync(HttpContext httpContext, HttpResponseMessage? proxyResponse, CancellationToken cancellationToken)
+#pragma warning disable CS0618 // We're calling the overload without the CancellationToken for backwards compatibility.
         => TransformResponseAsync(httpContext, proxyResponse);
+#pragma warning restore CS0618
 
     /// <summary>
     /// A callback that is invoked when the proxied response is received. The status code and reason phrase will be copied
@@ -162,6 +167,7 @@ public class HttpTransformer
     /// <returns>A bool indicating if the response should be proxied to the client or not. A derived implementation
     /// that returns false may send an alternate response inline or return control to the caller for it to retry, respond,
     /// etc.</returns>
+    [Obsolete("This overload of TransformResponseAsync is obsolete. Override and use the overload accepting a CancellationToken instead.")]
     public virtual ValueTask<bool> TransformResponseAsync(HttpContext httpContext, HttpResponseMessage? proxyResponse)
     {
         if (proxyResponse is null)
@@ -212,7 +218,9 @@ public class HttpTransformer
     /// <param name="proxyResponse">The response from the destination.</param>
     /// <param name="cancellationToken">Indicates that the request is being canceled.</param>
     public virtual ValueTask TransformResponseTrailersAsync(HttpContext httpContext, HttpResponseMessage proxyResponse, CancellationToken cancellationToken)
+#pragma warning disable CS0618 // We're calling the overload without the CancellationToken for backwards compatibility.
         => TransformResponseTrailersAsync(httpContext, proxyResponse);
+#pragma warning restore CS0618
 
     /// <summary>
     /// A callback that is invoked after the response body to modify trailers, if supported. The trailers will be
@@ -220,6 +228,7 @@ public class HttpTransformer
     /// </summary>
     /// <param name="httpContext">The incoming request.</param>
     /// <param name="proxyResponse">The response from the destination.</param>
+    [Obsolete("This overload of TransformResponseTrailersAsync is obsolete. Override and use the overload accepting a CancellationToken instead.")]
     public virtual ValueTask TransformResponseTrailersAsync(HttpContext httpContext, HttpResponseMessage proxyResponse)
     {
         // NOTE: Deliberately not using `context.Response.SupportsTrailers()`, `context.Response.AppendTrailer(...)`

--- a/src/ReverseProxy/Forwarder/RequestTransformer.cs
+++ b/src/ReverseProxy/Forwarder/RequestTransformer.cs
@@ -3,12 +3,13 @@
 
 using System;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
 namespace Yarp.ReverseProxy.Forwarder;
 
-internal class RequestTransformer : HttpTransformer
+internal sealed class RequestTransformer : HttpTransformer
 {
     private readonly Func<HttpContext, HttpRequestMessage, ValueTask> _requestTransform;
 
@@ -17,9 +18,9 @@ internal class RequestTransformer : HttpTransformer
         _requestTransform = requestTransform;
     }
 
-    public override async ValueTask TransformRequestAsync(HttpContext httpContext, HttpRequestMessage proxyRequest, string destinationPrefix)
+    public override async ValueTask TransformRequestAsync(HttpContext httpContext, HttpRequestMessage proxyRequest, string destinationPrefix, CancellationToken cancellationToken)
     {
-        await base.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix);
+        await base.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix, cancellationToken);
         await _requestTransform(httpContext, proxyRequest);
     }
 }

--- a/src/ReverseProxy/Transforms/Builder/StructuredTransformer.cs
+++ b/src/ReverseProxy/Transforms/Builder/StructuredTransformer.cs
@@ -64,11 +64,29 @@ internal sealed class StructuredTransformer : HttpTransformer
     /// </summary>
     internal ResponseTrailersTransform[] ResponseTrailerTransforms { get; }
 
+#pragma warning disable CS0672 // We're overriding the obsolete overloads to preserve backwards compatibility.
+    public override ValueTask TransformRequestAsync(HttpContext httpContext, HttpRequestMessage proxyRequest, string destinationPrefix) =>
+        TransformRequestAsync(httpContext, proxyRequest, destinationPrefix, CancellationToken.None);
+
+    public override ValueTask<bool> TransformResponseAsync(HttpContext httpContext, HttpResponseMessage? proxyResponse) =>
+        TransformResponseAsync(httpContext, proxyResponse, CancellationToken.None);
+
+    public override ValueTask TransformResponseTrailersAsync(HttpContext httpContext, HttpResponseMessage proxyResponse) =>
+        TransformResponseTrailersAsync(httpContext, proxyResponse, CancellationToken.None);
+#pragma warning restore
+
     public override async ValueTask TransformRequestAsync(HttpContext httpContext, HttpRequestMessage proxyRequest, string destinationPrefix, CancellationToken cancellationToken)
     {
         if (ShouldCopyRequestHeaders.GetValueOrDefault(true))
         {
-            await base.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix, cancellationToken);
+            // We own the base implementation and know it doesn't make use of the cancellation token.
+            // We're intentionally calling the overload without it to avoid it calling back into this derived implementation, causing a stack overflow.
+
+#pragma warning disable CA2016 // Forward the 'CancellationToken' parameter to methods
+#pragma warning disable CS0618 // Type or member is obsolete
+            await base.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix);
+#pragma warning restore CS0618
+#pragma warning restore CA2016
         }
 
         if (RequestTransforms.Length == 0)
@@ -111,7 +129,14 @@ internal sealed class StructuredTransformer : HttpTransformer
     {
         if (ShouldCopyResponseHeaders.GetValueOrDefault(true))
         {
-            await base.TransformResponseAsync(httpContext, proxyResponse, cancellationToken);
+            // We own the base implementation and know it doesn't make use of the cancellation token.
+            // We're intentionally calling the overload without it to avoid it calling back into this derived implementation, causing a stack overflow.
+
+#pragma warning disable CA2016 // Forward the 'CancellationToken' parameter to methods
+#pragma warning disable CS0618 // Type or member is obsolete
+            await base.TransformResponseAsync(httpContext, proxyResponse);
+#pragma warning restore CS0618
+#pragma warning restore CA2016
         }
 
         if (ResponseTransforms.Length == 0)
@@ -139,7 +164,14 @@ internal sealed class StructuredTransformer : HttpTransformer
     {
         if (ShouldCopyResponseTrailers.GetValueOrDefault(true))
         {
-            await base.TransformResponseTrailersAsync(httpContext, proxyResponse, cancellationToken);
+            // We own the base implementation and know it doesn't make use of the cancellation token.
+            // We're intentionally calling the overload without it to avoid it calling back into this derived implementation, causing a stack overflow.
+
+#pragma warning disable CA2016 // Forward the 'CancellationToken' parameter to methods
+#pragma warning disable CS0618 // Type or member is obsolete
+            await base.TransformResponseTrailersAsync(httpContext, proxyResponse);
+#pragma warning restore CS0618
+#pragma warning restore CA2016
         }
 
         if (ResponseTrailerTransforms.Length == 0)

--- a/test/ReverseProxy.Tests/Common/TestTrailersFeature.cs
+++ b/test/ReverseProxy.Tests/Common/TestTrailersFeature.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Http;
+
+namespace Yarp.Tests.Common;
+
+internal sealed class TestTrailersFeature : IHttpResponseTrailersFeature
+{
+    public IHeaderDictionary Trailers { get; set; } = new HeaderDictionary();
+}

--- a/test/ReverseProxy.Tests/Forwarder/HttpTransformerTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/HttpTransformerTests.cs
@@ -2,13 +2,19 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Net.Http.Headers;
 using Xunit;
+using Yarp.ReverseProxy.Transforms;
+using Yarp.ReverseProxy.Transforms.Builder.Tests;
+using Yarp.Tests.Common;
 
 namespace Yarp.ReverseProxy.Forwarder.Tests;
 
@@ -48,7 +54,7 @@ public class HttpTransformerTests
             httpContext.Request.Headers[header] = "value";
         }
 
-        await transformer.TransformRequestAsync(httpContext, proxyRequest, "prefix");
+        await transformer.TransformRequestAsync(httpContext, proxyRequest, "prefix", CancellationToken.None);
 
         foreach (var header in RestrictedHeaders)
         {
@@ -67,7 +73,7 @@ public class HttpTransformerTests
 
         httpContext.Request.Host = new HostString("example.com:3456");
 
-        await transformer.TransformRequestAsync(httpContext, proxyRequest, "prefix");
+        await transformer.TransformRequestAsync(httpContext, proxyRequest, "prefix", CancellationToken.None);
 
         Assert.Equal("example.com:3456", proxyRequest.Headers.Host);
     }
@@ -82,7 +88,7 @@ public class HttpTransformerTests
 
         httpContext.Request.Headers[HeaderNames.TE] = "traiLers";
 
-        await transformer.TransformRequestAsync(httpContext, proxyRequest, "prefix");
+        await transformer.TransformRequestAsync(httpContext, proxyRequest, "prefix", CancellationToken.None);
 
         Assert.True(proxyRequest.Headers.TryGetValues(HeaderNames.TE, out var values));
         var value = Assert.Single(values);
@@ -104,7 +110,7 @@ public class HttpTransformerTests
         httpContext.Request.Headers[HeaderNames.TransferEncoding] = "chUnked";
         httpContext.Request.Headers[HeaderNames.ContentLength] = "10";
 
-        await transformer.TransformRequestAsync(httpContext, proxyRequest, "prefix");
+        await transformer.TransformRequestAsync(httpContext, proxyRequest, "prefix", CancellationToken.None);
 
         Assert.False(proxyRequest.Content.Headers.TryGetValues(HeaderNames.ContentLength, out var _));
         // Transfer-Encoding is on the restricted list and removed. HttpClient will re-add it if required.
@@ -127,7 +133,7 @@ public class HttpTransformerTests
         };
 
         Assert.Equal(0, proxyResponse.Content.Headers.ContentLength);
-        await transformer.TransformResponseAsync(httpContext, proxyResponse);
+        await transformer.TransformResponseAsync(httpContext, proxyResponse, CancellationToken.None);
         Assert.False(httpContext.Response.Headers.ContainsKey(HeaderNames.ContentLength));
     }
 
@@ -149,7 +155,7 @@ public class HttpTransformerTests
             }
         }
 
-        await transformer.TransformResponseAsync(httpContext, proxyResponse);
+        await transformer.TransformResponseAsync(httpContext, proxyResponse, CancellationToken.None);
 
         foreach (var header in RestrictedHeaders)
         {
@@ -170,7 +176,7 @@ public class HttpTransformerTests
         proxyResponse.Headers.TransferEncodingChunked = true;
         Assert.Equal(10, proxyResponse.Content.Headers.ContentLength);
 
-        await transformer.TransformResponseAsync(httpContext, proxyResponse);
+        await transformer.TransformResponseAsync(httpContext, proxyResponse, CancellationToken.None);
 
         Assert.False(httpContext.Response.Headers.ContainsKey(HeaderNames.ContentLength));
         // Transfer-Encoding is on the restricted list and removed. HttpClient will re-add it if required.
@@ -191,7 +197,7 @@ public class HttpTransformerTests
             Assert.True(proxyResponse.TrailingHeaders.TryAddWithoutValidation(header, "value"));
         }
 
-        await transformer.TransformResponseTrailersAsync(httpContext, proxyResponse);
+        await transformer.TransformResponseTrailersAsync(httpContext, proxyResponse, CancellationToken.None);
 
         foreach (var header in RestrictedHeaders)
         {
@@ -199,8 +205,146 @@ public class HttpTransformerTests
         }
     }
 
-    private class TestTrailersFeature : IHttpResponseTrailersFeature
+    public enum ImplementationType
     {
-        public IHeaderDictionary Trailers { get; set; } = new HeaderDictionary();
+        StructuredTransformer,
+        DerivedWithoutCT,
+        DerivedWithCT,
+    }
+
+    public static IEnumerable<object[]> ImplementationTypes_MemberData() =>
+        Enum.GetValues<ImplementationType>().Select(i => new object[] { i });
+
+    [Theory]
+    [MemberData(nameof(ImplementationTypes_MemberData))]
+    public async Task DerivedImplementation_TransformRequestAsync_DerivedImplementationCalled(ImplementationType implementationType)
+    {
+        var implementationCalled = 0;
+
+        var transformer = GetTransformerImplementation(implementationType, () => implementationCalled++);
+
+        var httpContext = new DefaultHttpContext();
+        var proxyRequest = new HttpRequestMessage();
+        var destinationPrefix = "http://destinationhost:9090/path";
+
+        using var cts = new CancellationTokenSource();
+        await transformer.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix, cts.Token);
+
+        Assert.Equal(1, implementationCalled);
+    }
+
+    [Theory]
+    [MemberData(nameof(ImplementationTypes_MemberData))]
+    public async Task DerivedImplementation_TransformResponseAsync_DerivedImplementationCalled(ImplementationType implementationType)
+    {
+        var implementationCalled = 0;
+
+        var transformer = GetTransformerImplementation(implementationType, () => implementationCalled++);
+
+        var httpContext = new DefaultHttpContext();
+        var proxyResponse = new HttpResponseMessage();
+
+        using var cts = new CancellationTokenSource();
+        await transformer.TransformResponseAsync(httpContext, proxyResponse, cts.Token);
+
+        Assert.Equal(1, implementationCalled);
+    }
+
+    [Theory]
+    [MemberData(nameof(ImplementationTypes_MemberData))]
+    public async Task DerivedImplementation_TransformResponseTrailersAsync_DerivedImplementationCalled(ImplementationType implementationType)
+    {
+        var implementationCalled = 0;
+
+        var transformer = GetTransformerImplementation(implementationType, () => implementationCalled++);
+
+        var httpContext = new DefaultHttpContext();
+        var proxyResponse = new HttpResponseMessage();
+
+        httpContext.Features.Set<IHttpResponseTrailersFeature>(new TestTrailersFeature());
+
+        using var cts = new CancellationTokenSource();
+        await transformer.TransformResponseTrailersAsync(httpContext, proxyResponse, cts.Token);
+
+        Assert.Equal(1, implementationCalled);
+    }
+
+    private static HttpTransformer GetTransformerImplementation(ImplementationType implementationType, Action callback)
+    {
+        return implementationType switch
+        {
+            ImplementationType.StructuredTransformer => TransformBuilderTests.CreateTransformBuilder().CreateInternal(context =>
+            {
+                context.AddRequestTransform(context =>
+                {
+                    callback();
+                    return default;
+                });
+                context.AddResponseTransform(context =>
+                {
+                    callback();
+                    return default;
+                });
+                context.AddResponseTrailersTransform(context =>
+                {
+                    callback();
+                    return default;
+                });
+            }),
+            ImplementationType.DerivedWithoutCT => new DerivedTransformerWithoutCT { Callback = callback },
+            ImplementationType.DerivedWithCT => new DerivedTransformerWithCT { Callback = callback },
+            _ => throw new InvalidOperationException(implementationType.ToString())
+        };
+    }
+
+    private sealed class DerivedTransformerWithoutCT : HttpTransformer
+    {
+        public Action Callback { get; set; }
+
+#pragma warning disable CS0672 // We're intentionally testing the obsolete overloads
+#pragma warning disable CS0618
+        public override ValueTask TransformRequestAsync(HttpContext httpContext, HttpRequestMessage proxyRequest, string destinationPrefix)
+        {
+            Callback();
+
+            return base.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix);
+        }
+
+        public override ValueTask<bool> TransformResponseAsync(HttpContext httpContext, HttpResponseMessage proxyResponse)
+        {
+            Callback();
+            return base.TransformResponseAsync(httpContext, proxyResponse);
+        }
+
+        public override ValueTask TransformResponseTrailersAsync(HttpContext httpContext, HttpResponseMessage proxyResponse)
+        {
+            Callback();
+            return base.TransformResponseTrailersAsync(httpContext, proxyResponse);
+        }
+#pragma warning restore CS0618
+#pragma warning restore CS0672
+    }
+
+    private sealed class DerivedTransformerWithCT : HttpTransformer
+    {
+        public Action Callback { get; set; }
+
+        public override ValueTask TransformRequestAsync(HttpContext httpContext, HttpRequestMessage proxyRequest, string destinationPrefix, CancellationToken cancellationToken)
+        {
+            Callback();
+            return base.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix, cancellationToken);
+        }
+
+        public override ValueTask<bool> TransformResponseAsync(HttpContext httpContext, HttpResponseMessage proxyResponse, CancellationToken cancellationToken)
+        {
+            Callback();
+            return base.TransformResponseAsync(httpContext, proxyResponse, cancellationToken);
+        }
+
+        public override ValueTask TransformResponseTrailersAsync(HttpContext httpContext, HttpResponseMessage proxyResponse, CancellationToken cancellationToken)
+        {
+            Callback();
+            return base.TransformResponseTrailersAsync(httpContext, proxyResponse, cancellationToken);
+        }
     }
 }

--- a/test/ReverseProxy.Tests/Transforms/ResponseTrailerRemoveTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/ResponseTrailerRemoveTransformTests.cs
@@ -60,9 +60,4 @@ public class ResponseTrailerRemoveTransformTests
         var expectedHeaders = expected.Split("; ", StringSplitOptions.RemoveEmptyEntries);
         Assert.Equal(expectedHeaders, trailerFeature.Trailers.Select(h => h.Key));
     }
-
-    private class TestTrailersFeature : IHttpResponseTrailersFeature
-    {
-        public IHeaderDictionary Trailers { get; set; } = new HeaderDictionary();
-    }
 }

--- a/test/ReverseProxy.Tests/Transforms/ResponseTrailerValueTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/ResponseTrailerValueTransformTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Xunit;
+using Yarp.Tests.Common;
 
 namespace Yarp.ReverseProxy.Transforms.Tests;
 
@@ -51,10 +52,5 @@ public class ResponseTrailerValueTransformTests
         var transform = new ResponseTrailerValueTransform("name", value, append, condition);
         await transform.ApplyAsync(transformContext);
         Assert.Equal(expected.Split(";", System.StringSplitOptions.RemoveEmptyEntries), trailerFeature.Trailers["name"]);
-    }
-
-    private class TestTrailersFeature : IHttpResponseTrailersFeature
-    {
-        public IHeaderDictionary Trailers { get; set; } = new HeaderDictionary();
     }
 }

--- a/test/ReverseProxy.Tests/Transforms/ResponseTrailersAllowedTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/ResponseTrailersAllowedTransformTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Net.Http.Headers;
 using Xunit;
+using Yarp.Tests.Common;
 
 namespace Yarp.ReverseProxy.Transforms.Tests;
 
@@ -83,10 +84,5 @@ public class ResponseTrailersAllowedTransformTests
         {
             Assert.Contains(header.Key, allowed, StringComparer.OrdinalIgnoreCase);
         }
-    }
-
-    private class TestTrailersFeature : IHttpResponseTrailersFeature
-    {
-        public IHeaderDictionary Trailers { get; set; } = new HeaderDictionary();
     }
 }

--- a/test/ReverseProxy.Tests/Transforms/ResponseTrailersTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/ResponseTrailersTransformTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Primitives;
 using Xunit;
+using Yarp.Tests.Common;
 
 namespace Yarp.ReverseProxy.Transforms.Tests;
 
@@ -69,10 +70,5 @@ public class ResponseTrailersTransformTests
         Assert.Equal(StringValues.Empty, result);
         Assert.False(trailerFeature.Trailers.TryGetValue("name", out var _));
         Assert.Equal(new[] { "value1" }, proxyResponse.TrailingHeaders.GetValues("name"));
-    }
-
-    private class TestTrailersFeature : IHttpResponseTrailersFeature
-    {
-        public IHeaderDictionary Trailers { get; set; } = new HeaderDictionary();
     }
 }

--- a/test/ReverseProxy.Tests/Utilities/ActivityCancellationTokenSourceTests.cs
+++ b/test/ReverseProxy.Tests/Utilities/ActivityCancellationTokenSourceTests.cs
@@ -52,6 +52,7 @@ public class ActivityCancellationTokenSourceTests
         var cts = ActivityCancellationTokenSource.Rent(TimeSpan.FromSeconds(10), linkedCts.Token);
         linkedCts.Cancel();
 
+        Assert.True(cts.CancelledByLinkedToken);
         Assert.True(cts.IsCancellationRequested);
     }
 
@@ -63,6 +64,7 @@ public class ActivityCancellationTokenSourceTests
         var cts = ActivityCancellationTokenSource.Rent(TimeSpan.FromSeconds(10), default, linkedCts.Token);
         linkedCts.Cancel();
 
+        Assert.True(cts.CancelledByLinkedToken);
         Assert.True(cts.IsCancellationRequested);
     }
 
@@ -76,6 +78,7 @@ public class ActivityCancellationTokenSourceTests
         linkedCts1.Cancel();
         linkedCts2.Cancel();
 
+        Assert.True(cts.CancelledByLinkedToken);
         Assert.True(cts.IsCancellationRequested);
     }
 
@@ -103,6 +106,7 @@ public class ActivityCancellationTokenSourceTests
         {
             if (cts.IsCancellationRequested)
             {
+                Assert.False(cts.CancelledByLinkedToken);
                 return;
             }
 

--- a/testassets/ReverseProxy.Direct/Startup.cs
+++ b/testassets/ReverseProxy.Direct/Startup.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -65,10 +66,10 @@ public class Startup
 
     private class CustomTransformer : HttpTransformer
     {
-        public override async ValueTask TransformRequestAsync(HttpContext httpContext, HttpRequestMessage proxyRequest, string destinationPrefix)
+        public override async ValueTask TransformRequestAsync(HttpContext httpContext, HttpRequestMessage proxyRequest, string destinationPrefix, CancellationToken cancellationToken)
         {
             // Copy all request headers
-            await base.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix);
+            await base.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix, cancellationToken);
 
             // Customize the query string:
             var queryContext = new QueryTransformContext(httpContext.Request);
@@ -82,7 +83,7 @@ public class Startup
             proxyRequest.Headers.Host = null;
         }
 
-        public override ValueTask<bool> TransformResponseAsync(HttpContext httpContext, HttpResponseMessage proxyResponse)
+        public override ValueTask<bool> TransformResponseAsync(HttpContext httpContext, HttpResponseMessage proxyResponse, CancellationToken cancellationToken)
         {
             // Suppress the response body from errors.
             // The status code was already copied.
@@ -91,7 +92,7 @@ public class Startup
                 return new ValueTask<bool>(false);
             }
 
-            return base.TransformResponseAsync(httpContext, proxyResponse);
+            return base.TransformResponseAsync(httpContext, proxyResponse, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
This PR does a few things:
- Marks `HttpTransformer` overloads without the `CancellationToken` as obsolete.
- Makes sure all scenarios work as expected with the built-in `StructuredTransformer` (you can call overloads with or without the CT and it'll work).
- Makes sure `HttpForwarder` always calls the overloads with the cancellation token.
- Moves request transform calls into the try/catch block with `HttpClient.SendAsync` so that any failures are reported in a similar manner. Also added `ForwarderError.RequestCreation` in case the exception is not related to cancellation.
- Switched the error reported if the manual CT is signaled to `RequestCanceled` (was `RequestTimedOut`).
- Added a bunch of tests for the above.