### PR TITLE
add cluster destination address validation

### DIFF
--- a/src/ReverseProxy/Configuration/ConfigValidator.cs
+++ b/src/ReverseProxy/Configuration/ConfigValidator.cs
@@ -112,6 +112,7 @@ internal sealed class ConfigValidator : IConfigValidator
         }
 
         errors.AddRange(_transformBuilder.ValidateCluster(cluster));
+        ValidateDestinations(errors, cluster);
         ValidateLoadBalancing(errors, cluster);
         ValidateSessionAffinity(errors, cluster);
         ValidateProxyHttpClient(errors, cluster);
@@ -363,6 +364,21 @@ internal sealed class ConfigValidator : IConfigValidator
         catch (Exception ex)
         {
             errors.Add(new ArgumentException($"Unable to retrieve the CORS policy '{corsPolicyName}' for route '{routeId}'.", ex));
+        }
+    }
+
+    private void ValidateDestinations(IList<Exception> errors, ClusterConfig cluster)
+    {
+        if (cluster.Destinations is null)
+        {
+            return;
+        }
+        foreach (var (name, destination) in cluster.Destinations)
+        {
+            if (string.IsNullOrEmpty(destination.Address))
+            {
+                errors.Add(new ArgumentException($"No address found for destination '{name}' on cluster '{cluster.ClusterId}'."));
+            }
         }
     }
 


### PR DESCRIPTION
closes #2175

This PR adds validation that the destination address in a cluster config is not null or empty. It's possible that the destination property of the cluster is null or empty, I decided not to validate that because it was not clear if that should be considered valid. I chose to not report that as an error. If it should be an error, then all the Validation unit tests would need to be updated as they currently expect null destinations to not produce an error.