### PR TITLE
Update NotContains match mode for Header and QueryParameters to support missing/empty values

### DIFF
--- a/src/ReverseProxy/Routing/HeaderMatcherPolicy.cs
+++ b/src/ReverseProxy/Routing/HeaderMatcherPolicy.cs
@@ -83,7 +83,7 @@ internal sealed class HeaderMatcherPolicy : MatcherPolicy, IEndpointComparerPoli
                         }
                         break;
                     case HeaderMatchMode.NotExists:
-                        if (!keyExists || valueIsEmpty)
+                        if (!keyExists)
                         {
                             matched = true;
                         }

--- a/src/ReverseProxy/Routing/HeaderMatcherPolicy.cs
+++ b/src/ReverseProxy/Routing/HeaderMatcherPolicy.cs
@@ -89,11 +89,6 @@ internal sealed class HeaderMatcherPolicy : MatcherPolicy, IEndpointComparerPoli
                         }
                         break;
                     case HeaderMatchMode.ExactHeader:
-                        if (keyExists && !valueIsEmpty)
-                        {
-                            matched = TryMatchExactOrPrefix(matcher, requestHeaderValues);
-                        }
-                        break;
                     case HeaderMatchMode.HeaderPrefix:
                         if (keyExists && !valueIsEmpty)
                         {

--- a/src/ReverseProxy/Routing/QueryParameterMatcherPolicy.cs
+++ b/src/ReverseProxy/Routing/QueryParameterMatcherPolicy.cs
@@ -69,8 +69,8 @@ internal sealed class QueryParameterMatcherPolicy : MatcherPolicy, IEndpointComp
 
             foreach (var matcher in matchers)
             {
-                if (query.TryGetValue(matcher.Name, out var requestQueryParameterValues) &&
-                    !StringValues.IsNullOrEmpty(requestQueryParameterValues))
+                if (query.TryGetValue(matcher.Name, out var requestQueryParameterValues)
+                    && !StringValues.IsNullOrEmpty(requestQueryParameterValues))
                 {
                     if (matcher.Mode is QueryParameterMatchMode.Exists)
                     {
@@ -81,6 +81,10 @@ internal sealed class QueryParameterMatcherPolicy : MatcherPolicy, IEndpointComp
                     {
                         continue;
                     }
+                }
+                else if (matcher.Mode is QueryParameterMatchMode.NotContains)
+                {
+                    continue;
                 }
 
                 candidates.SetValidity(i, false);

--- a/test/ReverseProxy.Tests/Routing/HeaderMatcherPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Routing/HeaderMatcherPolicyTests.cs
@@ -154,7 +154,7 @@ public class HeaderMatcherPolicyTests
     [InlineData("", HeaderMatchMode.Exists, false)]
     [InlineData("abc", HeaderMatchMode.Exists, true)]
     [InlineData(null, HeaderMatchMode.NotExists, true)]
-    [InlineData("", HeaderMatchMode.NotExists, true)]
+    [InlineData("", HeaderMatchMode.NotExists, false)]
     [InlineData("abc", HeaderMatchMode.NotExists, false)]
     public async Task ApplyAsync_MatchingScenarios_AnyHeaderValue(string incomingHeaderValue, HeaderMatchMode mode, bool shouldMatch)
     {

--- a/test/ReverseProxy.Tests/Routing/HeaderMatcherPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Routing/HeaderMatcherPolicyTests.cs
@@ -154,7 +154,7 @@ public class HeaderMatcherPolicyTests
     [InlineData("", HeaderMatchMode.Exists, false)]
     [InlineData("abc", HeaderMatchMode.Exists, true)]
     [InlineData(null, HeaderMatchMode.NotExists, true)]
-    [InlineData("", HeaderMatchMode.NotExists, false)]
+    [InlineData("", HeaderMatchMode.NotExists, true)]
     [InlineData("abc", HeaderMatchMode.NotExists, false)]
     public async Task ApplyAsync_MatchingScenarios_AnyHeaderValue(string incomingHeaderValue, HeaderMatchMode mode, bool shouldMatch)
     {
@@ -276,12 +276,14 @@ public class HeaderMatcherPolicyTests
     [InlineData("abc", HeaderMatchMode.Contains, false, "abc\"", true)]
     [InlineData("abc", HeaderMatchMode.Contains, false, "\"abc\"", true)]
     [InlineData("abc", HeaderMatchMode.Contains, false, "ab\"c", false)]
-    [InlineData("abc", HeaderMatchMode.NotContains, false, "", false)]
+    [InlineData("abc", HeaderMatchMode.NotContains, false, null, true)]
+    [InlineData("abc", HeaderMatchMode.NotContains, false, "", true)]
     [InlineData("abc", HeaderMatchMode.NotContains, false, "ababc", false)]
     [InlineData("abc", HeaderMatchMode.NotContains, false, "zaBCz", false)]
     [InlineData("abc", HeaderMatchMode.NotContains, false, "dcbaabcd", false)]
     [InlineData("abc", HeaderMatchMode.NotContains, false, "ababab", true)]
-    [InlineData("abc", HeaderMatchMode.NotContains, true, "", false)]
+    [InlineData("abc", HeaderMatchMode.NotContains, true, null, true)]
+    [InlineData("abc", HeaderMatchMode.NotContains, true, "", true)]
     [InlineData("abc", HeaderMatchMode.NotContains, true, "abcc", false)]
     [InlineData("abc", HeaderMatchMode.NotContains, true, "aaaBC", true)]
     [InlineData("abc", HeaderMatchMode.NotContains, true, "bbabcdb", false)]
@@ -412,16 +414,16 @@ public class HeaderMatcherPolicyTests
     [InlineData("abc", "def", HeaderMatchMode.Contains, true, "\"abc, def\"", true)]
     [InlineData("abc", "def", HeaderMatchMode.Contains, true, "\"abc\", def\"", true)]
     [InlineData("abc", "def", HeaderMatchMode.Contains, true, "ab\"cde\"f", false)]
-    [InlineData("abc", "def", HeaderMatchMode.NotContains, false, null, false)]
-    [InlineData("abc", "def", HeaderMatchMode.NotContains, false, "", false)]
+    [InlineData("abc", "def", HeaderMatchMode.NotContains, false, null, true)]
+    [InlineData("abc", "def", HeaderMatchMode.NotContains, false, "", true)]
     [InlineData("abc", "def", HeaderMatchMode.NotContains, false, "aabc", false)]
     [InlineData("abc", "def", HeaderMatchMode.NotContains, false, "baBc", false)]
     [InlineData("abc", "def", HeaderMatchMode.NotContains, false, "ababcd", false)]
     [InlineData("abc", "def", HeaderMatchMode.NotContains, false, "dcabcD", false)]
     [InlineData("abc", "def", HeaderMatchMode.NotContains, false, "def", false)]
     [InlineData("abc", "def", HeaderMatchMode.NotContains, false, "ghi", true)]
-    [InlineData("abc", "def", HeaderMatchMode.NotContains, true, null, false)]
-    [InlineData("abc", "def", HeaderMatchMode.NotContains, true, "", false)]
+    [InlineData("abc", "def", HeaderMatchMode.NotContains, true, null, true)]
+    [InlineData("abc", "def", HeaderMatchMode.NotContains, true, "", true)]
     [InlineData("abc", "def", HeaderMatchMode.NotContains, true, "cabca", false)]
     [InlineData("abc", "def", HeaderMatchMode.NotContains, true, "aBCa", true)]
     [InlineData("abc", "def", HeaderMatchMode.NotContains, true, "CaBCdd", true)]
@@ -453,6 +455,42 @@ public class HeaderMatcherPolicyTests
 
         var endpoint = CreateEndpoint("org-id", new[] { header1Value, header2Value }, headerValueMatchMode, isCaseSensitive);
 
+        var candidates = new CandidateSet(new[] { endpoint }, new RouteValueDictionary[1], new int[1]);
+        var sut = new HeaderMatcherPolicy();
+
+        await sut.ApplyAsync(context, candidates);
+
+        Assert.Equal(shouldMatch, candidates.IsValidCandidate(0));
+    }
+
+    [Theory]
+    [InlineData(HeaderMatchMode.Contains, true, false)]
+    [InlineData(HeaderMatchMode.Contains, false, false)]
+    [InlineData(HeaderMatchMode.NotContains, true, true)]
+    [InlineData(HeaderMatchMode.NotContains, false, true)]
+    [InlineData(HeaderMatchMode.HeaderPrefix, true, false)]
+    [InlineData(HeaderMatchMode.HeaderPrefix, false, false)]
+    [InlineData(HeaderMatchMode.ExactHeader, true, false)]
+    [InlineData(HeaderMatchMode.ExactHeader, false, false)]
+    [InlineData(HeaderMatchMode.NotExists, true, true)]
+    [InlineData(HeaderMatchMode.NotExists, false, true)]
+    [InlineData(HeaderMatchMode.Exists, true, false)]
+    [InlineData(HeaderMatchMode.Exists, false, false)]
+    public async Task ApplyAsync_MatchingScenarios_MissingHeader(
+        HeaderMatchMode headerValueMatchMode,
+        bool isCaseSensitive,
+        bool shouldMatch)
+    {
+        var context = new DefaultHttpContext();
+
+        var headerValues = new[] { "bar" };
+        if (headerValueMatchMode == HeaderMatchMode.Exists
+            || headerValueMatchMode == HeaderMatchMode.NotExists)
+        {
+            headerValues = null;
+        }
+
+        var endpoint = CreateEndpoint("foo", headerValues, headerValueMatchMode, isCaseSensitive);
         var candidates = new CandidateSet(new[] { endpoint }, new RouteValueDictionary[1], new int[1]);
         var sut = new HeaderMatcherPolicy();
 

--- a/test/ReverseProxy.Tests/Routing/QueryMatcherPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Routing/QueryMatcherPolicyTests.cs
@@ -394,12 +394,6 @@ public class QueryParameterMatcherPolicyTests
         Assert.Equal(shouldMatch, candidates.IsValidCandidate(0));
     }
 
-    /// <summary>
-    /// Test each match mode where the matched query param is non-existent in the request querystring.
-    /// </summary>
-    /// <param name="queryParamValueMatchMode">Match mode.</param>
-    /// <param name="isCaseSensitive">Test case sensitivity</param>
-    /// <param name="shouldMatch">Expected match result.</param>
     [Theory]
     [InlineData(QueryParameterMatchMode.NotContains, true, true)]
     [InlineData(QueryParameterMatchMode.NotContains, false, true)]


### PR DESCRIPTION
fixes #2260

Currently the NotContains modes for both Header and QueryParameter matches do not match correctly when the value of the header/query is empty or if the key does not exist entirely. 

Updated the match logic to the below (assuming any non-empty request values match the value specified by the route):

| Type | Mode | RequestKey | RequestValue | CurrentMatch | ExpectedMatch |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| Header/QueryParam | NotContains | None | - | No | **Yes** |
| Header/QueryParam | NotContains | Exists | Empty | No | **Yes** |
| Header/QueryParam | NotContains | Exists | NonEmpty | No | No |