### PR TITLE
fix small mistake in transform documentation

### DIFF
--- a/docs/docfx/articles/transforms.md
+++ b/docs/docfx/articles/transforms.md
@@ -1049,7 +1049,7 @@ services.AddReverseProxy()
 ```C#
 internal class MyTransformProvider : ITransformProvider
 {
-    public void Validate(TransformValidationContext context)
+    public void Validate(TransformRouteValidationContext context)
     {
         // Check all routes for a custom property and validate the associated
         // transform data.


### PR DESCRIPTION
Replace TransformValidationContext with TransformRouteValidationContext in TransformFactory example. I noticed it was wrong when I copied the code into a project I"m working on. It is correct in the sample at https://github.com/microsoft/reverse-proxy/blob/main/samples/ReverseProxy.Transforms.Sample/MyTransformFactory.cs