### PR TITLE
Use SearchValues in `RequestUtilities.EncodePath`

### DIFF
--- a/src/ReverseProxy/Transforms/RequestHeaderForwardedTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderForwardedTransform.cs
@@ -79,13 +79,12 @@ public class RequestHeaderForwardedTransform : RequestTransform
 
     private string GetHeaderValue(HttpContext httpContext)
     {
-        var builder = new ValueStringBuilder();
+        var builder = new ValueStringBuilder(stackalloc char[ValueStringBuilder.StackallocThreshold]);
         AppendProto(httpContext, ref builder);
         AppendHost(httpContext, ref builder);
         AppendFor(httpContext, ref builder);
         AppendBy(httpContext, ref builder);
-        var value = builder.ToString();
-        return value;
+        return builder.ToString();
     }
 
     private void AppendProto(HttpContext context, ref ValueStringBuilder builder)

--- a/src/ReverseProxy/Utilities/SkipLocalsInit.cs
+++ b/src/ReverseProxy/Utilities/SkipLocalsInit.cs
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Used to indicate to the compiler that the .locals init flag should not be set in method headers.
+[module: System.Runtime.CompilerServices.SkipLocalsInit]

--- a/src/ReverseProxy/Utilities/ValueStringBuilder.cs
+++ b/src/ReverseProxy/Utilities/ValueStringBuilder.cs
@@ -77,6 +77,18 @@ internal ref partial struct ValueStringBuilder
         _pos += s.Length;
     }
 
+    public void Append(ReadOnlySpan<char> value)
+    {
+        var pos = _pos;
+        if (pos > _chars.Length - value.Length)
+        {
+            Grow(value.Length);
+        }
+
+        value.CopyTo(_chars.Slice(_pos));
+        _pos += value.Length;
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Append(int i)
     {


### PR DESCRIPTION
Same idea (and therefore similar numbers) as https://github.com/dotnet/aspnetcore/pull/49117.

While I was touching the code, I also added support for using a `stackalloc`ed buffer with `ValueStringBuilder` now that we're targeting TFMs that can always use `SkipLocalsInit`.

Also removed the `if (count == value.Length && !requiresEscaping)` path that's unreachable in our case (it's reachable in `PathString` because there we detect percent-encoded sequences and avoid re-encoding them).