### PR TITLE
Set IsPackable to true for the k8s project on non rtw builds

### DIFF
--- a/src/Kubernetes.Controller/Yarp.Kubernetes.Controller.csproj
+++ b/src/Kubernetes.Controller/Yarp.Kubernetes.Controller.csproj
@@ -5,7 +5,8 @@
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
-    <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'rtw'">false</IsPackable>
+    <IsPackable>true</IsPackable>
+    <IsShipping>false</IsShipping>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Kubernetes.Controller/Yarp.Kubernetes.Controller.csproj
+++ b/src/Kubernetes.Controller/Yarp.Kubernetes.Controller.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
-    <IsPackable>$('System.TeamProject') != 'internal'</IsPackable>
+    <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'rtw'">false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix #2134

This will enable the package creation only for non rtw build, meaning that the NuGet will be created for nightly and preview builds.