### PR TITLE
Workaround EventListener bug when consuming metrics

### DIFF
--- a/src/TelemetryConsumption/EventListenerService.cs
+++ b/src/TelemetryConsumption/EventListenerService.cs
@@ -120,6 +120,14 @@ internal abstract class EventListenerService<TService, TTelemetryConsumer, TMetr
     {
         if (eventData.EventId == -1)
         {
+            if (!ReferenceEquals(eventData.EventSource, _eventSource))
+            {
+                // Workaround for https://github.com/dotnet/runtime/issues/31927
+                // EventCounters are published to all EventListeners, regardless of
+                // which EventSource providers a listener is enabled for.
+                return;
+            }
+
             // Throwing an exception here would crash the process
             if (eventData.EventName != "EventCounters" ||
                 eventData.Payload?.Count != 1 ||


### PR DESCRIPTION
Fixes #2102

I confirmed manually that this does resolve the issue. I'm not sure we can have a reliable test for this without tooling like `RemoteExecutor` since the EventSources and listeners are all global in a given process.