### PR TITLE
Update log level to warning for unsuccessful proxying

### DIFF
--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -990,7 +990,7 @@ internal sealed class HttpForwarder : IHttpForwarder
             "Proxying to {targetUrl} {version} {versionPolicy} {isStreaming}");
 
         private static readonly Action<ILogger, ForwarderError, string, Exception> _proxyError = LoggerMessage.Define<ForwarderError, string>(
-            LogLevel.Information,
+            LogLevel.Warning,
             EventIds.ForwardingError,
             "{error}: {message}");
 
@@ -1010,7 +1010,7 @@ internal sealed class HttpForwarder : IHttpForwarder
             "Unable to proxy the WebSocket using HTTP/2, server does not support HTTP/2. Retrying with HTTP/1.1. Disable HTTP/2 negotiation for improved performance.");
 
         private static readonly Action<ILogger, string?, Exception?> _invalidKeyHeader = LoggerMessage.Define<string?>(
-            LogLevel.Information,
+            LogLevel.Warning,
             EventIds.InvalidSecWebSocketKeyHeader,
             "Invalid Sec-WebSocket-Key header: '{key}'.");
 


### PR DESCRIPTION
Fixes #2025 

Warning level should be for any unsuccessful proxying, things YARP is able to recover from - e.g. destination going out, client-side problems with network- see [list in code](https://github.com/microsoft/reverse-proxy/blob/03a4d6a91b9b65f90e8c616bebc77e1338bec81a/src/ReverseProxy/Forwarder/HttpForwarder.cs#L1063-L1081).