### PR TITLE
Fix docs on route metadata

### DIFF
--- a/samples/KubernetesIngress.Sample/README.md
+++ b/samples/KubernetesIngress.Sample/README.md
@@ -151,8 +151,8 @@ See https://microsoft.github.io/reverse-proxy/api/Yarp.ReverseProxy.Configuratio
 
 ```
 yarp.ingress.kubernetes.io/route-metadata: |
-  - Custom: "orange"
-  - Tenant: "12345"
+  Custom: "orange"
+  Tenant: "12345"
 ```
 
 #### Session Affinity


### PR DESCRIPTION
I recently tried using the Kubernetes Ingress controller pieces from this repository. While trying out some things I noticed that the doc wasn't correct on how metadata should be configured using annotations on the Ingress. If I did it the way the docs said I got the following error:

```
warn: Yarp.Kubernetes.Controller.Services.Reconciler[0]
      Uncaught exception occured while reconciling ingress default/minimal-ingress
      (Line: 1, Col: 1, Idx: 0) - (Line: 1, Col: 1, Idx: 0): Expected 'MappingStart', got 'SequenceStart' (at Line: 1, Col: 1, Idx: 0).
```

After removing the dashes from the annotation it worked correctly.