### PR TITLE
Changed streaming flag to empty string when logging no gRPC request

### DIFF
--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -980,7 +980,7 @@ internal sealed class HttpForwarder : IHttpForwarder
             // Avoid computing the AbsoluteUri unless logging is enabled
             if (logger.IsEnabled(LogLevel.Information))
             {
-                var streaming = isStreamingRequest ? "streaming" : "no-streaming";
+                var streaming = isStreamingRequest ? "streaming" : string.Empty;
                 var version = HttpProtocol.GetHttpProtocol(msg.Version);
                 var versionPolicy = ProtocolHelper.GetVersionPolicy(msg.VersionPolicy);
                 _proxying(logger, msg.RequestUri!.AbsoluteUri, version, versionPolicy, streaming, null);


### PR DESCRIPTION
As agreed in [issue](https://github.com/microsoft/reverse-proxy/issues/2194) I've changed `no-streaming` flag to empty string when logging request that is not an gRPC request.