### PR TITLE
Remove erroneous test assert

### DIFF
--- a/test/ReverseProxy.FunctionalTests/HeaderTests.cs
+++ b/test/ReverseProxy.FunctionalTests/HeaderTests.cs
@@ -388,7 +388,6 @@ public class HeaderTests
             Assert.False(response.Headers.TryGetValues(HeaderNames.Location, out _));
             Assert.False(response.Headers.TryGetValues("Test-Extra", out _));
 
-            Assert.True(destinationTask.IsCompleted);
             await destinationTask;
         }
         finally


### PR DESCRIPTION
Hit in #2122

This condition doesn't add value to the test and is also wrong in a race - the thread pool is free to run the HttpClient continuations first, before completing the `destinationTask`.