### PR TITLE
💡feat: allow for simpler override of Response header encoding of Forwarded Requests

### DIFF
--- a/docs/docfx/articles/config-files.md
+++ b/docs/docfx/articles/config-files.md
@@ -13,10 +13,10 @@ public Startup(IConfiguration configuration)
     Configuration = configuration;
 }
 
-public void ConfigureServices(IServiceCollection services) 
-{ 
-    services.AddReverseProxy() 
-        .LoadFromConfig(Configuration.GetSection("ReverseProxy")); 
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddReverseProxy()
+        .LoadFromConfig(Configuration.GetSection("ReverseProxy"));
 }
 
 public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
@@ -27,11 +27,11 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
     }
 
     app.UseRouting();
-    app.UseEndpoints(endpoints => 
+    app.UseEndpoints(endpoints =>
     {
-        endpoints.MapReverseProxy(); 
-    }); 
-} 
+        endpoints.MapReverseProxy();
+    });
+}
 ```
 **Note**: For details about middleware ordering see [here](https://docs.microsoft.com/aspnet/core/fundamentals/middleware/#middleware-order).
 
@@ -118,7 +118,7 @@ For additional fields see [ClusterConfig](xref:Yarp.ReverseProxy.Configuration.C
   },
   "ReverseProxy": {
     // Routes tell the proxy which requests to forward
-    "Routes": { 
+    "Routes": {
       "minimumroute" : {
         // Matches anything and routes it to www.example.com
         "ClusterId": "minimumcluster",
@@ -134,7 +134,7 @@ For additional fields see [ClusterConfig](xref:Yarp.ReverseProxy.Configuration.C
         "Authorization Policy" : "Anonymous", // Name of the policy or "Default", "Anonymous"
         "CorsPolicy" : "Default", // Name of the CorsPolicy to apply to this route or "Default", "Disable"
         "Match": {
-          "Path": "/something/{**remainder}", // The path to match using ASP.NET syntax. 
+          "Path": "/something/{**remainder}", // The path to match using ASP.NET syntax.
           "Hosts" : [ "www.aaaaa.com", "www.bbbbb.com"], // The host names to match, unspecified is any
           "Methods" : [ "GET", "PUT" ], // The HTTP methods that match, uspecified is all
           "Headers": [ // The headers to match, unspecified is any
@@ -161,7 +161,7 @@ For additional fields see [ClusterConfig](xref:Yarp.ReverseProxy.Configuration.C
           {
             "RequestHeader": "MyHeader",
             "Set": "MyValue",
-          } 
+          }
         ]
       }
     },
@@ -194,7 +194,7 @@ For additional fields see [ClusterConfig](xref:Yarp.ReverseProxy.Configuration.C
           }
         },
         "HealthCheck": {
-          "Active": { // Makes API calls to validate the health. 
+          "Active": { // Makes API calls to validate the health.
             "Enabled": "true",
             "Interval": "00:00:10",
             "Timeout": "00:00:10",
@@ -212,7 +212,8 @@ For additional fields see [ClusterConfig](xref:Yarp.ReverseProxy.Configuration.C
           "DangerousAcceptAnyServerCertificate" : false,
           "MaxConnectionsPerServer" : 1024,
           "EnableMultipleHttp2Connections" : true,
-          "RequestHeaderEncoding" : "Latin1" // How to interpret non ASCII characters in header values
+          "RequestHeaderEncoding" : "Latin1", // How to interpret non ASCII characters in request header values
+          "ResponseHeaderEncoding" : "Latin1" // How to interpret non ASCII characters in response header values
         },
         "HttpRequest" : { // Options for sending request to destination
           "ActivityTimeout" : "00:02:00",

--- a/docs/docfx/articles/http-client-config.md
+++ b/docs/docfx/articles/http-client-config.md
@@ -12,7 +12,7 @@ The configuration is represented differently if you're using the [IConfiguration
 These types are focused on defining serializable configuration. The code based configuration model is described below in the "Code Configuration" section.
 
 ### HttpClient
-HTTP client configuration is based on [HttpClientConfig](xref:Yarp.ReverseProxy.Configuration.HttpClientConfig) and represented by the following configuration schema.
+HTTP client configuration is based on [HttpClientConfig](xref:Yarp.ReverseProxy.Configuration.HttpClientConfig) and represented by the following configuration schema. If you need a more granular approach, please use a [custom implementation](https://microsoft.github.io/reverse-proxy/articles/http-client-config.html#custom-iforwarderhttpclientfactory) of `IForwarderHttpClientFactory`.
 ```JSON
 "HttpClient": {
     "SslProtocols": [ "<protocol-names>" ],
@@ -52,21 +52,6 @@ Configuration settings:
 - ResponseHeaderEncoding - enables other than ASCII encoding for incoming response headers (from requests that the proxy would forward out). Setting this value will leverage [`SocketsHttpHandler.ResponseHeaderEncodingSelector`](https://docs.microsoft.com/dotnet/api/system.net.http.socketshttphandler.responseheaderencodingselector) and use the selected encoding for all headers. The value is then parsed by [`Encoding.GetEncoding`](https://docs.microsoft.com/dotnet/api/system.text.encoding.getencoding#System_Text_Encoding_GetEncoding_System_String_), use values like: "utf-8", "iso-8859-1", etc.
 ```JSON
 "ResponseHeaderEncoding": "utf-8"
-```
-If you need more granular approach, please use custom `IForwarderHttpClientFactory`. However, if you're using an encoding other than ASCII (or UTF-8 for Kestrel) you also need to set your server to accept requests and/or send responses with such headers. For example, use [`KestrelServerOptions.RequestHeaderEncodingSelector`](https://docs.microsoft.com/dotnet/api/Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.RequestHeaderEncodingSelector) / [`.ResponseHeaderEncodingSelector`](https://docs.microsoft.com/dotnet/api/Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ResponseHeaderEncodingSelector) to set up Kestrel to accept Latin1 ("iso-8859-1") headers:
-```C#
-private static IHostBuilder CreateHostBuilder(string[] args) =>
-    Host.CreateDefaultBuilder(args)
-        .ConfigureWebHostDefaults(webBuilder =>
-        {
-            webBuilder.UseStartup<Startup>()
-                      .ConfigureKestrel(kestrel =>
-                      {
-                          kestrel.RequestHeaderEncodingSelector = _ => Encoding.Latin1;
-                          // and/or
-                          kestrel.ResponseHeaderEncodingSelector = _ => Encoding.Latin1;
-                      });
-        });
 ```
 - EnableMultipleHttp2Connections - enables opening additional HTTP/2 connections to the same server when the maximum number of concurrent streams is reached on all existing connections. The default is `true`. See [SocketsHttpHandler.EnableMultipleHttp2Connections](https://docs.microsoft.com/dotnet/api/system.net.http.socketshttphandler.enablemultiplehttp2connections)
 ```JSON

--- a/docs/docfx/articles/http-client-config.md
+++ b/docs/docfx/articles/http-client-config.md
@@ -53,7 +53,7 @@ Configuration settings:
 ```JSON
 "ResponseHeaderEncoding": "utf-8"
 ```
-Note that if you're using an encoding other than ASCII, you also need to set your server to accept-requests and/or send-responses with such headers. For example, when using Kestrel as server, use [`KestrelServerOptions.RequestHeaderEncodingSelector`](https://docs.microsoft.com/dotnet/api/Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.RequestHeaderEncodingSelector) / [`.ResponseHeaderEncodingSelector`](https://docs.microsoft.com/dotnet/api/Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ResponseHeaderEncodingSelector) to configure Kestrel to allow `Latin1` ("`iso-8859-1`") headers:
+Note that if you're using an encoding other than ASCII, you also need to set your server to accept requests and/or send responses with such headers. For example, when using Kestrel as the server, use [`KestrelServerOptions.RequestHeaderEncodingSelector`](https://docs.microsoft.com/dotnet/api/Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.RequestHeaderEncodingSelector) / [`.ResponseHeaderEncodingSelector`](https://docs.microsoft.com/dotnet/api/Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ResponseHeaderEncodingSelector) to configure Kestrel to allow `Latin1` ("`iso-8859-1`") headers:
 ```C#
 private static IHostBuilder CreateHostBuilder(string[] args) =>
     Host.CreateDefaultBuilder(args)

--- a/docs/docfx/articles/http-client-config.md
+++ b/docs/docfx/articles/http-client-config.md
@@ -53,6 +53,21 @@ Configuration settings:
 ```JSON
 "ResponseHeaderEncoding": "utf-8"
 ```
+Note that if you're using an encoding other than ASCII, you also need to set your server to accept-requests and/or send-responses with such headers. For example, when using Kestrel as server, use [`KestrelServerOptions.RequestHeaderEncodingSelector`](https://docs.microsoft.com/dotnet/api/Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.RequestHeaderEncodingSelector) / [`.ResponseHeaderEncodingSelector`](https://docs.microsoft.com/dotnet/api/Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ResponseHeaderEncodingSelector) to configure Kestrel to allow `Latin1` ("`iso-8859-1`") headers:
+```C#
+private static IHostBuilder CreateHostBuilder(string[] args) =>
+    Host.CreateDefaultBuilder(args)
+        .ConfigureWebHostDefaults(webBuilder =>
+        {
+            webBuilder.UseStartup<Startup>()
+                      .ConfigureKestrel(kestrel =>
+                      {
+                          kestrel.RequestHeaderEncodingSelector = _ => Encoding.Latin1;
+                          // and/or
+                          kestrel.ResponseHeaderEncodingSelector = _ => Encoding.Latin1;
+                      });
+        });
+```
 - EnableMultipleHttp2Connections - enables opening additional HTTP/2 connections to the same server when the maximum number of concurrent streams is reached on all existing connections. The default is `true`. See [SocketsHttpHandler.EnableMultipleHttp2Connections](https://docs.microsoft.com/dotnet/api/system.net.http.socketshttphandler.enablemultiplehttp2connections)
 ```JSON
 "EnableMultipleHttp2Connections": false

--- a/docs/docfx/articles/http-client-config.md
+++ b/docs/docfx/articles/http-client-config.md
@@ -44,7 +44,7 @@ Configuration settings:
 ```JSON
 "DangerousAcceptAnyServerCertificate": "true"
 ```
-- RequestHeaderEncoding - enables other than ASCII encoding for outgoing request headers. Setting this value will leverage [`SocketsHttpHandler.RequestHeaderEncodingSelector`](https://docs.microsoft.com/dotnet/api/system.net.http.socketshttphandler.requestheaderencodingselector) and use the selected encoding for all headers. If you need more granular approach, please use custom `IProxyHttpClientFactory`. The value is then parsed by [`Encoding.GetEncoding`](https://docs.microsoft.com/dotnet/api/system.text.encoding.getencoding#System_Text_Encoding_GetEncoding_System_String_), use values like: "utf-8", "iso-8859-1", etc.
+- RequestHeaderEncoding - enables other than ASCII encoding for outgoing request headers. Setting this value will leverage [`SocketsHttpHandler.RequestHeaderEncodingSelector`](https://docs.microsoft.com/dotnet/api/system.net.http.socketshttphandler.requestheaderencodingselector) and use the selected encoding for all headers. If you need more granular approach, please use custom `IForwarderHttpClientFactory`. The value is then parsed by [`Encoding.GetEncoding`](https://docs.microsoft.com/dotnet/api/system.text.encoding.getencoding#System_Text_Encoding_GetEncoding_System_String_), use values like: "utf-8", "iso-8859-1", etc.
 ```JSON
 "RequestHeaderEncoding": "utf-8"
 ```

--- a/samples/ReverseProxy.Config.Sample/appsettings.json
+++ b/samples/ReverseProxy.Config.Sample/appsettings.json
@@ -33,7 +33,7 @@
         "Authorization Policy": "Anonymous", // Name of the policy or "Default", "Anonymous"
         "CorsPolicy": "disable", // Name of the CorsPolicy to apply to this route or "default", "disable"
         "Match": { // Rules that have to be met for the route to match the request
-          "Path": "/download/{**remainder}", // The path to match using ASP.NET syntax. 
+          "Path": "/download/{**remainder}", // The path to match using ASP.NET syntax.
           "Hosts": [ "localhost", "www.aaaaa.com", "www.bbbbb.com" ], // The host names to match, unspecified is any
           "Methods": [ "GET", "PUT" ], // The HTTP methods that match, unspecified is all
           "Headers": [ // The headers to match, unspecified is any
@@ -91,7 +91,7 @@
           "AffinityKeyName": "MySessionCookieName" // Required, no default
         },
         "HealthCheck": { // Ways to determine which destinations should be filtered out due to unhealthy state
-          "Active": { // Makes API calls to validate the health of each destination 
+          "Active": { // Makes API calls to validate the health of each destination
             "Enabled": "true",
             "Interval": "00:00:10", // How often to query for health data
             "Timeout": "00:00:10", // Timeout for the health check request/response
@@ -110,7 +110,8 @@
           "DangerousAcceptAnyServerCertificate": true, // Disables destination cert validation
           "MaxConnectionsPerServer": 1024, // Destination server can further limit this number
           "EnableMultipleHttp2Connections": true,
-          "RequestHeaderEncoding": "Latin1" // How to interpret non ASCII characters in header values
+          "RequestHeaderEncoding": "Latin1", // How to interpret non ASCII characters in proxied request's header values
+          "ResponseHeaderEncoding": "Latin1" // How to interpret non ASCII characters in proxied request's response header values
         },
         "HttpRequest": { // Options for sending request to destination
           "Timeout": "00:02:00", // Timeout for the HttpRequest

--- a/src/ReverseProxy/Configuration/ConfigProvider/ConfigurationConfigProvider.cs
+++ b/src/ReverseProxy/Configuration/ConfigProvider/ConfigurationConfigProvider.cs
@@ -350,6 +350,7 @@ internal sealed class ConfigurationConfigProvider : IProxyConfigProvider, IDispo
             MaxConnectionsPerServer = section.ReadInt32(nameof(HttpClientConfig.MaxConnectionsPerServer)),
             EnableMultipleHttp2Connections = section.ReadBool(nameof(HttpClientConfig.EnableMultipleHttp2Connections)),
             RequestHeaderEncoding = section[nameof(HttpClientConfig.RequestHeaderEncoding)],
+            ResponseHeaderEncoding = section[nameof(HttpClientConfig.ResponseHeaderEncoding)],
             WebProxy = webProxy
         };
     }
@@ -377,7 +378,7 @@ internal sealed class ConfigurationConfigProvider : IProxyConfigProvider, IDispo
             Address = section[nameof(DestinationConfig.Address)]!,
             Health = section[nameof(DestinationConfig.Health)],
             Metadata = section.GetSection(nameof(DestinationConfig.Metadata)).ReadStringDictionary(),
-            Host = section[nameof(DestinationConfig.Host)] 
+            Host = section[nameof(DestinationConfig.Host)]
         };
     }
 

--- a/src/ReverseProxy/Configuration/ConfigValidator.cs
+++ b/src/ReverseProxy/Configuration/ConfigValidator.cs
@@ -455,16 +455,29 @@ internal sealed class ConfigValidator : IConfigValidator
             errors.Add(new ArgumentException($"Max connections per server limit set on the cluster '{cluster.ClusterId}' must be positive."));
         }
 
-        var encoding = cluster.HttpClient.RequestHeaderEncoding;
-        if (encoding is not null)
+        var requestHeaderEncoding = cluster.HttpClient.RequestHeaderEncoding;
+        if (requestHeaderEncoding is not null)
         {
             try
             {
-                Encoding.GetEncoding(encoding);
+                Encoding.GetEncoding(requestHeaderEncoding);
             }
             catch (ArgumentException aex)
             {
-                errors.Add(new ArgumentException($"Invalid header encoding '{encoding}'.", aex));
+                errors.Add(new ArgumentException($"Invalid request header encoding '{requestHeaderEncoding}'.", aex));
+            }
+        }
+
+        var responseHeaderEncoding = cluster.HttpClient.ResponseHeaderEncoding;
+        if (responseHeaderEncoding is not null)
+        {
+            try
+            {
+                Encoding.GetEncoding(responseHeaderEncoding);
+            }
+            catch (ArgumentException aex)
+            {
+                errors.Add(new ArgumentException($"Invalid response header encoding '{responseHeaderEncoding}'.", aex));
             }
         }
     }

--- a/src/ReverseProxy/Configuration/HttpClientConfig.cs
+++ b/src/ReverseProxy/Configuration/HttpClientConfig.cs
@@ -2,7 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Net.Http;
 using System.Security.Authentication;
+using System.Text;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Yarp.ReverseProxy.Forwarder;
 
 namespace Yarp.ReverseProxy.Configuration;
 
@@ -10,7 +14,7 @@ namespace Yarp.ReverseProxy.Configuration;
 /// Options used for communicating with the destination servers.
 /// </summary>
 /// <remarks>
-/// If you need a more granular approach, please use a <see href="https://microsoft.github.io/reverse-proxy/articles/http-client-config.html#custom-iforwarderhttpclientfactory">custom implementation of <c>IForwarderHttpClientFactory</c></see>.
+/// If you need a more granular approach, please use a <see href="https://microsoft.github.io/reverse-proxy/articles/http-client-config.html#custom-iforwarderhttpclientfactory">custom implementation of <see cref="IForwarderHttpClientFactory"/></see>.
 /// </remarks>
 public sealed record HttpClientConfig
 {
@@ -50,13 +54,15 @@ public sealed record HttpClientConfig
     /// <summary>
     /// Allows overriding the default (ASCII) encoding for outgoing request headers.
     /// <para>
-    /// Setting this value will in turn set <see href="https://docs.microsoft.com/dotnet/api/system.net.http.socketshttphandler.requestheaderencodingselector">SocketsHttpHandler.RequestHeaderEncodingSelector</see> and use the selected encoding for all request headers. The value is then parsed by <see href="https://learn.microsoft.com/en-us/dotnet/api/system.text.encoding.getencoding#system-text-encoding-getencoding(system-string)">Encoding.GetEncoding</see>, so use values like: "utf-8", "iso-8859-1", etc.
+    /// Setting this value will in turn set <see cref="SocketsHttpHandler.RequestHeaderEncodingSelector"/> and use the selected encoding for all request headers.
+    /// The value is then parsed by <see cref="Encoding.GetEncoding(string)"/>, so use values like: "utf-8", "iso-8859-1", etc.
     /// </para>
     /// </summary>
     /// <remarks>
     /// Note: If you're using an encoding other than UTF-8 here, then you may also need to configure your server to accept request headers with such an encoding via the corresponding options for the server.
     /// <para>
-    /// For example, when using Kestrel as the server, use <see href="https://docs.microsoft.com/dotnet/api/Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.RequestHeaderEncodingSelector">KestrelServerOptions.RequestHeaderEncodingSelector</see> to <see href="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/options">configure Kestrel</see> to use the same encoding.
+    /// For example, when using Kestrel as the server, use <see cref="KestrelServerOptions.RequestHeaderEncodingSelector"/> to
+    /// <see href="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/options">configure Kestrel</see> to use the same encoding.
     /// </para>
     /// </remarks>
     public string? RequestHeaderEncoding { get; init; }
@@ -64,13 +70,15 @@ public sealed record HttpClientConfig
     /// <summary>
     /// Allows overriding the default (Latin1) encoding for incoming request headers.
     /// <para>
-    /// Setting this value will in turn set <see href="https://docs.microsoft.com/dotnet/api/system.net.http.socketshttphandler.responseheaderencodingselector">SocketsHttpHandler.ResponseHeaderEncodingSelector</see> and use the selected encoding for all response headers. The value is then parsed by <see href="https://learn.microsoft.com/en-us/dotnet/api/system.text.encoding.getencoding#system-text-encoding-getencoding(system-string)">Encoding.GetEncoding</see>, so use values like: "utf-8", "iso-8859-1", etc.
+    /// Setting this value will in turn set <see cref="SocketsHttpHandler.ResponseHeaderEncodingSelector"/> and use the selected encoding for all response headers.
+    /// The value is then parsed by <see cref="Encoding.GetEncoding(string)"/>, so use values like: "utf-8", "iso-8859-1", etc.
     /// </para>
     /// </summary>
     /// <remarks>
     /// Note: If you're using an encoding other than ASCII here, then you may also need to configure your server to send response headers with such an encoding via the corresponding options for the server.
     /// <para>
-    /// For example, when using Kestrel as the server, use <see href="https://docs.microsoft.com/dotnet/api/Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.RequestHeaderEncodingSelector">KestrelServerOptions.RequestHeaderEncodingSelector</see> to <see href="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/options">configure Kestrel</see> to use the same encoding.
+    /// For example, when using Kestrel as the server, use <see cref="KestrelServerOptions.ResponseHeaderEncodingSelector"/> to
+    /// <see href="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/options">configure Kestrel</see> to use the same encoding.
     /// </para>
     /// </remarks>
     public string? ResponseHeaderEncoding { get; init; }

--- a/src/ReverseProxy/Configuration/HttpClientConfig.cs
+++ b/src/ReverseProxy/Configuration/HttpClientConfig.cs
@@ -48,7 +48,7 @@ public sealed record HttpClientConfig
     public bool? EnableMultipleHttp2Connections { get; init; }
 
     /// <summary>
-    /// Allows overriding the default encoding for outgoing request headers.
+    /// Allows overriding the default (ASCII) encoding for outgoing request headers.
     /// <para>
     /// Setting this value will in turn set <see href="https://docs.microsoft.com/dotnet/api/system.net.http.socketshttphandler.requestheaderencodingselector">SocketsHttpHandler.RequestHeaderEncodingSelector</see> and use the selected encoding for all request headers. The value is then parsed by <see href="https://learn.microsoft.com/en-us/dotnet/api/system.text.encoding.getencoding#system-text-encoding-getencoding(system-string)">Encoding.GetEncoding</see>, so use values like: "utf-8", "iso-8859-1", etc.
     /// </para>
@@ -62,7 +62,7 @@ public sealed record HttpClientConfig
     public string? RequestHeaderEncoding { get; init; }
 
     /// <summary>
-    /// Allows overriding the default encoding for incoming request headers.
+    /// Allows overriding the default (ASCII) encoding for incoming request headers.
     /// <para>
     /// Setting this value will in turn set <see href="https://docs.microsoft.com/dotnet/api/system.net.http.socketshttphandler.responseheaderencodingselector">SocketsHttpHandler.ResponseHeaderEncodingSelector</see> and use the selected encoding for all response headers. The value is then parsed by <see href="https://learn.microsoft.com/en-us/dotnet/api/system.text.encoding.getencoding#system-text-encoding-getencoding(system-string)">Encoding.GetEncoding</see>, so use values like: "utf-8", "iso-8859-1", etc.
     /// </para>

--- a/src/ReverseProxy/Configuration/HttpClientConfig.cs
+++ b/src/ReverseProxy/Configuration/HttpClientConfig.cs
@@ -9,6 +9,9 @@ namespace Yarp.ReverseProxy.Configuration;
 /// <summary>
 /// Options used for communicating with the destination servers.
 /// </summary>
+/// <remarks>
+/// If you need a more granular approach, please use a <see href="https://microsoft.github.io/reverse-proxy/articles/http-client-config.html#custom-iforwarderhttpclientfactory">custom implementation of <c>IForwarderHttpClientFactory</c></see>
+/// </remarks>
 public sealed record HttpClientConfig
 {
     /// <summary>
@@ -45,13 +48,31 @@ public sealed record HttpClientConfig
     public bool? EnableMultipleHttp2Connections { get; init; }
 
     /// <summary>
-    /// Enables non-ASCII header encoding for outgoing requests.
+    /// Allows overriding the default encoding for outgoing request headers.
+    /// <para>
+    /// Setting this value will in turn set <see href="https://docs.microsoft.com/dotnet/api/system.net.http.socketshttphandler.requestheaderencodingselector">SocketsHttpHandler.RequestHeaderEncodingSelector</see> and use the selected encoding for all request headers. The value is then parsed by <see href="https://learn.microsoft.com/en-us/dotnet/api/system.text.encoding.getencoding#system-text-encoding-getencoding(system-string)">Encoding.GetEncoding</see>, so use values like: "utf-8", "iso-8859-1", etc.
+    /// </para>
     /// </summary>
+    /// <remarks>
+    /// Note: If you're using an encoding other than ASCII here, then you may also need to set your server to accept request headers with such encoding via the corresponding options for the server.
+    /// <para>
+    /// For example, when using Kestrel as server, use <see href="https://docs.microsoft.com/dotnet/api/Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.RequestHeaderEncodingSelector">KestrelServerOptions.RequestHeaderEncodingSelector</see> to <see href="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/options">configure Kestrel</see> to use the same encoding.
+    /// </para>
+    /// </remarks>
     public string? RequestHeaderEncoding { get; init; }
 
     /// <summary>
-    /// Enables non-ASCII header encoding for incoming responses.
+    /// Allows overriding the default encoding for incoming request headers.
+    /// <para>
+    /// Setting this value will in turn set <see href="https://docs.microsoft.com/dotnet/api/system.net.http.socketshttphandler.responseheaderencodingselector">SocketsHttpHandler.ResponseHeaderEncodingSelector</see> and use the selected encoding for all response headers. The value is then parsed by <see href="https://learn.microsoft.com/en-us/dotnet/api/system.text.encoding.getencoding#system-text-encoding-getencoding(system-string)">Encoding.GetEncoding</see>, so use values like: "utf-8", "iso-8859-1", etc.
+    /// </para>
     /// </summary>
+    /// <remarks>
+    /// Note: If you're using an encoding other than ASCII here, then you may also need to set your server to send response headers with such encoding via the corresponding options for the server.
+    /// <para>
+    /// For example, when using Kestrel as server, use <see href="https://docs.microsoft.com/dotnet/api/Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.RequestHeaderEncodingSelector">KestrelServerOptions.RequestHeaderEncodingSelector</see> to <see href="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/options">configure Kestrel</see> to use the same encoding.
+    /// </para>
+    /// </remarks>
     public string? ResponseHeaderEncoding { get; init; }
 
     public bool Equals(HttpClientConfig? other)

--- a/src/ReverseProxy/Configuration/HttpClientConfig.cs
+++ b/src/ReverseProxy/Configuration/HttpClientConfig.cs
@@ -10,7 +10,7 @@ namespace Yarp.ReverseProxy.Configuration;
 /// Options used for communicating with the destination servers.
 /// </summary>
 /// <remarks>
-/// If you need a more granular approach, please use a <see href="https://microsoft.github.io/reverse-proxy/articles/http-client-config.html#custom-iforwarderhttpclientfactory">custom implementation of <c>IForwarderHttpClientFactory</c></see>
+/// If you need a more granular approach, please use a <see href="https://microsoft.github.io/reverse-proxy/articles/http-client-config.html#custom-iforwarderhttpclientfactory">custom implementation of <c>IForwarderHttpClientFactory</c></see>.
 /// </remarks>
 public sealed record HttpClientConfig
 {
@@ -54,23 +54,23 @@ public sealed record HttpClientConfig
     /// </para>
     /// </summary>
     /// <remarks>
-    /// Note: If you're using an encoding other than ASCII here, then you may also need to set your server to accept request headers with such encoding via the corresponding options for the server.
+    /// Note: If you're using an encoding other than UTF-8 here, then you may also need to configure your server to accept request headers with such an encoding via the corresponding options for the server.
     /// <para>
-    /// For example, when using Kestrel as server, use <see href="https://docs.microsoft.com/dotnet/api/Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.RequestHeaderEncodingSelector">KestrelServerOptions.RequestHeaderEncodingSelector</see> to <see href="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/options">configure Kestrel</see> to use the same encoding.
+    /// For example, when using Kestrel as the server, use <see href="https://docs.microsoft.com/dotnet/api/Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.RequestHeaderEncodingSelector">KestrelServerOptions.RequestHeaderEncodingSelector</see> to <see href="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/options">configure Kestrel</see> to use the same encoding.
     /// </para>
     /// </remarks>
     public string? RequestHeaderEncoding { get; init; }
 
     /// <summary>
-    /// Allows overriding the default (ASCII) encoding for incoming request headers.
+    /// Allows overriding the default (Latin1) encoding for incoming request headers.
     /// <para>
     /// Setting this value will in turn set <see href="https://docs.microsoft.com/dotnet/api/system.net.http.socketshttphandler.responseheaderencodingselector">SocketsHttpHandler.ResponseHeaderEncodingSelector</see> and use the selected encoding for all response headers. The value is then parsed by <see href="https://learn.microsoft.com/en-us/dotnet/api/system.text.encoding.getencoding#system-text-encoding-getencoding(system-string)">Encoding.GetEncoding</see>, so use values like: "utf-8", "iso-8859-1", etc.
     /// </para>
     /// </summary>
     /// <remarks>
-    /// Note: If you're using an encoding other than ASCII here, then you may also need to set your server to send response headers with such encoding via the corresponding options for the server.
+    /// Note: If you're using an encoding other than ASCII here, then you may also need to configure your server to send response headers with such an encoding via the corresponding options for the server.
     /// <para>
-    /// For example, when using Kestrel as server, use <see href="https://docs.microsoft.com/dotnet/api/Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.RequestHeaderEncodingSelector">KestrelServerOptions.RequestHeaderEncodingSelector</see> to <see href="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/options">configure Kestrel</see> to use the same encoding.
+    /// For example, when using Kestrel as the server, use <see href="https://docs.microsoft.com/dotnet/api/Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.RequestHeaderEncodingSelector">KestrelServerOptions.RequestHeaderEncodingSelector</see> to <see href="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/options">configure Kestrel</see> to use the same encoding.
     /// </para>
     /// </remarks>
     public string? ResponseHeaderEncoding { get; init; }

--- a/src/ReverseProxy/Configuration/HttpClientConfig.cs
+++ b/src/ReverseProxy/Configuration/HttpClientConfig.cs
@@ -33,7 +33,7 @@ public sealed record HttpClientConfig
     public int? MaxConnectionsPerServer { get; init; }
 
     /// <summary>
-    /// Optional web proxy used when communicating with the destination server. 
+    /// Optional web proxy used when communicating with the destination server.
     /// </summary>
     public WebProxyConfig? WebProxy { get; init; }
 
@@ -49,6 +49,11 @@ public sealed record HttpClientConfig
     /// </summary>
     public string? RequestHeaderEncoding { get; init; }
 
+    /// <summary>
+    /// Enables non-ASCII header encoding for incoming responses.
+    /// </summary>
+    public string? ResponseHeaderEncoding { get; init; }
+
     public bool Equals(HttpClientConfig? other)
     {
         if (other is null)
@@ -62,6 +67,7 @@ public sealed record HttpClientConfig
                && EnableMultipleHttp2Connections == other.EnableMultipleHttp2Connections
                // Comparing by reference is fine here since Encoding.GetEncoding returns the same instance for each encoding.
                && RequestHeaderEncoding == other.RequestHeaderEncoding
+               && ResponseHeaderEncoding == other.ResponseHeaderEncoding
                && WebProxy == other.WebProxy;
     }
 
@@ -72,6 +78,7 @@ public sealed record HttpClientConfig
             MaxConnectionsPerServer,
             EnableMultipleHttp2Connections,
             RequestHeaderEncoding,
+            ResponseHeaderEncoding,
             WebProxy);
     }
 }

--- a/src/ReverseProxy/Forwarder/ForwarderHttpClientFactory.cs
+++ b/src/ReverseProxy/Forwarder/ForwarderHttpClientFactory.cs
@@ -102,6 +102,12 @@ public class ForwarderHttpClientFactory : IForwarderHttpClientFactory
             handler.RequestHeaderEncodingSelector = (_, _) => encoding;
         }
 
+        if (newConfig.ResponseHeaderEncoding is not null)
+        {
+            var encoding = Encoding.GetEncoding(newConfig.ResponseHeaderEncoding);
+            handler.ResponseHeaderEncodingSelector = (_, _) => encoding;
+        }
+
         var webProxy = TryCreateWebProxy(newConfig.WebProxy);
         if (webProxy is not null)
         {

--- a/test/ReverseProxy.Tests/Configuration/ClusterConfigTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ClusterConfigTests.cs
@@ -85,7 +85,8 @@ public class ClusterConfigTests
                 SslProtocols = SslProtocols.Tls11 | SslProtocols.Tls12,
                 MaxConnectionsPerServer = 10,
                 DangerousAcceptAnyServerCertificate = true,
-                RequestHeaderEncoding = Encoding.UTF8.WebName
+                RequestHeaderEncoding = Encoding.UTF8.WebName,
+                ResponseHeaderEncoding = Encoding.UTF8.WebName
             },
             HttpRequest = new ForwarderRequestConfig
             {
@@ -161,7 +162,8 @@ public class ClusterConfigTests
                 SslProtocols = SslProtocols.Tls11 | SslProtocols.Tls12,
                 MaxConnectionsPerServer = 10,
                 DangerousAcceptAnyServerCertificate = true,
-                RequestHeaderEncoding = Encoding.UTF8.WebName
+                RequestHeaderEncoding = Encoding.UTF8.WebName,
+                ResponseHeaderEncoding = Encoding.UTF8.WebName
             },
             HttpRequest = new ForwarderRequestConfig
             {

--- a/test/ReverseProxy.Tests/Configuration/ConfigProvider/ConfigurationConfigProviderTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigProvider/ConfigurationConfigProviderTests.cs
@@ -248,6 +248,7 @@ public class ConfigurationConfigProviderTests
                 ""MaxConnectionsPerServer"": 10,
                 ""EnableMultipleHttp2Connections"": true,
                 ""RequestHeaderEncoding"": ""utf-8"",
+                ""ResponseHeaderEncoding"": ""utf-8"",
                 ""WebProxy"": {
                     ""Address"": ""http://localhost:8080"",
                     ""BypassOnLocal"": true,

--- a/test/ReverseProxy.Tests/Configuration/ConfigProvider/ConfigurationConfigProviderTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigProvider/ConfigurationConfigProviderTests.cs
@@ -309,7 +309,7 @@ public class ConfigurationConfigProviderTests
         }
     },
     ""Routes"": {
-        ""routeA"" : {   
+        ""routeA"" : {
             ""Match"": {
                 ""Methods"": [
                     ""GET"",
@@ -547,6 +547,7 @@ public class ConfigurationConfigProviderTests
         Assert.Equal(cluster1.HttpClient.MaxConnectionsPerServer, abstractCluster1.HttpClient.MaxConnectionsPerServer);
         Assert.Equal(cluster1.HttpClient.EnableMultipleHttp2Connections, abstractCluster1.HttpClient.EnableMultipleHttp2Connections);
         Assert.Equal(Encoding.UTF8.WebName, abstractCluster1.HttpClient.RequestHeaderEncoding);
+        Assert.Equal(Encoding.UTF8.WebName, abstractCluster1.HttpClient.ResponseHeaderEncoding);
         Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, abstractCluster1.HttpClient.SslProtocols);
         Assert.Equal(cluster1.HttpRequest.ActivityTimeout, abstractCluster1.HttpRequest.ActivityTimeout);
         Assert.Equal(HttpVersion.Version10, abstractCluster1.HttpRequest.Version);

--- a/test/ReverseProxy.Tests/Configuration/ConfigValidatorTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigValidatorTests.cs
@@ -1159,7 +1159,7 @@ public class ConfigValidatorTests
             ClusterId = "cluster1",
             HttpClient = new HttpClientConfig
             {
-                RequestHeaderEncoding = "utf-8"
+                ResponseHeaderEncoding = "utf-8"
             }
         };
 
@@ -1179,7 +1179,7 @@ public class ConfigValidatorTests
             ClusterId = "cluster1",
             HttpClient = new HttpClientConfig
             {
-                RequestHeaderEncoding = "base64"
+                ResponseHeaderEncoding = "base64"
             }
         };
 

--- a/test/ReverseProxy.Tests/Configuration/ConfigValidatorTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigValidatorTests.cs
@@ -1108,7 +1108,7 @@ public class ConfigValidatorTests
     }
 
     [Fact]
-    public async Task HttpClient_HeaderEncoding_Valid()
+    public async Task HttpClient_RequestHeaderEncoding_Valid()
     {
         var services = CreateServices();
         var validator = services.GetRequiredService<IConfigValidator>();
@@ -1128,7 +1128,7 @@ public class ConfigValidatorTests
     }
 
     [Fact]
-    public async Task HttpClient_HeaderEncoding_Invalid()
+    public async Task HttpClient_RequestHeaderEncoding_Invalid()
     {
         var services = CreateServices();
         var validator = services.GetRequiredService<IConfigValidator>();
@@ -1145,6 +1145,47 @@ public class ConfigValidatorTests
         var errors = await validator.ValidateClusterAsync(cluster);
 
         Assert.Equal(1, errors.Count);
-        Assert.Equal("Invalid header encoding 'base64'.", errors[0].Message);
+        Assert.Equal("Invalid request header encoding 'base64'.", errors[0].Message);
+    }
+
+    [Fact]
+    public async Task HttpClient_ResponseHeaderEncoding_Valid()
+    {
+        var services = CreateServices();
+        var validator = services.GetRequiredService<IConfigValidator>();
+
+        var cluster = new ClusterConfig
+        {
+            ClusterId = "cluster1",
+            HttpClient = new HttpClientConfig
+            {
+                RequestHeaderEncoding = "utf-8"
+            }
+        };
+
+        var errors = await validator.ValidateClusterAsync(cluster);
+
+        Assert.Equal(0, errors.Count);
+    }
+
+    [Fact]
+    public async Task HttpClient_ResponseHeaderEncoding_Invalid()
+    {
+        var services = CreateServices();
+        var validator = services.GetRequiredService<IConfigValidator>();
+
+        var cluster = new ClusterConfig
+        {
+            ClusterId = "cluster1",
+            HttpClient = new HttpClientConfig
+            {
+                RequestHeaderEncoding = "base64"
+            }
+        };
+
+        var errors = await validator.ValidateClusterAsync(cluster);
+
+        Assert.Equal(1, errors.Count);
+        Assert.Equal("Invalid response header encoding 'base64'.", errors[0].Message);
     }
 }

--- a/test/ReverseProxy.Tests/Configuration/HttpClientConfigTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/HttpClientConfigTests.cs
@@ -20,6 +20,7 @@ public class HttpClientConfigTests
             MaxConnectionsPerServer = 20,
             WebProxy = new WebProxyConfig() { Address = new Uri("http://localhost:8080"), BypassOnLocal = true, UseDefaultCredentials = true },
             RequestHeaderEncoding = Encoding.UTF8.WebName,
+            ResponseHeaderEncoding = Encoding.UTF8.WebName,
         };
 
         var options2 = new HttpClientConfig
@@ -29,6 +30,7 @@ public class HttpClientConfigTests
             MaxConnectionsPerServer = 20,
             WebProxy = new WebProxyConfig() { Address = new Uri("http://localhost:8080"), BypassOnLocal = true, UseDefaultCredentials = true },
             RequestHeaderEncoding = Encoding.UTF8.WebName,
+            ResponseHeaderEncoding = Encoding.UTF8.WebName,
         };
 
         var equals = options1.Equals(options2);

--- a/test/ReverseProxy.Tests/Forwarder/ForwarderHttpClientFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/ForwarderHttpClientFactoryTests.cs
@@ -132,6 +132,24 @@ public class ForwarderHttpClientFactoryTests : TestAutoMockBase
     }
 
     [Fact]
+    public void CreateClient_ApplyResponseHeaderEncoding_Success()
+    {
+        var factory = new ForwarderHttpClientFactory(Mock<ILogger<ForwarderHttpClientFactory>>().Object);
+        var options = new HttpClientConfig
+        {
+            ResponseHeaderEncoding = Encoding.Latin1.WebName
+        };
+        var client = factory.CreateClient(new ForwarderHttpClientContext { NewConfig = options });
+
+        var handler = GetHandler(client);
+
+        Assert.NotNull(handler);
+        Assert.NotNull(handler.RequestHeaderEncodingSelector);
+        Assert.Equal(Encoding.Latin1, handler.ResponseHeaderEncodingSelector(default, default));
+        VerifyDefaultValues(handler, nameof(SocketsHttpHandler.ResponseHeaderEncodingSelector));
+    }
+
+    [Fact]
     public void CreateClient_OldClientExistsNoConfigChange_ReturnsOldInstance()
     {
         var factory = new ForwarderHttpClientFactory(Mock<ILogger<ForwarderHttpClientFactory>>().Object);
@@ -329,6 +347,41 @@ public class ForwarderHttpClientFactoryTests : TestAutoMockBase
                     DangerousAcceptAnyServerCertificate = true,
                     MaxConnectionsPerServer = 10,
                     RequestHeaderEncoding = Encoding.Latin1.WebName,
+                },
+            },
+            new object[] {
+                new HttpClientConfig
+                {
+                    SslProtocols = SslProtocols.Tls11,
+                    DangerousAcceptAnyServerCertificate = true,
+                    MaxConnectionsPerServer = 10,
+                    RequestHeaderEncoding = Encoding.UTF8.WebName,
+                },
+                new HttpClientConfig
+                {
+                    SslProtocols = SslProtocols.Tls11,
+                    DangerousAcceptAnyServerCertificate = true,
+                    MaxConnectionsPerServer = 10,
+                    RequestHeaderEncoding = Encoding.UTF8.WebName,
+                    ResponseHeaderEncoding = Encoding.UTF8.WebName,
+                },
+            },
+            new object[] {
+                new HttpClientConfig
+                {
+                    SslProtocols = SslProtocols.Tls11,
+                    DangerousAcceptAnyServerCertificate = true,
+                    MaxConnectionsPerServer = 10,
+                    RequestHeaderEncoding = Encoding.UTF8.WebName,
+                    ResponseHeaderEncoding = Encoding.Latin1.WebName,
+                },
+                new HttpClientConfig
+                {
+                    SslProtocols = SslProtocols.Tls11,
+                    DangerousAcceptAnyServerCertificate = true,
+                    MaxConnectionsPerServer = 10,
+                    RequestHeaderEncoding = Encoding.UTF8.WebName,
+                    ResponseHeaderEncoding = Encoding.UTF8.WebName,
                 },
             }
         };

--- a/test/ReverseProxy.Tests/Forwarder/ForwarderHttpClientFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/ForwarderHttpClientFactoryTests.cs
@@ -144,7 +144,7 @@ public class ForwarderHttpClientFactoryTests : TestAutoMockBase
         var handler = GetHandler(client);
 
         Assert.NotNull(handler);
-        Assert.NotNull(handler.RequestHeaderEncodingSelector);
+        Assert.NotNull(handler.ResponseHeaderEncodingSelector);
         Assert.Equal(Encoding.Latin1, handler.ResponseHeaderEncodingSelector(default, default));
         VerifyDefaultValues(handler, nameof(SocketsHttpHandler.ResponseHeaderEncodingSelector));
     }

--- a/test/ReverseProxy.Tests/Management/ProxyConfigManagerTests.cs
+++ b/test/ReverseProxy.Tests/Management/ProxyConfigManagerTests.cs
@@ -806,6 +806,7 @@ public class ProxyConfigManagerTests
                 SslProtocols = SslProtocols.Tls11 | SslProtocols.Tls12,
                 MaxConnectionsPerServer = 10,
                 RequestHeaderEncoding = Encoding.UTF8.WebName,
+                ResponseHeaderEncoding = Encoding.UTF8.WebName,
             },
             HealthCheck = new HealthCheckConfig
             {
@@ -834,6 +835,7 @@ public class ProxyConfigManagerTests
         Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, clusterModel.Config.HttpClient.SslProtocols);
         Assert.Equal(10, clusterModel.Config.HttpClient.MaxConnectionsPerServer);
         Assert.Equal(Encoding.UTF8.WebName, clusterModel.Config.HttpClient.RequestHeaderEncoding);
+        Assert.Equal(Encoding.UTF8.WebName, clusterModel.Config.HttpClient.ResponseHeaderEncoding);
 
         var handler = ForwarderHttpClientFactoryTests.GetHandler(clusterModel.HttpClient);
         Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, handler.SslOptions.EnabledSslProtocols);


### PR DESCRIPTION
## Overview

This change intends to allow consumers to be able to choose tolerance for non-default (non-ASCII) encoding of Response headers for forwarded requests by leveraging [`SocketsHttpHandler.ResponseHeaderEncodingSelector`](https://docs.microsoft.com/dotnet/api/system.net.http.socketshttphandler.responseheaderencodingselector). The idea is to provide something similar to the existing [`HttpClientConfig.RequestHeaderEncoding`](https://microsoft.github.io/reverse-proxy/api/Yarp.ReverseProxy.Configuration.HttpClientConfig.html#Yarp_ReverseProxy_Configuration_HttpClientConfig_RequestHeaderEncoding) property via a new `HttpClientConfig.ResponseHeaderEncoding` property.

Hopefully, this helps close https://github.com/microsoft/reverse-proxy/issues/1346 and helps simplify solution for https://github.com/microsoft/reverse-proxy/issues/2076.

## Changes

1. add support for [`SocketsHttpHandler.ResponseHeaderEncodingSelector`](https://docs.microsoft.com/dotnet/api/system.net.http.socketshttphandler.responseheaderencodingselector) via new `ResponseHeaderEncoding` member in [`HttpClientConfig`](https://microsoft.github.io/reverse-proxy/api/Yarp.ReverseProxy.Configuration.HttpClientConfig.html)
1. honour the same in [`ForwarderHttpClientFactory.ConfigureHandler`](https://microsoft.github.io/reverse-proxy/api/Yarp.ReverseProxy.Forwarder.ForwarderHttpClientFactory.html#Yarp_ReverseProxy_Forwarder_ForwarderHttpClientFactory_ConfigureHandler_Yarp_ReverseProxy_Forwarder_ForwarderHttpClientContext_SocketsHttpHandler_)
1. update existing & add new relevant tests
1. update relevant documentation for API, usage & samples

## Testing

No additional testing has been performed other than relying on CI to validate updated & newly added tests in code. Happy to discuss more testing if required.