### PR TITLE
Update distributed-tracing.md

### DIFF
--- a/docs/docfx/articles/distributed-tracing.md
+++ b/docs/docfx/articles/distributed-tracing.md
@@ -23,7 +23,7 @@ services.AddReverseProxy()
     .ConfigureHttpClient((context, handler) => handler.ActivityHeadersPropagator = null);
 ```
 
-[OpenTelemetry]: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/docs/trace/getting-started/README.md
+[OpenTelemetry]: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/docs/trace/getting-started-aspnetcore/README.md
 [Application Insights]: https://docs.microsoft.com/azure/azure-monitor/app/asp-net-core
 [B3 propagation]: https://github.com/openzipkin/b3-propagation
 [`DistributedContextPropagator`]: https://docs.microsoft.com/dotnet/api/system.diagnostics.distributedcontextpropagator


### PR DESCRIPTION
docs: The existing URL no longer exists, suggested updating to the asp-net core version as this is most likely one to be used.