### PR TITLE
Fix edge-case error attribution bug on WS downgrade

### DIFF
--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -191,6 +191,11 @@ internal sealed class HttpForwarder : IHttpForwarder
                         Version = HttpVersion.Version11,
                         VersionPolicy = HttpVersionPolicy.RequestVersionExact
                     };
+
+                    // Set the request back to null while we call into CreateRequestMessageAsync so that
+                    // potential exceptions are correctly treated as 'RequestCreation'.
+                    destinationRequest = null;
+
                     (destinationRequest, requestContent, _) = await CreateRequestMessageAsync(
                         context, destinationPrefix, transformer, config, isStreamingRequest, activityCancellationSource);
 


### PR DESCRIPTION
We determine whether to report `Request` vs `RequestCreation` based on whether `destinationRequest is null` or not.
If an exception was thrown by the request transform for the downgrade request, it would be reported as `Request` instead of `RequestCreation`.