### PR TITLE
failing tests for rate limiter policy validation when 'default' or 'disable' used

### DIFF
--- a/src/ReverseProxy/Configuration/ConfigValidator.cs
+++ b/src/ReverseProxy/Configuration/ConfigValidator.cs
@@ -312,6 +312,7 @@ internal sealed class ConfigValidator : IConfigValidator
                 return;
             }
 
+            //TODO: this only gets invoked if a custom RateLimiter policy is named one of the following, AND it gets used. Is there a better way to check this at startup? or is it unlikely that the policy will be registered but not used?
             if (string.Equals(RateLimitingConstants.Default, rateLimiterPolicyName, StringComparison.OrdinalIgnoreCase)
                 || string.Equals(RateLimitingConstants.Disable, rateLimiterPolicyName, StringComparison.OrdinalIgnoreCase))
             {

--- a/src/ReverseProxy/Configuration/ConfigValidator.cs
+++ b/src/ReverseProxy/Configuration/ConfigValidator.cs
@@ -308,6 +308,13 @@ internal sealed class ConfigValidator : IConfigValidator
 
             if (policy is null)
             {
+                if (string.Equals(RateLimitingConstants.Default, rateLimiterPolicyName, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(RateLimitingConstants.Disable, rateLimiterPolicyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    // We weren't expecting to find a policy with these names.
+                    return;
+                }    
+            
                 errors.Add(new ArgumentException($"RateLimiter policy '{rateLimiterPolicyName}' not found for route '{routeId}'."));
                 return;
             }

--- a/test/ReverseProxy.Tests/Configuration/ConfigValidatorTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigValidatorTests.cs
@@ -4,7 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+#if NET7_0_OR_GREATER
+using Microsoft.AspNetCore.Builder;
+#endif
 using Microsoft.AspNetCore.Cors.Infrastructure;
+#if NET7_0_OR_GREATER
+using Microsoft.AspNetCore.RateLimiting;
+#endif
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
@@ -732,6 +738,34 @@ public class ConfigValidatorTests
         var result = await validator.ValidateRouteAsync(route);
 
         Assert.Empty(result);
+    }
+
+    [Theory]
+    [InlineData("Default")]
+    [InlineData("Disable")]
+    public async Task Reports_BuildInRateLimiterPolicyNameConflict(string rateLimiterPolicy)
+    {
+        var route = new RouteConfig
+        {
+            RouteId = "route1",
+            Match = new RouteMatch
+            {
+                Hosts = new[] { "localhost" },
+            },
+            ClusterId = "cluster1",
+            RateLimiterPolicy = rateLimiterPolicy
+        };
+
+        var services = CreateServices(s =>
+        {
+            s.AddRateLimiter(o => o.AddConcurrencyLimiter(rateLimiterPolicy, c => { }));
+        });
+        var validator = services.GetRequiredService<IConfigValidator>();
+
+        var result = await validator.ValidateRouteAsync(route);
+
+        Assert.NotEmpty(result);
+        Assert.Contains(result, err => err.Message.Contains($"The application has registered a RateLimiter policy named '{rateLimiterPolicy}' that conflicts with the reserved RateLimiter policy name used on this route. The registered policy name needs to be changed for this route to function."));
     }
 
     [Theory]


### PR DESCRIPTION
Debugging during a test run I can see that `_rateLimiterPolicyProvider.GetPolicyAsync(rateLimiterPolicyName)` always returns null for the values `default` or `disable`, and the reason seems to be that the collection the method is reading from is empty - should it contain some default policies?