### PR TITLE
Expose a public ConcurrentRequestCount property on ClusterState, like DestinationState

### DIFF
--- a/src/ReverseProxy/Model/ClusterState.cs
+++ b/src/ReverseProxy/Model/ClusterState.cs
@@ -70,6 +70,14 @@ public sealed class ClusterState
     /// <summary>
     /// Keeps track of the total number of concurrent requests on this cluster.
     /// </summary>
+    public int ConcurrentRequestCount
+    {
+        get => ConcurrencyCounter.Value;
+    }
+
+    /// <summary>
+    /// Keeps track of the total number of concurrent requests on this cluster.
+    /// </summary>
     internal AtomicCounter ConcurrencyCounter { get; } = new AtomicCounter();
 
     /// <summary>


### PR DESCRIPTION
We use different clusters for rolling out updates to our software. To support rollout we want each YARP server to monitor the outgoing clusters for remaining connections. When this drops to zero for a cluster, the YARP server communicates this to a central location and drops the reference to the ClusterState. Once all YARP servers have reported the cluster as drained (or a timeout occurs) we mark the deployment as complete.

DestinationState has a public ConcurrentRequestCount property that works the same way, by exposing `ConcurrencyCounter.Value`. I didn't add the setter in this PR (DestinationState says it is only for testing) in the interests of a making the change smaller.