### PR TITLE
Improve route string syntax usage

### DIFF
--- a/samples/ReverseProxy.Auth.Sample/Startup.cs
+++ b/samples/ReverseProxy.Auth.Sample/Startup.cs
@@ -106,7 +106,6 @@ namespace Yarp.Sample
             {
                 endpoints.MapControllers();
                 endpoints.MapReverseProxy();
-                endpoints.MapForwarder("{test}", "", c => c.AddPathRouteValues("{sss}"));
             });
         }
     }

--- a/samples/ReverseProxy.Auth.Sample/Startup.cs
+++ b/samples/ReverseProxy.Auth.Sample/Startup.cs
@@ -106,6 +106,7 @@ namespace Yarp.Sample
             {
                 endpoints.MapControllers();
                 endpoints.MapReverseProxy();
+                endpoints.MapForwarder("{test}", "", c => c.AddPathRouteValues("{sss}"));
             });
         }
     }

--- a/src/ReverseProxy/Routing/DirectForwardingIEndpointRouteBuilderExtensions.cs
+++ b/src/ReverseProxy/Routing/DirectForwardingIEndpointRouteBuilderExtensions.cs
@@ -21,10 +21,7 @@ public static class DirectForwardingIEndpointRouteBuilderExtensions
     /// Adds direct forwarding of HTTP requests that match the specified pattern to a specific destination using default configuration for the outgoing request, default transforms, and default HTTP client.
     /// </summary>
     public static IEndpointConventionBuilder MapForwarder(this IEndpointRouteBuilder endpoints,
-    #if NET7_0_OR_GREATER
-    [StringSyntax("Route")]
-    #endif
-    string pattern, string destinationPrefix)
+        [StringSyntax("Route")] string pattern, string destinationPrefix)
     {
         return endpoints.MapForwarder(pattern, destinationPrefix, ForwarderRequestConfig.Empty);
     }
@@ -33,10 +30,7 @@ public static class DirectForwardingIEndpointRouteBuilderExtensions
     /// Adds direct forwarding of HTTP requests that match the specified pattern to a specific destination and target path applying route values from the pattern using default configuration for the outgoing request, and default HTTP client.
     /// </summary>
     public static IEndpointConventionBuilder MapForwarder(this IEndpointRouteBuilder endpoints,
-    #if NET7_0_OR_GREATER
-    [StringSyntax("Route")]
-    #endif
-    string pattern, string destinationPrefix, string targetPath)
+        [StringSyntax("Route")] string pattern, string destinationPrefix, [StringSyntax("Route")] string targetPath)
     {
         return endpoints.MapForwarder(pattern, destinationPrefix, ForwarderRequestConfig.Empty, targetPath);
     }
@@ -45,10 +39,7 @@ public static class DirectForwardingIEndpointRouteBuilderExtensions
     /// Adds direct forwarding of HTTP requests that match the specified pattern to a specific destination and target path applying route values from the pattern using customized configuration for the outgoing request, and default HTTP client.
     /// </summary>
     public static IEndpointConventionBuilder MapForwarder(this IEndpointRouteBuilder endpoints,
-    #if NET7_0_OR_GREATER
-    [StringSyntax("Route")]
-    #endif
-    string pattern, string destinationPrefix, ForwarderRequestConfig requestConfig, string targetPath)
+        [StringSyntax("Route")] string pattern, string destinationPrefix, ForwarderRequestConfig requestConfig, [StringSyntax("Route")] string targetPath)
     {
         return endpoints.MapForwarder(pattern, destinationPrefix, requestConfig, b => b.AddPathRouteValues(targetPath));
     }
