### PR TITLE
Improve diagnostics for IDestinationResolver exceptions

### DIFF
--- a/src/ReverseProxy/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Management/ProxyConfigManager.cs
@@ -359,7 +359,17 @@ internal sealed class ProxyConfigManager : EndpointDataSource, IProxyStateLookup
         {
             foreach (var (i, task) in resolverTasks)
             {
-                var resolvedDestinations = await task;
+                ResolvedDestinationCollection resolvedDestinations;
+                try
+                {
+                    resolvedDestinations = await task;
+                }
+                catch (Exception exception)
+                {
+                    var cluster = clusters[i];
+                    throw new InvalidOperationException($"Error resolving destinations for cluster {cluster.ClusterId}", exception); 
+                }
+
                 clusters[i] = clusters[i] with { Destinations = resolvedDestinations.Destinations };
                 if (resolvedDestinations.ChangeToken is { } token)
                 {

--- a/src/ReverseProxy/ServiceDiscovery/DnsDestinationResolver.cs
+++ b/src/ReverseProxy/ServiceDiscovery/DnsDestinationResolver.cs
@@ -66,11 +66,21 @@ internal class DnsDestinationResolver : IDestinationResolver
     {
         var originalUri = new Uri(originalConfig.Address);
         var originalHost = originalConfig.Host is { Length: > 0 } host ? host : originalUri.Authority;
-        var addresses = options.AddressFamily switch
+        var hostName = originalUri.DnsSafeHost;
+        IPAddress[] addresses;
+        try
         {
-            { } addressFamily => await Dns.GetHostAddressesAsync(originalUri.DnsSafeHost, addressFamily, cancellationToken).ConfigureAwait(false),
-            null => await Dns.GetHostAddressesAsync(originalUri.DnsSafeHost, cancellationToken).ConfigureAwait(false)
-        };
+            addresses = options.AddressFamily switch
+            {
+                { } addressFamily => await Dns.GetHostAddressesAsync(hostName, addressFamily, cancellationToken).ConfigureAwait(false),
+                null => await Dns.GetHostAddressesAsync(hostName, cancellationToken).ConfigureAwait(false)
+            };
+        }
+        catch (Exception exception)
+        {
+            throw new InvalidOperationException($"Failed to resolve host {hostName}. See {nameof(Exception.InnerException)} for details.", exception);
+        }
+
         var results = new List<(string Name, DestinationConfig Config)>(addresses.Length);
         var uriBuilder = new UriBuilder(originalUri);
         var healthUri = originalConfig.Health is { Length: > 0 } health ? new Uri(health) : null;

--- a/src/ReverseProxy/ServiceDiscovery/DnsDestinationResolver.cs
+++ b/src/ReverseProxy/ServiceDiscovery/DnsDestinationResolver.cs
@@ -78,7 +78,7 @@ internal class DnsDestinationResolver : IDestinationResolver
         }
         catch (Exception exception)
         {
-            throw new InvalidOperationException($"Failed to resolve host {hostName}. See {nameof(Exception.InnerException)} for details.", exception);
+            throw new InvalidOperationException($"Failed to resolve host '{hostName}'. See {nameof(Exception.InnerException)} for details.", exception);
         }
 
         var results = new List<(string Name, DestinationConfig Config)>(addresses.Length);

--- a/test/ReverseProxy.Tests/Management/ProxyConfigManagerTests.cs
+++ b/test/ReverseProxy.Tests/Management/ProxyConfigManagerTests.cs
@@ -1392,8 +1392,10 @@ public class ProxyConfigManagerTests
         var ioEx = await Assert.ThrowsAsync<InvalidOperationException>(() => configManager.InitialLoadAsync());
         Assert.Equal("Unable to load or apply the proxy configuration.", ioEx.Message);
 
-        var innerExc = Assert.IsType<InvalidOperationException>(ioEx.InnerException);
-        Assert.Equal("Throwing!", innerExc.Message);
+        var innerExc1 = Assert.IsType<InvalidOperationException>(ioEx.InnerException);
+        Assert.Equal("Error resolving destinations for cluster cluster1", innerExc1.Message);
+        var innerExc2 = Assert.IsType<InvalidOperationException>(innerExc1.InnerException);
+        Assert.Equal("Throwing!", innerExc2.Message);
     }
 
     [Fact]
@@ -1640,7 +1642,9 @@ public class ProxyConfigManagerTests
 
         // Read the failure event
         var configLoadException = Assert.IsType<TestConfigChangeListener.ConfigurationLoadingFailedEvent>(await configListener.Events.Reader.ReadAsync());
-        var ex = configLoadException.Exception;
-        Assert.Equal("Throwing!", ex.Message);
+        var innerExc1 = Assert.IsType<InvalidOperationException>(configLoadException.Exception);
+        Assert.Equal("Error resolving destinations for cluster cluster1", innerExc1.Message);
+        var innerExc2 = Assert.IsType<InvalidOperationException>(innerExc1.InnerException);
+        Assert.Equal("Throwing!", innerExc2.Message);
     }
 }


### PR DESCRIPTION
When an exception is thrown from `IDestinationResolver.ResolveDestinationsAsync`, we should catch the exception and rethrow it with context, such as which cluster failed resolution and, if possible, which destination failed to be resolved.