### PR TITLE
Ingress status update fixes

### DIFF
--- a/samples/KubernetesIngress.Sample/Combined/ingress-controller.yaml
+++ b/samples/KubernetesIngress.Sample/Combined/ingress-controller.yaml
@@ -14,7 +14,9 @@ data:
       "Yarp": {
         "ControllerClass": "microsoft.com/ingress-yarp",
         "ServerCertificates": false,
-        "DefaultSslCertificate": "yarp/yarp-ingress-tls"
+        "DefaultSslCertificate": "yarp/yarp-ingress-tls",
+        "ControllerServiceName": "ingress-yarp-controller",
+        "ControllerServiceNamespace": "yarp"
       }
     }
 ---
@@ -56,6 +58,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - get
+- apiGroups:
   - networking.k8s.io
   - extensions
   - networking.internal.knative.dev
@@ -80,6 +88,7 @@ rules:
   resources:
   - ingresses/status
   verbs:
+  - get
   - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/samples/KubernetesIngress.Sample/Monitor/ingress-monitor.yaml
+++ b/samples/KubernetesIngress.Sample/Monitor/ingress-monitor.yaml
@@ -12,7 +12,9 @@ data:
   yarp.json: |
     {
       "Yarp": {
-        "ControllerClass": "microsoft.com/ingress-yarp"
+        "ControllerClass": "microsoft.com/ingress-yarp",
+        "ControllerServiceName": "yarp-controller",
+        "ControllerServiceNamespace": "yarp"
       }
     }
 ---
@@ -54,6 +56,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - get
+- apiGroups:
   - networking.k8s.io
   - extensions
   - networking.internal.knative.dev
@@ -78,6 +86,7 @@ rules:
   resources:
   - ingresses/status
   verbs:
+  - get
   - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/src/Kubernetes.Controller/Caching/ICache.cs
+++ b/src/Kubernetes.Controller/Caching/ICache.cs
@@ -23,5 +23,4 @@ public interface ICache
     bool TryGetReconcileData(NamespacedName key, out ReconcileData data);
     void GetKeys(List<NamespacedName> keys);
     IEnumerable<IngressData> GetIngresses();
-    bool IsYarpIngress(IngressData ingress);
 }

--- a/src/Kubernetes.Controller/Caching/IngressCache.cs
+++ b/src/Kubernetes.Controller/Caching/IngressCache.cs
@@ -151,14 +151,14 @@ public class IngressCache : ICache
         {
             foreach (var ns in _namespaceCaches)
             {
-                ingresses.AddRange(ns.Value.GetIngresses());
+                ingresses.AddRange(ns.Value.GetIngresses().Where(IsYarpIngress));
             }
         }
 
         return ingresses;
     }
 
-    public bool IsYarpIngress(IngressData ingress)
+    private bool IsYarpIngress(IngressData ingress)
     {
         if (ingress.Spec.IngressClassName is null)
         {

--- a/src/Kubernetes.Controller/Client/IIngressResourceStatusUpdater.cs
+++ b/src/Kubernetes.Controller/Client/IIngressResourceStatusUpdater.cs
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System.Collections.Generic;
-using k8s;
-using k8s.Models;
-using Microsoft.Extensions.Hosting;
-using System;
+
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,5 +11,5 @@ public interface IIngressResourceStatusUpdater
     /// <summary>
     /// Updates the status of cached ingresses.
     /// </summary>
-    Task UpdateStatusAsync();
+    Task UpdateStatusAsync(CancellationToken cancellationToken);
 }

--- a/src/Kubernetes.Controller/Services/Reconciler.cs
+++ b/src/Kubernetes.Controller/Services/Reconciler.cs
@@ -45,11 +45,6 @@ public partial class Reconciler : IReconciler
             {
                 try
                 {
-                    if (!_cache.IsYarpIngress(ingress))
-                    {
-                        continue;
-                    }
-
                     if (_cache.TryGetReconcileData(new NamespacedName(ingress.Metadata.NamespaceProperty, ingress.Metadata.Name), out var data))
                     {
                         var ingressContext = new YarpIngressContext(ingress, data.ServiceList, data.EndpointsList);

--- a/src/Kubernetes.Controller/Services/Reconciler.cs
+++ b/src/Kubernetes.Controller/Services/Reconciler.cs
@@ -68,7 +68,7 @@ public partial class Reconciler : IReconciler
             _logger.LogInformation(JsonSerializer.Serialize(clusters));
 
             await _updateConfig.UpdateAsync(configContext.Routes, clusters, cancellationToken).ConfigureAwait(false);
-            await _ingressResourceStatusUpdater.UpdateStatusAsync();
+            await _ingressResourceStatusUpdater.UpdateStatusAsync(cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Kubernetes.Controller/YarpOptions.cs
+++ b/src/Kubernetes.Controller/YarpOptions.cs
@@ -5,13 +5,25 @@ namespace Yarp.Kubernetes.Controller;
 
 public class YarpOptions
 {
+    /// <summary>
+    /// Defines a name of the ingress controller. IngressClass ".spec.controller" field should match this.
+    /// This field is required.
+    /// </summary>
     public string ControllerClass { get; set; }
 
     public bool ServerCertificates { get; set; }
 
     public string DefaultSslCertificate { get; set; }
 
+    /// <summary>
+    /// Name of the Kubernetes Service the ingress controller is running in.
+    /// This field is required.
+    /// </summary>
     public string ControllerServiceName { get; set; }
 
+    /// <summary>
+    /// Namespace of the Kubernetes Service the ingress controller is running in.
+    /// This field is required.
+    /// </summary>
     public string ControllerServiceNamespace { get; set; }
 }

--- a/test/Kubernetes.Tests/IngressCacheTests.cs
+++ b/test/Kubernetes.Tests/IngressCacheTests.cs
@@ -64,7 +64,7 @@ public class IngressCacheTests
         _cacheUnderTest.Update(WatchEventType.Added, ingress);
 
         // Assert
-        var ingresses = _cacheUnderTest.GetIngresses().Where(_cacheUnderTest.IsYarpIngress).ToArray();
+        var ingresses = _cacheUnderTest.GetIngresses().ToArray();
 
         Assert.Equal(expectedIngressCount, ingresses.Length);
     }
@@ -90,7 +90,7 @@ public class IngressCacheTests
         _cacheUnderTest.Update(WatchEventType.Added, ingress);
 
         // Assert
-        var ingresses = _cacheUnderTest.GetIngresses().Where(_cacheUnderTest.IsYarpIngress).ToArray();
+        var ingresses = _cacheUnderTest.GetIngresses().ToArray();
 
         Assert.Equal(expectedIngressCount, ingresses.Length);
     }
@@ -111,7 +111,7 @@ public class IngressCacheTests
 
         // Assert
         var ingresses = _cacheUnderTest.GetIngresses().ToArray();
-        Assert.All(ingresses, i => Assert.False(_cacheUnderTest.IsYarpIngress(i)));
+        Assert.Empty(ingresses);
     }
 
     [Fact]
@@ -149,7 +149,7 @@ public class IngressCacheTests
 
         // Assert
         var ingresses = _cacheUnderTest.GetIngresses().ToArray();
-        Assert.All(ingresses, i => Assert.False(_cacheUnderTest.IsYarpIngress(i)));
+        Assert.Empty(ingresses);
     }
 
     [Fact]


### PR DESCRIPTION
- Updates samples with required permissions and ingress controller options.
- Adds code documentation for required options.
- Fixes case when the ingress controller updates statuses of ingresses not belonging to the controller.

This should address #2018. Also refactors changes from #1953 to avoid future errors.