@@ -57,10 +48,7 @@ public static class DirectForwardingIEndpointRouteBuilderExtensions
     /// Adds direct forwarding of HTTP requests that match the specified pattern to a specific destination using default configuration for the outgoing request, customized transforms, and default HTTP client.
     /// </summary>
     public static IEndpointConventionBuilder MapForwarder(this IEndpointRouteBuilder endpoints,
-    #if NET7_0_OR_GREATER
-    [StringSyntax("Route")]
-    #endif
-    string pattern, string destinationPrefix, Action<TransformBuilderContext> configureTransform)
+        [StringSyntax("Route")] string pattern, string destinationPrefix, Action<TransformBuilderContext> configureTransform)
     {
         return endpoints.MapForwarder(pattern, destinationPrefix, ForwarderRequestConfig.Empty, configureTransform);
     }
@@ -69,10 +57,7 @@ public static class DirectForwardingIEndpointRouteBuilderExtensions
     /// Adds direct forwarding of HTTP requests that match the specified pattern to a specific destination using customized configuration for the outgoing request, customized transforms, and default HTTP client.
     /// </summary>
     public static IEndpointConventionBuilder MapForwarder(this IEndpointRouteBuilder endpoints,
-    #if NET7_0_OR_GREATER
-    [StringSyntax("Route")]
-    #endif
-    string pattern, string destinationPrefix, ForwarderRequestConfig requestConfig, Action<TransformBuilderContext> configureTransform)
+        [StringSyntax("Route")] string pattern, string destinationPrefix, ForwarderRequestConfig requestConfig, Action<TransformBuilderContext> configureTransform)
     {
         var transformBuilder = endpoints.ServiceProvider.GetRequiredService<ITransformBuilder>();
 
@@ -85,10 +70,7 @@ public static class DirectForwardingIEndpointRouteBuilderExtensions
     /// Adds direct forwarding of HTTP requests that match the specified pattern to a specific destination using customized configuration for the outgoing request, default transforms, and default HTTP client.
     /// </summary>
     public static IEndpointConventionBuilder MapForwarder(this IEndpointRouteBuilder endpoints,
-    #if NET7_0_OR_GREATER
-    [StringSyntax("Route")]
-    #endif
-     string pattern, string destinationPrefix, ForwarderRequestConfig requestConfig)
+        [StringSyntax("Route")] string pattern, string destinationPrefix, ForwarderRequestConfig requestConfig)
     {
         return endpoints.MapForwarder(pattern, destinationPrefix, requestConfig, HttpTransformer.Default);
     }
@@ -97,10 +79,7 @@ public static class DirectForwardingIEndpointRouteBuilderExtensions
     /// Adds direct forwarding of HTTP requests that match the specified pattern to a specific destination using customized configuration for the outgoing request, customized transforms, and default HTTP client.
     /// </summary>
     public static IEndpointConventionBuilder MapForwarder(this IEndpointRouteBuilder endpoints,
-    #if NET7_0_OR_GREATER
-    [StringSyntax("Route")]
-    #endif
-    string pattern, string destinationPrefix, ForwarderRequestConfig requestConfig, HttpTransformer transformer)
+        [StringSyntax("Route")] string pattern, string destinationPrefix, ForwarderRequestConfig requestConfig, HttpTransformer transformer)
     {
         var httpClientProvider = endpoints.ServiceProvider.GetRequiredService<DirectForwardingHttpClientProvider>();
 
@@ -111,10 +90,7 @@ public static class DirectForwardingIEndpointRouteBuilderExtensions
     /// Adds direct forwarding of HTTP requests that match the specified pattern to a specific destination using customized configuration for the outgoing request, customized transforms, and customized HTTP client.
     /// </summary>
     public static IEndpointConventionBuilder MapForwarder(this IEndpointRouteBuilder endpoints,
-    #if NET7_0_OR_GREATER
-    [StringSyntax("Route")]
-    #endif
-    string pattern, string destinationPrefix, ForwarderRequestConfig requestConfig, HttpTransformer transformer, HttpMessageInvoker httpClient)
+        [StringSyntax("Route")] string pattern, string destinationPrefix, ForwarderRequestConfig requestConfig, HttpTransformer transformer, HttpMessageInvoker httpClient)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
         ArgumentNullException.ThrowIfNull(destinationPrefix);

