### PR TITLE
Overload constructors for ClusterState and DestinationState to enable unit testing

### DIFF
--- a/src/ReverseProxy/Model/ClusterState.cs
+++ b/src/ReverseProxy/Model/ClusterState.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Http;
+using Yarp.ReverseProxy.Configuration;
 using Yarp.ReverseProxy.Utilities;
 
 namespace Yarp.ReverseProxy.Model;
@@ -22,6 +24,16 @@ public sealed class ClusterState
     public ClusterState(string clusterId)
     {
         ClusterId = clusterId ?? throw new ArgumentNullException(nameof(clusterId));
+    }
+
+    /// <summary>
+    /// Constructor overload to additionally initialize the <see cref="ClusterModel"/> for tests and infrastructure,
+    /// such as updating the <see cref="ReverseProxyFeature"/> via <see cref="HttpContextFeaturesExtensions"/>
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="model"/> is <see langword="null"/>.</exception>
+    public ClusterState(string clusterId, ClusterModel model) : this(clusterId)
+    {
+        Model = model ?? throw new ArgumentNullException(nameof(model));
     }
 
     /// <summary>

--- a/src/ReverseProxy/Model/DestinationState.cs
+++ b/src/ReverseProxy/Model/DestinationState.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
 using Yarp.ReverseProxy.Utilities;
 
 namespace Yarp.ReverseProxy.Model;
@@ -26,6 +27,16 @@ public sealed class DestinationState : IReadOnlyList<DestinationState>
             throw new ArgumentNullException(nameof(destinationId));
         }
         DestinationId = destinationId;
+    }
+
+    /// <summary>
+    /// Constructor overload to additionally initialize the <see cref="DestinationModel"/> for tests and infrastructure,
+    /// such as updating the <see cref="ReverseProxyFeature"/> via <see cref="HttpContextFeaturesExtensions"/>
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="model"/> is <see langword="null"/>.</exception>
+    public DestinationState(string destinationId, DestinationModel model) : this(destinationId)
+    {
+        Model = model ?? throw new ArgumentNullException(nameof(model));
     }
 
     /// <summary>


### PR DESCRIPTION
This addresses two open issues, #2142 and #1792, related to difficulties in unit testing custom middleware due to the inability to initialize/modify ClusterState and DestinationState.

The `ClusterState` and `DestinationState` constructors are now overloaded to accept additional parameters, which enables better unit testing when updating the `ReverseProxyFeature` via `HttpContextFeaturesExtensions`. 

However it's worth noting that lifting these restrictions may allow the user to set the state in the `ReverseProxyFeature` that may potentially cause unintended side effects. Once I started diving deeper into the code, it seemed that there is some level of dependency on the immutable design, as there is logic related to making the state eventually consistent; I believe that's why there is some duplicate data such as the clusterId and destination configurations in the nested objects of `ClusterState`. But it seems that this potential risk was present before these changes, so it's most likely acceptable in a unit testing context.

Here is a sample of leveraging these new constructors in the context of the two open issues
```
    public void Configure(IApplicationBuilder app, IProxyStateLookup lookup)
    {
        app.UseRouting();
        app.UseAuthorization();
        app.UseEndpoints(endpoints =>
        {
            endpoints.MapControllers();
            endpoints.MapReverseProxy(proxyPipeline =>
            {
                proxyPipeline.Use((context, next) =>
                {
                    if (lookup.TryGetCluster("cluster2", out var cluster))
                    {
                        var newDestinationId = "destination3";
                        var newDestinationConfig = new DestinationConfig {
                            Address = "https://127.0.0.1:123/abcd1234/",
                            Health = "http://127.0.0.1:1234/"
                        };

                        var reverseProxyFeature = context.Features.Get<IReverseProxyFeature>();
                        // key-value stored in Metadata to trigger update
                        if(reverseProxyFeature.AvailableDestinations.Any(x => x.Model.Config.Metadata?["key"] != null)) {
                            var destinationNew = new DestinationState(
                                newDestinationId,
                                new DestinationModel(newDestinationConfig)
                            );

                            cluster = new ClusterState("cluster3", new ClusterModel(
                                    new ClusterConfig {
                                        ClusterId = "cluster3",
                                        Destinations =
                                            new Dictionary<string, DestinationConfig>(StringComparer
                                                .OrdinalIgnoreCase) { { destinationNew.DestinationId, destinationNew.Model.Config } }
                                    },
                                    new HttpMessageInvoker(new HttpClientHandler())
                                )
                            );

                            cluster.DestinationsState = new ClusterDestinationsState(
                                reverseProxyFeature.AllDestinations,
                                new List<DestinationState> { destinationNew }
                            );

                            context.ReassignProxyRequest(cluster);
                        }
                    }

                    return next();
                });
                proxyPipeline.UseSessionAffinity();
                proxyPipeline.UseLoadBalancing();
            });
        });
    }
```

These changes offer better granularity for unit testing through reassigning the `ReverseProxyFeature` with a `ClusterState`, via creating/modifying the `ClusterModel` along with its `ClusterConfig`, and the `DestinationState`s of the `AllDestinations` and `AllDestinations` properties with their associated `DestinationModel`s and `DestinationConfig`s.


