### PR TITLE
Make Receiver's HttpClient extensible

### DIFF
--- a/src/Kubernetes.Controller/Protocol/Receiver.cs
+++ b/src/Kubernetes.Controller/Protocol/Receiver.cs
@@ -42,8 +42,6 @@ public class Receiver : BackgroundHostedService
 
     public override async Task RunAsync(CancellationToken cancellationToken)
     {
-        using var client = new HttpClient();
-
         while (!cancellationToken.IsCancellationRequested)
         {
             await _limiter.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -53,7 +51,7 @@ public class Receiver : BackgroundHostedService
 
             try
             {
-                using var stream = await client.GetStreamAsync(_options.ControllerUrl, cancellationToken).ConfigureAwait(false);
+                using var stream = await _options.Client.GetStreamAsync(_options.ControllerUrl, cancellationToken).ConfigureAwait(false);
                 using var reader = new StreamReader(stream, Encoding.UTF8, leaveOpen: true);
                 using var cancellation = cancellationToken.Register(stream.Close);
                 while (true)

--- a/src/Kubernetes.Controller/Protocol/Receiver.cs
+++ b/src/Kubernetes.Controller/Protocol/Receiver.cs
@@ -68,7 +68,7 @@ public class Receiver : BackgroundHostedService
             try
             {
                 var requestMessage = new HttpRequestMessage(HttpMethod.Get, _options.ControllerUrl);
-                var responseMessage = await _options.Client.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                var responseMessage = await _options.Client.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
                 using var stream = await responseMessage.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
                 using var reader = new StreamReader(stream, Encoding.UTF8, leaveOpen: true);
                 using var cancellation = cancellationToken.Register(stream.Close);

--- a/src/Kubernetes.Controller/Protocol/Receiver.cs
+++ b/src/Kubernetes.Controller/Protocol/Receiver.cs
@@ -35,6 +35,12 @@ public class Receiver : BackgroundHostedService
 
         _options = options.Value;
 
+        if (_options.Client == null)
+        {
+            _options.Client = new(_options.ClientHttpHandler ?? new HttpClientHandler());
+            _options.Client.Timeout = _options.ClientTimeout;
+        }
+
         // two requests per second after third failure
         _limiter = new Limiter(new Limit(2), 3);
         _proxyConfigProvider = proxyConfigProvider;

--- a/src/Kubernetes.Controller/Protocol/Receiver.cs
+++ b/src/Kubernetes.Controller/Protocol/Receiver.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
@@ -13,6 +15,7 @@ using Microsoft.Extensions.Options;
 using Yarp.Kubernetes.Controller.Configuration;
 using Yarp.Kubernetes.Controller.Hosting;
 using Yarp.Kubernetes.Controller.Rate;
+using Yarp.ReverseProxy.Forwarder;
 
 namespace Yarp.Kubernetes.Protocol;
 
@@ -37,8 +40,15 @@ public class Receiver : BackgroundHostedService
 
         if (_options.Client == null)
         {
-            _options.Client = new(_options.ClientHttpHandler ?? new HttpClientHandler());
-            _options.Client.Timeout = _options.ClientTimeout;
+            _options.Client = new(new SocketsHttpHandler
+            {
+                UseProxy = false,
+                AllowAutoRedirect = false,
+                AutomaticDecompression = DecompressionMethods.None,
+                UseCookies = false,
+                ActivityHeadersPropagator = new ReverseProxyPropagator(DistributedContextPropagator.Current),
+                ConnectTimeout = TimeSpan.FromSeconds(15),
+            });
         }
 
         // two requests per second after third failure
@@ -57,7 +67,9 @@ public class Receiver : BackgroundHostedService
 
             try
             {
-                using var stream = await _options.Client.GetStreamAsync(_options.ControllerUrl, cancellationToken).ConfigureAwait(false);
+                var requestMessage = new HttpRequestMessage(HttpMethod.Get, _options.ControllerUrl);
+                var responseMessage = await _options.Client.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
+                using var stream = await responseMessage.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
                 using var reader = new StreamReader(stream, Encoding.UTF8, leaveOpen: true);
                 using var cancellation = cancellationToken.Register(stream.Close);
                 while (true)

--- a/src/Kubernetes.Controller/Protocol/Receiver.cs
+++ b/src/Kubernetes.Controller/Protocol/Receiver.cs
@@ -68,7 +68,7 @@ public class Receiver : BackgroundHostedService
             try
             {
                 var requestMessage = new HttpRequestMessage(HttpMethod.Get, _options.ControllerUrl);
-                var responseMessage = await _options.Client.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
+                var responseMessage = await _options.Client.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                 using var stream = await responseMessage.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
                 using var reader = new StreamReader(stream, Encoding.UTF8, leaveOpen: true);
                 using var cancellation = cancellationToken.Register(stream.Close);

--- a/src/Kubernetes.Controller/Protocol/ReceiverOptions.cs
+++ b/src/Kubernetes.Controller/Protocol/ReceiverOptions.cs
@@ -2,10 +2,13 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Net.Http;
 
 namespace Yarp.Kubernetes.Protocol;
 
 public class ReceiverOptions
 {
     public Uri ControllerUrl { get; set; }
+
+    public HttpClient Client { get; set; } = default!;
 }

--- a/src/Kubernetes.Controller/Protocol/ReceiverOptions.cs
+++ b/src/Kubernetes.Controller/Protocol/ReceiverOptions.cs
@@ -10,5 +10,9 @@ public class ReceiverOptions
 {
     public Uri ControllerUrl { get; set; }
 
+    public TimeSpan ClientTimeout { get; set; } = TimeSpan.FromSeconds(60);
+
+    public HttpMessageHandler ClientHttpHandler { get; set; }
+
     public HttpClient Client { get; set; } = default!;
 }

--- a/src/Kubernetes.Controller/Protocol/ReceiverOptions.cs
+++ b/src/Kubernetes.Controller/Protocol/ReceiverOptions.cs
@@ -9,10 +9,6 @@ namespace Yarp.Kubernetes.Protocol;
 public class ReceiverOptions
 {
     public Uri ControllerUrl { get; set; }
-
-    public TimeSpan ClientTimeout { get; set; } = TimeSpan.FromSeconds(60);
-
-    public HttpMessageHandler ClientHttpHandler { get; set; }
-
-    public HttpClient Client { get; set; } = default!;
+    
+    public HttpMessageInvoker Client { get; set; }
 }


### PR DESCRIPTION
For #1926 , make Receiver's HttpClient instance from ReceiverOptions.