### PR TITLE
Use Arcade's pool-providers.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,7 @@ variables:
     value: Release
   - name: runCodeQL3000
     value: ${{ and(ne(variables['System.TeamProject'], 'public'), or(eq(variables['Build.Reason'], 'Schedule'), and(eq(variables['Build.Reason'], 'Manual'), eq(parameters.runCodeQL3000, 'true')))) }}
+  - template: /eng/common/templates/variables/pool-providers.yml
   # Rely on task Arcade injects, not auto-injected build step.
   - name: skipComponentGovernanceDetection
     value: true
@@ -75,10 +76,10 @@ stages:
       - job: Windows
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: NetCore-Public
+            name: $(DncEngPublicBuildPool)
             demands: ImageOverride -equals windows.vs2019.amd64.open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
-            name: NetCore1ESPool-Internal
+            name: $(DncEngInternalBuildPool)
             demands: ImageOverride -equals windows.vs2019.amd64
         ${{ if eq(variables.runCodeQL3000, 'true') }}:
           # Component governance and SBOM creation are not needed here. Disable what Arcade would inject.


### PR DESCRIPTION
- import the variable template
- use the two variables it provides wherever we name the pool
  - future release branches will now automatically switch to the -Svc pools