### PR TITLE
Forwarder blame improvements

### DIFF
--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -416,7 +416,7 @@ internal sealed class HttpForwarder : IHttpForwarder
 
         // :: Step 2: Setup copy of request body (background) Client --► Proxy --► Destination
         // Note that we must do this before step (3) because step (3) may also add headers to the HttpContent that we set up here.
-        var requestContent = SetupRequestBodyCopy(context.Request, isStreamingRequest, activityToken);
+        var requestContent = SetupRequestBodyCopy(context, isStreamingRequest, activityToken);
         destinationRequest.Content = requestContent;
 
         // :: Step 3: Copy request headers Client --► Proxy --► Destination
@@ -496,12 +496,13 @@ internal sealed class HttpForwarder : IHttpForwarder
         // else not an upgrade, or H2->H2, no changes needed
     }
 
-    private StreamCopyHttpContent? SetupRequestBodyCopy(HttpRequest request, bool isStreamingRequest, ActivityCancellationTokenSource activityToken)
+    private StreamCopyHttpContent? SetupRequestBodyCopy(HttpContext context, bool isStreamingRequest, ActivityCancellationTokenSource activityToken)
     {
         // If we generate an HttpContent without a Content-Length then for HTTP/1.1 HttpClient will add a Transfer-Encoding: chunked header
         // even if it's a GET request. Some servers reject requests containing a Transfer-Encoding header if they're not expecting a body.
         // Try to be as specific as possible about the client's intent to send a body. The one thing we don't want to do is to start
         // reading the body early because that has side-effects like 100-continue.
+        var request = context.Request;
         var hasBody = true;
         var contentLength = request.Headers.ContentLength;
         var method = request.Method;
@@ -512,8 +513,9 @@ internal sealed class HttpForwarder : IHttpForwarder
             // 5.0 servers provide a definitive answer for us.
             hasBody = canHaveBodyFeature.CanHaveBody;
 
-            // TODO: Kestrel bug, this shouldn't be true for ExtendedConnect.
-#if NET7_0_OR_GREATER
+#if NET7_0
+            // TODO: Kestrel 7.0 bug only, hasBody shouldn't be true for ExtendedConnect.
+            // https://github.com/dotnet/aspnetcore/issues/46002 Fixed in 8.0
             var connectFeature = request.HttpContext.Features.Get<IHttpExtendedConnectFeature>();
             if (connectFeature?.IsExtendedConnect == true)
             {
@@ -560,31 +562,13 @@ internal sealed class HttpForwarder : IHttpForwarder
 
         if (hasBody)
         {
-            if (isStreamingRequest)
-            {
-                DisableMinRequestBodyDataRateAndMaxRequestBodySize(request.HttpContext);
-            }
-
-            // Note on `autoFlushHttpClientOutgoingStream: isStreamingRequest`:
-            // The.NET Core HttpClient stack keeps its own buffers on top of the underlying outgoing connection socket.
-            // We flush those buffers down to the socket on every write when this is set,
-            // but it does NOT result in calls to flush on the underlying socket.
-            // This is necessary because we proxy http2 transparently,
-            // and we are deliberately unaware of packet structure used e.g. in gRPC duplex channels.
-            // Because the sockets aren't flushed, the perf impact of this choice is expected to be small.
-            // Future: It may be wise to set this to true for *all* http2 incoming requests,
-            // but for now, out of an abundance of caution, we only do it for requests that look like gRPC.
-            return new StreamCopyHttpContent(
-                request: request,
-                autoFlushHttpClientOutgoingStream: isStreamingRequest,
-                timeProvider: _timeProvider,
-                activityToken);
+            return new StreamCopyHttpContent(context, isStreamingRequest, _timeProvider, _logger, activityToken);
         }
 
         return null;
     }
 
-    private ForwarderError HandleRequestBodyFailure(HttpContext context, StreamCopyResult requestBodyCopyResult, Exception requestBodyException, Exception additionalException)
+    private ForwarderError HandleRequestBodyFailure(HttpContext context, StreamCopyResult requestBodyCopyResult, Exception requestBodyException, Exception additionalException, bool timedOut)
     {
         ForwarderError requestBodyError;
         int statusCode;
@@ -593,19 +577,12 @@ internal sealed class HttpForwarder : IHttpForwarder
             // Failed while trying to copy the request body from the client. It's ambiguous if the request or response failed first.
             case StreamCopyResult.InputError:
                 requestBodyError = ForwarderError.RequestBodyClient;
-                statusCode = StatusCodes.Status400BadRequest;
+                statusCode = timedOut ? StatusCodes.Status408RequestTimeout : StatusCodes.Status400BadRequest;
                 break;
             // Failed while trying to copy the request body to the destination. It's ambiguous if the request or response failed first.
             case StreamCopyResult.OutputError:
                 requestBodyError = ForwarderError.RequestBodyDestination;
-                statusCode = StatusCodes.Status502BadGateway;
-                break;
-            // Canceled while trying to copy the request body, either due to a client disconnect or a timeout. This probably caused the response to fail as a secondary error.
-            case StreamCopyResult.Canceled:
-                requestBodyError = ForwarderError.RequestBodyCanceled;
-                // Timeouts (504s) are handled at the SendAsync call site.
-                // The request body should only be canceled by the RequestAborted token.
-                statusCode = StatusCodes.Status502BadGateway;
+                statusCode = timedOut ? StatusCodes.Status504GatewayTimeout : StatusCodes.Status502BadGateway;
                 break;
             default:
                 throw new NotImplementedException(requestBodyCopyResult.ToString());
@@ -630,31 +607,44 @@ internal sealed class HttpForwarder : IHttpForwarder
     private async ValueTask<ForwarderError> HandleRequestFailureAsync(HttpContext context, StreamCopyHttpContent? requestContent, Exception requestException,
         HttpTransformer transformer, ActivityCancellationTokenSource requestCancellationSource, bool failedDuringRequestCreation)
     {
-        if (requestException is OperationCanceledException)
+        var triedRequestBody = requestContent?.ConsumptionTask.IsCompleted == true;
+
+        if (requestCancellationSource.CancelledByLinkedToken)
         {
-            if (requestCancellationSource.CancelledByLinkedToken)
+            var requestBodyCanceled = false;
+            if (triedRequestBody)
             {
-                // Either the client went away (HttpContext.RequestAborted) or the CancellationToken provided to SendAsync was signaled.
-                return await ReportErrorAsync(ForwarderError.RequestCanceled, StatusCodes.Status502BadGateway);
+                var (requestBodyCopyResult, requestBodyException) = requestContent!.ConsumptionTask.Result;
+                requestBodyCanceled = requestBodyCopyResult == StreamCopyResult.Canceled;
+                if (requestBodyCanceled)
+                {
+                    requestException = new AggregateException(requestException, requestBodyException!);
+                }
             }
-            else
-            {
-                Debug.Assert(requestCancellationSource.IsCancellationRequested || requestException.ToString().Contains("ConnectTimeout"), requestException.ToString());
-                return await ReportErrorAsync(ForwarderError.RequestTimedOut, StatusCodes.Status504GatewayTimeout);
-            }
+            // Either the client went away (HttpContext.RequestAborted) or the CancellationToken provided to SendAsync was signaled.
+            return await ReportErrorAsync(requestBodyCanceled ? ForwarderError.RequestBodyCanceled : ForwarderError.RequestCanceled,
+                context.RequestAborted.IsCancellationRequested ? StatusCodes.Status400BadRequest : StatusCodes.Status502BadGateway);
         }
 
         // Check for request body errors, these may have triggered the response error.
-        if (requestContent?.ConsumptionTask.IsCompleted == true)
+        if (triedRequestBody)
         {
-            var (requestBodyCopyResult, requestBodyException) = requestContent.ConsumptionTask.Result;
+            var (requestBodyCopyResult, requestBodyException) = requestContent!.ConsumptionTask.Result;
 
-            if (requestBodyCopyResult != StreamCopyResult.Success)
+            if (requestBodyCopyResult is StreamCopyResult.InputError or StreamCopyResult.OutputError)
             {
-                var error = HandleRequestBodyFailure(context, requestBodyCopyResult, requestBodyException!, requestException);
+                var error = HandleRequestBodyFailure(context, requestBodyCopyResult, requestBodyException!, requestException,
+                    timedOut: requestCancellationSource.IsCancellationRequested);
                 await transformer.TransformResponseAsync(context, proxyResponse: null, requestCancellationSource.Token);
                 return error;
             }
+        }
+
+        if (requestException is OperationCanceledException)
+        {
+            Debug.Assert(requestCancellationSource.IsCancellationRequested || requestException.ToString().Contains("ConnectTimeout"), requestException.ToString());
+
+            return await ReportErrorAsync(ForwarderError.RequestTimedOut, StatusCodes.Status504GatewayTimeout);
         }
 
         // We couldn't communicate with the destination.
@@ -870,7 +860,7 @@ internal sealed class HttpForwarder : IHttpForwarder
         return (StreamCopyResult.Success, null);
     }
 
-    private async ValueTask<ForwarderError> HandleResponseBodyErrorAsync(HttpContext context, StreamCopyHttpContent? requestContent, StreamCopyResult responseBodyCopyResult, Exception responseBodyException, CancellationTokenSource requestCancellationSource)
+    private async ValueTask<ForwarderError> HandleResponseBodyErrorAsync(HttpContext context, StreamCopyHttpContent? requestContent, StreamCopyResult responseBodyCopyResult, Exception responseBodyException, ActivityCancellationTokenSource requestCancellationSource)
     {
         if (requestContent is not null && requestContent.Started)
         {
@@ -884,9 +874,10 @@ internal sealed class HttpForwarder : IHttpForwarder
             var (requestBodyCopyResult, requestBodyError) = await requestContent.ConsumptionTask;
 
             // Check for request body errors, these may have triggered the response error.
-            if (alreadyFinished && requestBodyCopyResult != StreamCopyResult.Success)
+            if (alreadyFinished && requestBodyCopyResult is StreamCopyResult.InputError or StreamCopyResult.OutputError)
             {
-                return HandleRequestBodyFailure(context, requestBodyCopyResult, requestBodyError!, responseBodyException);
+                return HandleRequestBodyFailure(context, requestBodyCopyResult, requestBodyError!, responseBodyException,
+                    timedOut: requestCancellationSource.IsCancellationRequested && !requestCancellationSource.CancelledByLinkedToken);
             }
         }
 
@@ -918,41 +909,6 @@ internal sealed class HttpForwarder : IHttpForwarder
     {
         // Copies trailers
         return transformer.TransformResponseTrailersAsync(context, source, cancellationToken);
-    }
-
-
-    /// <summary>
-    /// Disable some ASP .NET Core server limits so that we can handle long-running gRPC requests unconstrained.
-    /// Note that the gRPC server implementation on ASP .NET Core does the same for client-streaming and duplex methods.
-    /// Since in Gateway we have no way to determine if the current request requires client-streaming or duplex comm,
-    /// we do this for *all* incoming requests that look like they might be gRPC.
-    /// </summary>
-    /// <remarks>
-    /// Inspired on
-    /// <see href="https://github.com/grpc/grpc-dotnet/blob/3ce9b104524a4929f5014c13cd99ba9a1c2431d4/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerCallHandlerBase.cs#L127"/>.
-    /// </remarks>
-    private void DisableMinRequestBodyDataRateAndMaxRequestBodySize(HttpContext httpContext)
-    {
-        var minRequestBodyDataRateFeature = httpContext.Features.Get<IHttpMinRequestBodyDataRateFeature>();
-        if (minRequestBodyDataRateFeature is not null)
-        {
-            minRequestBodyDataRateFeature.MinDataRate = null;
-        }
-
-        var maxRequestBodySizeFeature = httpContext.Features.Get<IHttpMaxRequestBodySizeFeature>();
-        if (maxRequestBodySizeFeature is not null)
-        {
-            if (!maxRequestBodySizeFeature.IsReadOnly)
-            {
-                maxRequestBodySizeFeature.MaxRequestBodySize = null;
-            }
-            else
-            {
-                // IsReadOnly could be true if middleware has already started reading the request body
-                // In that case we can't disable the max request body size for the request stream
-                _logger.LogWarning("Unable to disable max request body size.");
-            }
-        }
     }
 
     private void ReportProxyError(HttpContext context, ForwarderError error, Exception ex)

--- a/src/ReverseProxy/Forwarder/StreamCopier.cs
+++ b/src/ReverseProxy/Forwarder/StreamCopier.cs
@@ -124,9 +124,13 @@ internal static class StreamCopier
                 telemetry?.AfterWrite();
             }
 
-            var result = ex is OperationCanceledException ? StreamCopyResult.Canceled :
-                (read == 0 ? StreamCopyResult.InputError : StreamCopyResult.OutputError);
+            if (activityToken.CancelledByLinkedToken)
+            {
+                return (StreamCopyResult.Canceled, ex);
+            }
 
+            // If the activity timeout triggered while reading or writing, blame the sender or receiver.
+            var result = read == 0 ? StreamCopyResult.InputError : StreamCopyResult.OutputError;
             return (result, ex);
         }
         finally

--- a/test/ReverseProxy.Tests/Forwarder/StreamCopierTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/StreamCopierTests.cs
@@ -102,8 +102,9 @@ public class StreamCopierTests : TestAutoMockBase
         var source = new MemoryStream(new byte[10]);
         var destination = new MemoryStream();
 
-        using var cts = ActivityCancellationTokenSource.Rent(TimeSpan.FromSeconds(10), CancellationToken.None);
-        cts.Cancel();
+        var requestCts = new CancellationTokenSource();
+        using var cts = ActivityCancellationTokenSource.Rent(TimeSpan.FromSeconds(10), requestCts.Token);
+        requestCts.Cancel();
         var (result, error) = await StreamCopier.CopyAsync(isRequest, source, destination, StreamCopier.UnknownLength, new TestTimeProvider(), cts, cts.Token);
         Assert.Equal(StreamCopyResult.Canceled, result);
         Assert.IsAssignableFrom<OperationCanceledException>(error);

--- a/test/ReverseProxy.Tests/Forwarder/StreamCopyHttpContentTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/StreamCopyHttpContentTests.cs
@@ -8,24 +8,23 @@ using System.Net.Http;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
-using Yarp.Tests.Common;
 using Yarp.ReverseProxy.Utilities;
-using Microsoft.AspNetCore.Http;
+using Yarp.Tests.Common;
 
 namespace Yarp.ReverseProxy.Forwarder.Tests;
 
 public class StreamCopyHttpContentTests
 {
-    private static StreamCopyHttpContent CreateContent(HttpRequest request = null, bool autoFlushHttpClientOutgoingStream = false, TimeProvider timeProvider = null, ActivityCancellationTokenSource contentCancellation = null)
+    private static StreamCopyHttpContent CreateContent(HttpContext context = null, bool isStreamingRequest = false, TimeProvider timeProvider = null, ActivityCancellationTokenSource contentCancellation = null)
     {
-        request ??= new DefaultHttpContext().Request;
+        context ??= new DefaultHttpContext();
         timeProvider ??= TimeProvider.System;
-
         contentCancellation ??= ActivityCancellationTokenSource.Rent(TimeSpan.FromSeconds(10), CancellationToken.None);
-
-        return new StreamCopyHttpContent(request, autoFlushHttpClientOutgoingStream, timeProvider, contentCancellation);
+        return new StreamCopyHttpContent(context, isStreamingRequest, timeProvider, NullLogger.Instance, contentCancellation);
     }
 
     [Fact]
@@ -34,11 +33,11 @@ public class StreamCopyHttpContentTests
         const int SourceSize = (128 * 1024) - 3;
 
         var sourceBytes = Enumerable.Range(0, SourceSize).Select(i => (byte)(i % 256)).ToArray();
-        var request = new DefaultHttpContext().Request;
-        request.Body = new MemoryStream(sourceBytes);
+        var context = new DefaultHttpContext();
+        context.Request.Body = new MemoryStream(sourceBytes);
         var destination = new MemoryStream();
 
-        var sut = CreateContent(request);
+        var sut = CreateContent(context);
 
         Assert.False(sut.ConsumptionTask.IsCompleted);
         Assert.False(sut.Started);
@@ -68,12 +67,12 @@ public class StreamCopyHttpContentTests
         expectedFlushes++;
 
         var sourceBytes = Enumerable.Range(0, SourceSize).Select(i => (byte)(i % 256)).ToArray();
-        var request = new DefaultHttpContext().Request;
-        request.Body = new MemoryStream(sourceBytes);
+        var context = new DefaultHttpContext();
+        context.Request.Body = new MemoryStream(sourceBytes);
         var destination = new MemoryStream();
         var flushCountingDestination = new FlushCountingStream(destination);
 
-        var sut = CreateContent(request, autoFlushHttpClientOutgoingStream: autoFlush);
+        var sut = CreateContent(context, autoFlush);
 
         Assert.False(sut.ConsumptionTask.IsCompleted);
         Assert.False(sut.Started);
@@ -91,11 +90,11 @@ public class StreamCopyHttpContentTests
         var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
         var source = new Mock<Stream>();
         source.Setup(s => s.ReadAsync(It.IsAny<Memory<byte>>(), It.IsAny<CancellationToken>())).Returns(() => new ValueTask<int>(tcs.Task));
-        var request = new DefaultHttpContext().Request;
-        request.Body = source.Object;
+        var context = new DefaultHttpContext();
+        context.Request.Body = source.Object;
         var destination = new MemoryStream();
 
-        var sut = CreateContent(request);
+        var sut = CreateContent(context);
 
         Assert.False(sut.ConsumptionTask.IsCompleted);
         Assert.False(sut.Started);
@@ -151,12 +150,12 @@ public class StreamCopyHttpContentTests
             return 0;
         });
 
-        var request = new DefaultHttpContext().Request;
-        request.Body = source;
+        var context = new DefaultHttpContext();
+        context.Request.Body = source;
 
         using var contentCts = ActivityCancellationTokenSource.Rent(TimeSpan.FromSeconds(10), CancellationToken.None);
 
-        var sut = CreateContent(request, contentCancellation: contentCts);
+        var sut = CreateContent(context, contentCancellation: contentCts);
 
         var copyToTask = sut.CopyToWithCancellationAsync(new MemoryStream());
         contentCts.Cancel();
@@ -183,10 +182,10 @@ public class StreamCopyHttpContentTests
             return 0;
         });
 
-        var request = new DefaultHttpContext().Request;
-        request.Body = source;
+        var context = new DefaultHttpContext();
+        context.Request.Body = source;
 
-        var sut = CreateContent(request);
+        var sut = CreateContent(context);
 
         using var cts = new CancellationTokenSource();
         var copyToTask = sut.CopyToAsync(new MemoryStream(), cts.Token);


### PR DESCRIPTION
Passive health checks rely on ForwarderError's reported by HttpForwarder to determine if the client, destination, or proxy was to blame for the failure. These are some improvements to how blame is attributed based on different error conditions.