### PR TITLE
Enable AOT Compatibility

### DIFF
--- a/src/ReverseProxy/Forwarder/ForwarderTelemetry.cs
+++ b/src/ReverseProxy/Forwarder/ForwarderTelemetry.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 using System.Threading;
 
@@ -122,6 +123,8 @@ internal sealed class ForwarderTelemetry : EventSource
     }
 
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+        Justification = "Parameters to this method are primitive and are trimmer safe.")]
     [NonEvent]
     private unsafe void WriteEvent(int eventId, bool arg1, long arg2, long arg3, long arg4, long arg5)
     {
@@ -157,6 +160,8 @@ internal sealed class ForwarderTelemetry : EventSource
         WriteEventCore(eventId, NumEventDatas, descrs);
     }
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+        Justification = "Parameters to this method are primitive and are trimmer safe.")]
     [NonEvent]
     private unsafe void WriteEvent(int eventId, bool arg1, long arg2, long arg3, long arg4, long arg5, long arg6)
     {

--- a/src/ReverseProxy/Management/ReverseProxyServiceCollectionExtensions.cs
+++ b/src/ReverseProxy/Management/ReverseProxyServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net.Http;
 using Microsoft.Extensions.Configuration;
@@ -87,7 +88,7 @@ public static class ReverseProxyServiceCollectionExtensions
     /// Registers a singleton IProxyConfigFilter service. Multiple filters are allowed and they will be run in registration order.
     /// </summary>
     /// <typeparam name="TService">A class that implements IProxyConfigFilter.</typeparam>
-    public static IReverseProxyBuilder AddConfigFilter<TService>(this IReverseProxyBuilder builder) where TService : class, IProxyConfigFilter
+    public static IReverseProxyBuilder AddConfigFilter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TService>(this IReverseProxyBuilder builder) where TService : class, IProxyConfigFilter
     {
         if (builder is null)
         {
@@ -118,7 +119,7 @@ public static class ReverseProxyServiceCollectionExtensions
     /// Provides a <see cref="ITransformProvider"/> implementation that will be run for each route to conditionally add transforms.
     /// <see cref="AddTransforms{T}(IReverseProxyBuilder)"/> can be called multiple times to provide multiple distinct types.
     /// </summary>
-    public static IReverseProxyBuilder AddTransforms<T>(this IReverseProxyBuilder builder) where T : class, ITransformProvider
+    public static IReverseProxyBuilder AddTransforms<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IReverseProxyBuilder builder) where T : class, ITransformProvider
     {
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ITransformProvider, T>());
         return builder;
@@ -129,7 +130,7 @@ public static class ReverseProxyServiceCollectionExtensions
     /// the associated transform actions. <see cref="AddTransformFactory{T}(IReverseProxyBuilder)"/> can be called multiple
     /// times to provide multiple distinct types.
     /// </summary>
-    public static IReverseProxyBuilder AddTransformFactory<T>(this IReverseProxyBuilder builder) where T : class, ITransformFactory
+    public static IReverseProxyBuilder AddTransformFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IReverseProxyBuilder builder) where T : class, ITransformFactory
     {
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ITransformFactory, T>());
         return builder;

--- a/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetry.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetry.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 
 namespace Yarp.ReverseProxy.WebSocketsTelemetry;
@@ -10,6 +11,8 @@ internal sealed class WebSocketsTelemetry : EventSource
 {
     public static readonly WebSocketsTelemetry Log = new();
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+        Justification = "Parameters to this method are primitive and are trimmer safe.")]
     [Event(1, Level = EventLevel.Informational)]
     public void WebSocketClosed(long establishedTime, WebSocketCloseReason closeReason, long messagesRead, long messagesWritten)
     {

--- a/src/ReverseProxy/Yarp.ReverseProxy.csproj
+++ b/src/ReverseProxy/Yarp.ReverseProxy.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>Yarp.ReverseProxy</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
+    <IsAotCompatible>true</IsAotCompatible>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 


### PR DESCRIPTION
Add `IsAotCompatible=true` to Yarp.ReverseProxy, which enables trimming and AOT analyzers.

Address the current warnings.

cc @agocke @karelz @adityamandaleeka 