### PR TITLE
Enable AOT compatibility for Yarp.Telemetry.Consumption

### DIFF
--- a/src/Kubernetes.Controller/Management/KubernetesReverseProxyServiceCollectionExtensions.cs
+++ b/src/Kubernetes.Controller/Management/KubernetesReverseProxyServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using k8s;
 using k8s.Models;
 using Microsoft.Extensions.Configuration;
@@ -122,7 +123,7 @@ public static class KubernetesReverseProxyServiceCollectionExtensions
     /// <param name="services">The services.</param>
     /// <param name="fieldSelector">A field selector to constrain the resources the informer retrieves.</param>
     /// <returns>IServiceCollection.</returns>
-    public static IServiceCollection RegisterResourceInformer<TResource, TService>(this IServiceCollection services, string fieldSelector)
+    public static IServiceCollection RegisterResourceInformer<TResource, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TService>(this IServiceCollection services, string fieldSelector)
         where TResource : class, IKubernetesObject<V1ObjectMeta>, new()
         where TService : IResourceInformer<TResource>
     {

--- a/src/TelemetryConsumption/TelemetryConsumptionExtensions.cs
+++ b/src/TelemetryConsumption/TelemetryConsumptionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Yarp.Telemetry.Consumption;
 
@@ -86,7 +87,7 @@ public static class TelemetryConsumptionExtensions
     /// <summary>
     /// Registers a <typeparamref name="TConsumer"/> singleton for every I*TelemetryConsumer interface it implements.
     /// </summary>
-    public static IServiceCollection AddTelemetryConsumer<TConsumer>(this IServiceCollection services)
+    public static IServiceCollection AddTelemetryConsumer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TConsumer>(this IServiceCollection services)
         where TConsumer : class
     {
         var implementsAny = false;
@@ -201,7 +202,7 @@ public static class TelemetryConsumptionExtensions
     /// <summary>
     /// Registers a consumer singleton for every IMetricsConsumer interface it implements.
     /// </summary>
-    public static IServiceCollection AddMetricsConsumer<TConsumer>(this IServiceCollection services)
+    public static IServiceCollection AddMetricsConsumer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TConsumer>(this IServiceCollection services)
         where TConsumer : class
     {
         var implementsAny = false;

--- a/src/TelemetryConsumption/Yarp.Telemetry.Consumption.csproj
+++ b/src/TelemetryConsumption/Yarp.Telemetry.Consumption.csproj
@@ -6,6 +6,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Yarp.Telemetry.Consumption</RootNamespace>
     <Nullable>enable</Nullable>
+    <IsAotCompatible>true</IsAotCompatible>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 


### PR DESCRIPTION
Also fix a simple warning in Yarp.Kubernetes.Controller. The rest of the warnings in this project will be addressed in https://github.com/microsoft/reverse-proxy/issues/2145.

Follow up to https://github.com/microsoft/reverse-proxy/pull/2144#issuecomment-1561269092