--- a/src/ReverseProxy/Transforms/PathRouteValuesTransform.cs
+++ b/src/ReverseProxy/Transforms/PathRouteValuesTransform.cs
@@ -23,10 +23,7 @@ public class PathRouteValuesTransform : RequestTransform
     /// <param name="pattern">The pattern used to create the new request path.</param>
     /// <param name="binderFactory">The factory used to bind route parameters to the given path pattern.</param>
     public PathRouteValuesTransform(
-    #if NET7_0_OR_GREATER
-    [StringSyntax("Route")]
-    #endif
-    string pattern, TemplateBinderFactory binderFactory)
+        [StringSyntax("Route")] string pattern, TemplateBinderFactory binderFactory)
     {
         _ = pattern ?? throw new ArgumentNullException(nameof(pattern));
         _binderFactory = binderFactory ?? throw new ArgumentNullException(nameof(binderFactory));

--- a/src/ReverseProxy/Transforms/PathTransformExtensions.cs
+++ b/src/ReverseProxy/Transforms/PathTransformExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing.Template;
 using Microsoft.Extensions.DependencyInjection;
@@ -93,7 +94,7 @@ public static class PathTransformExtensions
     /// <summary>
     /// Clones the route and adds the transform which will set the request path with the given value.
     /// </summary>
-    public static RouteConfig WithTransformPathRouteValues(this RouteConfig route, PathString pattern)
+    public static RouteConfig WithTransformPathRouteValues(this RouteConfig route, [StringSyntax("Route")] PathString pattern)
     {
         if (pattern.Value is null)
         {
@@ -109,7 +110,7 @@ public static class PathTransformExtensions
     /// <summary>
     /// Clones the route and adds the transform which will set the request path with the given value.
     /// </summary>
-    public static TransformBuilderContext AddPathRouteValues(this TransformBuilderContext context, PathString pattern)
+    public static TransformBuilderContext AddPathRouteValues(this TransformBuilderContext context, [StringSyntax("Route")] PathString pattern)
     {
         if (pattern.Value is null)
         {

--- a/src/ReverseProxy/Utilities/StringSyntaxAttribute.cs
+++ b/src/ReverseProxy/Utilities/StringSyntaxAttribute.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+#if !NET7_0_OR_GREATER
+    /// <summary>Specifies the syntax used in a string.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    internal sealed class StringSyntaxAttribute : Attribute
+    {
+        /// <summary>Initializes the <see cref="StringSyntaxAttribute"/> with the identifier of the syntax used.</summary>
+        /// <param name="syntax">The syntax identifier.</param>
+        public StringSyntaxAttribute(string syntax)
+        {
+            Syntax = syntax;
+            Arguments = Array.Empty<object?>();
+        }
+
+        /// <summary>Initializes the <see cref="StringSyntaxAttribute"/> with the identifier of the syntax used.</summary>
+        /// <param name="syntax">The syntax identifier.</param>
+        /// <param name="arguments">Optional arguments associated with the specific syntax employed.</param>
+        public StringSyntaxAttribute(string syntax, params object?[] arguments)
+        {
+            Syntax = syntax;
+            Arguments = arguments;
+        }
+
+        /// <summary>Gets the identifier of the syntax used.</summary>
+        public string Syntax { get; }
+
+        /// <summary>Optional arguments associated with the specific syntax employed.</summary>
+        public object?[] Arguments { get; }
+    }
+#endif
+}


### PR DESCRIPTION
* Add internal StringSyntaxAttribute to remove `#ifdefs`
* Add route string syntax to a few more places

After:

![image](https://github.com/microsoft/reverse-proxy/assets/303201/ff7c884a-ec9f-4e5e-9718-b5a8d424bfe5)
