### PR TITLE
Enable BinSkim scan in nightly validation

### DIFF
--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -1,4 +1,5 @@
 -SourceToolsList @("policheck","credscan")
+-ArtifactToolsList @("binskim")
 -TsaInstanceURL https://devdiv.visualstudio.com/
 -TsaProjectName DEVDIV
 -TsaNotificationEmail dotnetrp@microsoft.com


### PR DESCRIPTION
Enabling BinSkim scan over build artifacts in [Validate-DotNet pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=827) and the .NET staging pipeline based on company requirements.

We are required to run SDL tools on official builds and implement automated bug filling for the tools output. Currently we are running SDL checks over the source code in the nightly builds and in the .NET staging pipeline, but to be compliant we need to also run BinSkim over the produced artifacts.

This PRs is enabling BinSkim checks in the nightly run of [Validate-DotNet pipeline](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdev.azure.com%2Fdnceng%2Finternal%2F_build%3FdefinitionId%3D827&data=05%7C01%7Capatsula%40microsoft.com%7Cf299e81d804d48e6c88008db73cfb359%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638231108144663200%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=T4Pt4cQfNKPlP9c7zXUlkSSgSd7IA06iatPgAAUmb%2F8%3D&reserved=0).

More information is in the [Automate BinSkim runs over official builds issue](https://github.com/dotnet/arcade-services/issues/2647) 