### PR TITLE
Timeout integration

### DIFF
--- a/docs/docfx/articles/timeouts.md
+++ b/docs/docfx/articles/timeouts.md
@@ -45,37 +45,26 @@ Example:
 }
 ```
 
-Timeout policies can be configured in Startup.ConfigureServices as follows:
-```
-public void ConfigureServices(IServiceCollection services)
+Timeout policies and the default policy can be configured in the service collection and the middleware can be added as follows:
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddReverseProxy()
+    .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
+
+builder.Services.AddRequestTimeouts(options =>
 {
-    services.AddRequestTimeouts(options =>
-    {
-        options.AddPolicy("customPolicy", TimeSpan.FromSeconds(20));
-    });
-}
+    options.AddPolicy("customPolicy", TimeSpan.FromSeconds(20));
+});
+
+var app = builder.Build();
+
+app.UseRequestTimeouts();
+
+app.MapReverseProxy();
+
+app.Run();
 ```
-
-In Startup.Configure add the timeout middleware between Routing and Endpoints.
-
-```
-public void Configure(IApplicationBuilder app)
-{
-    app.UseRouting();
-
-    app.UseRequestTimeouts();
-
-    app.UseEndpoints(endpoints =>
-    {
-        endpoints.MapReverseProxy();
-    });
-}
-```
-
-
-### DefaultPolicy
-
-Specifying the value `default` in a route's `TimeoutPolicy` parameter means that route will use the policy defined in [RequestTimeoutOptions.DefaultPolicy](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.http.timeouts.requesttimeoutoptions.defaultpolicy#microsoft-aspnetcore-http-timeouts-requesttimeoutoptions-defaultpolicy).
 
 ### Disable timeouts
 

--- a/docs/docfx/articles/timeouts.md
+++ b/docs/docfx/articles/timeouts.md
@@ -1,0 +1,86 @@
+# Request Timeouts
+
+## Introduction
+
+.NET 8 introduced the [Request Timeouts Middleware](https://learn.microsoft.com/aspnet/core/performance/timeouts) to enable configuring request timeouts globally as well as per endpoint. This functionality is also available in YARP 2.1 when running on .NET 8.
+
+## Defaults
+Requests do not have any timeouts by default, other than the [Activity Timeout](http-client-config.md#HttpRequest) used to clean up idle requests. A default policy specified in [RequestTimeoutOptions](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.http.timeouts.requesttimeoutoptions) will apply to proxied requests as well.
+
+## Configuration
+Timeouts and Timeout Policies can be specified per route via [RouteConfig](xref:Yarp.ReverseProxy.Configuration.RouteConfig) and can be bound from the `Routes` sections of the config file. As with other route properties, this can be modified and reloaded without restarting the proxy. Policy names are case insensitive.
+
+Timeouts are specified in a TimeSpan HH:MM:SS format. Specifying both Timeout and TimeoutPolicy on the same route is invalid and will cause the configuration to be rejected.
+
+Example:
+```JSON
+{
+  "ReverseProxy": {
+    "Routes": {
+      "route1" : {
+        "ClusterId": "cluster1",
+        "TimeoutPolicy": "customPolicy",
+        "Match": {
+          "Hosts": [ "localhost" ]
+        },
+      }
+      "route2" : {
+        "ClusterId": "cluster1",
+        "Timeout": "00:01:00",
+        "Match": {
+          "Hosts": [ "localhost2" ]
+        },
+      }
+    },
+    "Clusters": {
+      "cluster1": {
+        "Destinations": {
+          "cluster1/destination1": {
+            "Address": "https://localhost:10001/"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Timeout policies can be configured in Startup.ConfigureServices as follows:
+```
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddRequestTimeouts(options =>
+    {
+        options.AddPolicy("customPolicy", TimeSpan.FromSeconds(20));
+    });
+}
+```
+
+In Startup.Configure add the timeout middleware between Routing and Endpoints.
+
+```
+public void Configure(IApplicationBuilder app)
+{
+    app.UseRouting();
+
+    app.UseRequestTimeouts();
+
+    app.UseEndpoints(endpoints =>
+    {
+        endpoints.MapReverseProxy();
+    });
+}
+```
+
+
+### DefaultPolicy
+
+Specifying the value `default` in a route's `TimeoutPolicy` parameter means that route will use the policy defined in [RequestTimeoutOptions.DefaultPolicy](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.http.timeouts.requesttimeoutoptions.defaultpolicy#microsoft-aspnetcore-http-timeouts-requesttimeoutoptions-defaultpolicy).
+
+### Disable timeouts
+
+Specifying the value `disable` in a route's `TimeoutPolicy` parameter means the request timeout middleware will not apply timeouts to this route.
+
+### WebSockets
+
+Request timeouts are disabled after the initial WebSocket handshake.

--- a/docs/docfx/articles/toc.yml
+++ b/docs/docfx/articles/toc.yml
@@ -42,6 +42,8 @@
   href: grpc.md
 - name: WebSockets and SPDY
   href: websockets.md
+- name: Timeouts
+  href: timeouts.md
 - name: Service Fabric Integration
   href: service-fabric-int.md
 - name: Http.sys Delegation

--- a/docs/docfx/articles/websockets.md
+++ b/docs/docfx/articles/websockets.md
@@ -21,3 +21,7 @@ The incoming and outgoing protocol versions do not need to match. The incoming W
 WebSockets require different HTTP headers for HTTP/2 so YARP will add and remove these headers as needed when adapting between the different versions.
 
 After the initial handshake WebSockets function the same way over both HTTP versions.
+
+## Timeout
+
+[Http Request Timeouts](https://learn.microsoft.com/aspnet/core/performance/timeouts) (.NET 8+) can apply timeouts to all requests by default or by policy. These timeouts will be disabled after a WebSocket handshake. They will still apply to gRPC requests. For additional configuration see [Timeouts](timeouts.md).

--- a/samples/ReverseProxy.Minimal.Sample/Program.cs
+++ b/samples/ReverseProxy.Minimal.Sample/Program.cs
@@ -2,9 +2,16 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddReverseProxy()
     .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
-
+#if NET8_0_OR_GREATER
+builder.Services.AddRequestTimeouts(options =>
+{
+    options.AddPolicy("customPolicy", TimeSpan.FromSeconds(20));
+});
+#endif
 var app = builder.Build();
-
+#if NET8_0_OR_GREATER
+app.UseRequestTimeouts();
+#endif
 app.MapReverseProxy();
 
 app.Run();

--- a/src/Kubernetes.Controller/Converters/YarpIngressOptions.cs
+++ b/src/Kubernetes.Controller/Converters/YarpIngressOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using Yarp.ReverseProxy.Configuration;
 
@@ -18,6 +19,8 @@ internal sealed class YarpIngressOptions
     public HttpClientConfig HttpClientConfig { get; set; }
     public string LoadBalancingPolicy { get; set; }
     public string CorsPolicy { get; set; }
+    public string TimeoutPolicy { get; set; }
+    public TimeSpan? Timeout { get; set; }
     public HealthCheckConfig HealthCheck { get; set; }
     public Dictionary<string, string> RouteMetadata { get; set; }
     public List<RouteHeader> RouteHeaders { get; set; }

--- a/src/Kubernetes.Controller/Converters/YarpParser.cs
+++ b/src/Kubernetes.Controller/Converters/YarpParser.cs
@@ -143,6 +143,10 @@ internal static class YarpParser
 #if NET7_0_OR_GREATER
             RateLimiterPolicy = ingressContext.Options.RateLimiterPolicy,
 #endif
+#if NET8_0_OR_GREATER
+            Timeout = ingressContext.Options.Timeout,
+            TimeoutPolicy = ingressContext.Options.TimeoutPolicy,
+#endif
             CorsPolicy = ingressContext.Options.CorsPolicy,
             Metadata = ingressContext.Options.RouteMetadata,
             Order = ingressContext.Options.RouteOrder,

--- a/src/ReverseProxy/Configuration/ConfigProvider/ConfigurationConfigProvider.cs
+++ b/src/ReverseProxy/Configuration/ConfigProvider/ConfigurationConfigProvider.cs
@@ -150,6 +150,10 @@ internal sealed class ConfigurationConfigProvider : IProxyConfigProvider, IDispo
 #if NET7_0_OR_GREATER
             RateLimiterPolicy = section[nameof(RouteConfig.RateLimiterPolicy)],
 #endif
+#if NET8_0_OR_GREATER
+            TimeoutPolicy = section[nameof(RouteConfig.TimeoutPolicy)],
+            Timeout = section.ReadTimeSpan(nameof(RouteConfig.Timeout)),
+#endif
             CorsPolicy = section[nameof(RouteConfig.CorsPolicy)],
             Metadata = section.GetSection(nameof(RouteConfig.Metadata)).ReadStringDictionary(),
             Transforms = CreateTransforms(section.GetSection(nameof(RouteConfig.Transforms))),

--- a/src/ReverseProxy/Configuration/ConfigValidator.cs
+++ b/src/ReverseProxy/Configuration/ConfigValidator.cs
@@ -93,6 +93,9 @@ internal sealed class ConfigValidator : IConfigValidator
 #if NET7_0_OR_GREATER
         await ValidateRateLimiterPolicyAsync(errors, route.RateLimiterPolicy, route.RouteId);
 #endif
+#if NET8_0_OR_GREATER
+        ValidateTimeoutPolicy(errors, route.TimeoutPolicy, route.Timeout, route.RouteId);
+#endif
         await ValidateCorsPolicyAsync(errors, route.CorsPolicy, route.RouteId);
 
         if (route.Match is null)

--- a/src/ReverseProxy/Configuration/ConfigValidator.cs
+++ b/src/ReverseProxy/Configuration/ConfigValidator.cs
@@ -318,8 +318,7 @@ internal sealed class ConfigValidator : IConfigValidator
         {
             var policies = _timeoutOptions.CurrentValue.Policies;
 
-            if (string.Equals(TimeoutPolicyConstants.Default, timeoutPolicyName, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(TimeoutPolicyConstants.Disable, timeoutPolicyName, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(TimeoutPolicyConstants.Disable, timeoutPolicyName, StringComparison.OrdinalIgnoreCase))
             {
                 if (policies.TryGetValue(timeoutPolicyName, out var _))
                 {
@@ -337,7 +336,7 @@ internal sealed class ConfigValidator : IConfigValidator
             }
         }
 
-        if (timeout.HasValue && timeout.Value.TotalMicroseconds <= 0)
+        if (timeout.HasValue && timeout.Value.TotalMilliseconds <= 0)
         {
             errors.Add(new ArgumentException($"The Timeout value '{timeout.Value}' is invalid for route '{routeId}'. The Timeout must be greater than zero milliseconds."));
         }

--- a/src/ReverseProxy/Configuration/RouteConfig.cs
+++ b/src/ReverseProxy/Configuration/RouteConfig.cs
@@ -107,6 +107,10 @@ public sealed record RouteConfig
 #if NET7_0_OR_GREATER
             && string.Equals(RateLimiterPolicy, other.RateLimiterPolicy, StringComparison.OrdinalIgnoreCase)
 #endif
+#if NET8_0_OR_GREATER
+            && string.Equals(TimeoutPolicy, other.TimeoutPolicy, StringComparison.OrdinalIgnoreCase)
+            && Timeout == other.Timeout
+#endif
             && string.Equals(CorsPolicy, other.CorsPolicy, StringComparison.OrdinalIgnoreCase)
             && Match == other.Match
             && CaseSensitiveEqualHelper.Equals(Metadata, other.Metadata)
@@ -123,6 +127,10 @@ public sealed record RouteConfig
         hash.Add(AuthorizationPolicy?.GetHashCode(StringComparison.OrdinalIgnoreCase));
 #if NET7_0_OR_GREATER
         hash.Add(RateLimiterPolicy?.GetHashCode(StringComparison.OrdinalIgnoreCase));
+#endif
+#if NET8_0_OR_GREATER
+        hash.Add(Timeout?.GetHashCode());
+        hash.Add(TimeoutPolicy?.GetHashCode(StringComparison.OrdinalIgnoreCase));
 #endif
         hash.Add(CorsPolicy?.GetHashCode(StringComparison.OrdinalIgnoreCase));
         hash.Add(Match);

--- a/src/ReverseProxy/Configuration/RouteConfig.cs
+++ b/src/ReverseProxy/Configuration/RouteConfig.cs
@@ -52,6 +52,23 @@ public sealed record RouteConfig
     /// </summary>
     public string? RateLimiterPolicy { get; init; }
 #endif
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// The name of the TimeoutPolicy to apply to this route.
+    /// Setting both Timeout and TimeoutPolicy is an error.
+    /// If not set then only the system default will apply.
+    /// Set to "Disable" to disable timeouts for this route.
+    /// Set to "Default" or leave empty to use the system defaults, if any.
+    /// </summary>
+    public string? TimeoutPolicy { get; init; }
+
+    /// <summary>
+    /// The Timeout to apply to this route. This overrides any system defaults.
+    /// Setting both Timeout and TimeoutPolicy is an error.
+    /// Timeout granularity is limited to milliseconds.
+    /// </summary>
+    public TimeSpan? Timeout { get; init; }
+#endif
     /// <summary>
     /// The name of the CorsPolicy to apply to this route.
     /// If not set then the route won't be automatically matched for cors preflight requests.

--- a/src/ReverseProxy/Configuration/TimeoutPolicyConstants.cs
+++ b/src/ReverseProxy/Configuration/TimeoutPolicyConstants.cs
@@ -5,6 +5,5 @@ namespace Yarp.ReverseProxy.Configuration;
 
 internal static class TimeoutPolicyConstants
 {
-    internal const string Default = "Default";
     internal const string Disable = "Disable";
 }

--- a/src/ReverseProxy/Configuration/TimeoutPolicyConstants.cs
+++ b/src/ReverseProxy/Configuration/TimeoutPolicyConstants.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Yarp.ReverseProxy.Configuration;
+
+internal static class TimeoutPolicyConstants
+{
+    internal const string Default = "Default";
+    internal const string Disable = "Disable";
+}

--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -12,6 +12,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+#if NET8_0_OR_GREATER
+using Microsoft.AspNetCore.Http.Timeouts;
+#endif
 using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
@@ -719,6 +722,10 @@ internal sealed class HttpForwarder : IHttpForwarder
                 Debug.Assert(upgradeFeature != null);
                 upgradeResult = await upgradeFeature.UpgradeAsync();
             }
+#if NET8_0_OR_GREATER
+            // Disable request timeout, if there is one, after the upgrade has been accepted
+            context.Features.Get<IHttpRequestTimeoutFeature>()?.DisableTimeout();
+#endif
         }
         catch (Exception ex)
         {

--- a/src/ReverseProxy/Model/ProxyPipelineInitializerMiddleware.cs
+++ b/src/ReverseProxy/Model/ProxyPipelineInitializerMiddleware.cs
@@ -50,7 +50,9 @@ internal sealed class ProxyPipelineInitializerMiddleware
 #if NET8_0_OR_GREATER
         // There's no way to detect the presence of the timeout middleware before this, only the options.
         if (endpoint.Metadata.GetMetadata<RequestTimeoutAttribute>() != null
-            && context.Features.Get<IHttpRequestTimeoutFeature>() == null)
+            && context.Features.Get<IHttpRequestTimeoutFeature>() == null
+            // The feature is skipped if the request is already canceled. We'll handle canceled requests later for consistency.
+            && !context.RequestAborted.IsCancellationRequested)
         {
             Log.TimeoutNotApplied(_logger, route.Config.RouteId);
             // Out of an abundance of caution, refuse the request rather than allowing it to proceed without the configured timeout.

--- a/src/ReverseProxy/Routing/ProxyEndpointFactory.cs
+++ b/src/ReverseProxy/Routing/ProxyEndpointFactory.cs
@@ -138,7 +138,6 @@ internal sealed class ProxyEndpointFactory
             endpointBuilder.Metadata.Add(new EnableRateLimitingAttribute(config.RateLimiterPolicy));
         }
 #endif
-
 #if NET8_0_OR_GREATER
         if (string.Equals(TimeoutPolicyConstants.Default, config.TimeoutPolicy, StringComparison.OrdinalIgnoreCase))
         {
@@ -148,6 +147,7 @@ internal sealed class ProxyEndpointFactory
         {
             endpointBuilder.Metadata.Add(_disableRequestTimeout);
         }
+        // The config validator shouldn't allow both TimeoutPolicy and Timeout, so we don't have to consider priority.
         else if (!string.IsNullOrEmpty(config.TimeoutPolicy))
         {
             endpointBuilder.Metadata.Add(new RequestTimeoutAttribute(config.TimeoutPolicy));

--- a/src/ReverseProxy/Routing/ProxyEndpointFactory.cs
+++ b/src/ReverseProxy/Routing/ProxyEndpointFactory.cs
@@ -139,11 +139,7 @@ internal sealed class ProxyEndpointFactory
         }
 #endif
 #if NET8_0_OR_GREATER
-        if (string.Equals(TimeoutPolicyConstants.Default, config.TimeoutPolicy, StringComparison.OrdinalIgnoreCase))
-        {
-            // No-op (middleware applies the default)
-        }
-        else if (string.Equals(TimeoutPolicyConstants.Disable, config.TimeoutPolicy, StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(TimeoutPolicyConstants.Disable, config.TimeoutPolicy, StringComparison.OrdinalIgnoreCase))
         {
             endpointBuilder.Metadata.Add(_disableRequestTimeout);
         }

--- a/src/ReverseProxy/Utilities/EventIds.cs
+++ b/src/ReverseProxy/Utilities/EventIds.cs
@@ -67,4 +67,5 @@ internal static class EventIds
     public static readonly EventId RetryingWebSocketDowngradeNoConnect = new EventId(61, "RetryingWebSocketDowngradeNoConnect");
     public static readonly EventId RetryingWebSocketDowngradeNoHttp2 = new EventId(62, "RetryingWebSocketDowngradeNoHttp2");
     public static readonly EventId InvalidSecWebSocketKeyHeader = new EventId(63, "InvalidSecWebSocketKeyHeader");
+    public static readonly EventId TimeoutNotApplied = new(64, nameof(TimeoutNotApplied));
 }

--- a/test/ReverseProxy.Tests/Configuration/ConfigProvider/ConfigurationConfigProviderTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigProvider/ConfigurationConfigProviderTests.cs
@@ -132,6 +132,10 @@ public class ConfigurationConfigProviderTests
 #if NET7_0_OR_GREATER
                 RateLimiterPolicy = "Default",
 #endif
+#if NET8_0_OR_GREATER
+                TimeoutPolicy = "Default",
+                Timeout = TimeSpan.Zero,
+#endif
                 CorsPolicy = "Default",
                 Order = -1,
                 MaxRequestBodySize = -1,
@@ -344,6 +348,8 @@ public class ConfigurationConfigProviderTests
             ""AuthorizationPolicy"": ""Default"",
             ""RateLimiterPolicy"": ""Default"",
             ""CorsPolicy"": ""Default"",
+            ""TimeoutPolicy"": ""Default"",
+            ""Timeout"": ""00:00:01"",
             ""Metadata"": {
                 ""routeA-K1"": ""routeA-V1"",
                 ""routeA-K2"": ""routeA-V2""

--- a/test/ReverseProxy.Tests/Configuration/ConfigValidatorTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigValidatorTests.cs
@@ -605,7 +605,6 @@ public class ConfigValidatorTests
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    [InlineData("defaulT")]
     [InlineData("disAble")]
     public async Task Accepts_ReservedTimeoutPolicy(string policy)
     {

--- a/test/ReverseProxy.Tests/Configuration/RouteConfigTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/RouteConfigTests.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Threading;
 using Xunit;
 
 namespace Yarp.ReverseProxy.Configuration.Tests;
@@ -17,6 +19,10 @@ public class RouteConfigTests
             AuthorizationPolicy = "a",
 #if NET7_0_OR_GREATER
             RateLimiterPolicy = "rl",
+#endif
+#if NET8_0_OR_GREATER
+            TimeoutPolicy = "t",
+            Timeout = TimeSpan.FromSeconds(1),
 #endif
             ClusterId = "c",
             CorsPolicy = "co",
@@ -48,6 +54,10 @@ public class RouteConfigTests
             AuthorizationPolicy = "A",
 #if NET7_0_OR_GREATER
             RateLimiterPolicy = "RL",
+#endif
+#if NET8_0_OR_GREATER
+            TimeoutPolicy = "T",
+            Timeout = TimeSpan.FromSeconds(1),
 #endif
             ClusterId = "C",
             CorsPolicy = "Co",
@@ -91,6 +101,10 @@ public class RouteConfigTests
 #if NET7_0_OR_GREATER
             RateLimiterPolicy = "rl",
 #endif
+#if NET8_0_OR_GREATER
+            TimeoutPolicy = "t",
+            Timeout = TimeSpan.FromSeconds(1),
+#endif
             ClusterId = "c",
             CorsPolicy = "co",
             Match = new RouteMatch()
@@ -126,6 +140,10 @@ public class RouteConfigTests
 #if NET7_0_OR_GREATER
         var i = a with { RateLimiterPolicy = "i" };
 #endif
+#if NET8_0_OR_GREATER
+        var j = a with { TimeoutPolicy = "j" };
+        var k = a with { Timeout = TimeSpan.FromSeconds(107) };
+#endif
 
         Assert.False(a.Equals(b));
         Assert.False(a.Equals(c));
@@ -136,6 +154,10 @@ public class RouteConfigTests
         Assert.False(a.Equals(h));
 #if NET7_0_OR_GREATER
         Assert.False(a.Equals(i));
+#endif
+#if NET8_0_OR_GREATER
+        Assert.False(a.Equals(j));
+        Assert.False(a.Equals(k));
 #endif
     }
 

--- a/test/ReverseProxy.Tests/Model/ProxyPipelineInitializerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Model/ProxyPipelineInitializerMiddlewareTests.cs
@@ -7,6 +7,9 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+#if NET8_0_OR_GREATER
+using Microsoft.AspNetCore.Http.Timeouts;
+#endif
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Moq;
@@ -119,14 +122,85 @@ public class ProxyPipelineInitializerMiddlewareTests : TestAutoMockBase
 
         Assert.Equal(StatusCodes.Status418ImATeapot, httpContext.Response.StatusCode);
     }
+#if NET8_0_OR_GREATER
+    [Fact]
+    public async Task Invoke_MissingTimeoutMiddleware_RefuseRequest()
+    {
+        var httpClient = new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object);
+        var cluster1 = new ClusterState(clusterId: "cluster1")
+        {
+            Model = new ClusterModel(new ClusterConfig(), httpClient)
+        };
 
-    private static Endpoint CreateAspNetCoreEndpoint(RouteModel routeConfig)
+        var aspNetCoreEndpoints = new List<Endpoint>();
+        var routeConfig = new RouteModel(
+            config: new RouteConfig(),
+            cluster: cluster1,
+            transformer: HttpTransformer.Default);
+        var aspNetCoreEndpoint = CreateAspNetCoreEndpoint(routeConfig,
+            builder =>
+            {
+                builder.Metadata.Add(new RequestTimeoutAttribute(1));
+            });
+        aspNetCoreEndpoints.Add(aspNetCoreEndpoint);
+        var httpContext = new DefaultHttpContext();
+        httpContext.SetEndpoint(aspNetCoreEndpoint);
+
+        var sut = Create<ProxyPipelineInitializerMiddleware>();
+
+        await sut.Invoke(httpContext);
+
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, httpContext.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Invoke_MissingTimeoutMiddleware_DefaultPolicyAllowed()
+    {
+        var httpClient = new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object);
+        var cluster1 = new ClusterState(clusterId: "cluster1");
+        cluster1.Model = new ClusterModel(new ClusterConfig(), httpClient);
+        var destination1 = cluster1.Destinations.GetOrAdd(
+            "destination1",
+            id => new DestinationState(id) { Model = new DestinationModel(new DestinationConfig { Address = "https://localhost:123/a/b/" }) });
+        cluster1.DestinationsState = new ClusterDestinationsState(new[] { destination1 }, new[] { destination1 });
+
+        var aspNetCoreEndpoints = new List<Endpoint>();
+        var routeConfig = new RouteModel(
+            config: new RouteConfig(),
+            cluster1,
+            HttpTransformer.Default);
+        var aspNetCoreEndpoint = CreateAspNetCoreEndpoint(routeConfig,
+            builder =>
+            {
+                builder.Metadata.Add(new RequestTimeoutAttribute(TimeoutPolicyConstants.Default));
+            });
+        aspNetCoreEndpoints.Add(aspNetCoreEndpoint);
+        var httpContext = new DefaultHttpContext();
+        httpContext.SetEndpoint(aspNetCoreEndpoint);
+
+        var sut = Create<ProxyPipelineInitializerMiddleware>();
+
+        await sut.Invoke(httpContext);
+
+        var proxyFeature = httpContext.GetReverseProxyFeature();
+        Assert.NotNull(proxyFeature);
+        Assert.NotNull(proxyFeature.AvailableDestinations);
+        Assert.Single(proxyFeature.AvailableDestinations);
+        Assert.Same(destination1, proxyFeature.AvailableDestinations[0]);
+        Assert.Same(cluster1.Model, proxyFeature.Cluster);
+
+        Assert.Equal(StatusCodes.Status418ImATeapot, httpContext.Response.StatusCode);
+    }
+#endif
+
+    private static Endpoint CreateAspNetCoreEndpoint(RouteModel routeConfig, Action<RouteEndpointBuilder> configure = null)
     {
         var endpointBuilder = new RouteEndpointBuilder(
             requestDelegate: httpContext => Task.CompletedTask,
             routePattern: RoutePatternFactory.Parse("/"),
             order: 0);
         endpointBuilder.Metadata.Add(routeConfig);
+        configure?.Invoke(endpointBuilder);
         return endpointBuilder.Build();
     }
 }

--- a/test/ReverseProxy.Tests/Routing/ProxyEndpointFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Routing/ProxyEndpointFactoryTests.cs
@@ -423,29 +423,6 @@ public class ProxyEndpointFactoryTests
 #endif
 #if NET8_0_OR_GREATER
     [Fact]
-    public void AddEndpoint_DefaultTimeoutPolicy_Works()
-    {
-        var services = CreateServices();
-        var factory = services.GetRequiredService<ProxyEndpointFactory>();
-        factory.SetProxyPipeline(context => Task.CompletedTask);
-
-        var route = new RouteConfig
-        {
-            RouteId = "route1",
-            TimeoutPolicy = "defaulT",
-            Order = 12,
-            Match = new RouteMatch(),
-        };
-        var cluster = new ClusterState("cluster1");
-        var routeState = new RouteState("route1");
-
-        var (routeEndpoint, _) = CreateEndpoint(factory, routeState, route, cluster);
-
-        Assert.Null(routeEndpoint.Metadata.GetMetadata<RequestTimeoutAttribute>());
-        Assert.Null(routeEndpoint.Metadata.GetMetadata<DisableRequestTimeoutAttribute>());
-    }
-
-    [Fact]
     public void AddEndpoint_CustomTimeoutPolicy_Works()
     {
         var services = CreateServices();

--- a/testassets/ReverseProxy.Code/ReverseProxy.Code.csproj
+++ b/testassets/ReverseProxy.Code/ReverseProxy.Code.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.ReverseProxy.Sample</RootNamespace>
   </PropertyGroup>

--- a/testassets/TestServer/Controllers/HttpController.cs
+++ b/testassets/TestServer/Controllers/HttpController.cs
@@ -38,6 +38,18 @@ public class HttpController : ControllerBase
     }
 
     /// <summary>
+    /// Returns a 409 response without consuming the request body.
+    /// This is used to exercise <c>Expect:100-continue</c> behavior.
+    /// </summary>
+    [HttpGet]
+    [Route("/api/slow")]
+    public async Task<IActionResult> Slow()
+    {
+        await Task.Delay(TimeSpan.FromSeconds(3));
+        return StatusCode(StatusCodes.Status200OK);
+    }
+
+    /// <summary>
     /// Returns a 200 response dumping all info from the incoming request.
     /// </summary>
     [HttpGet, HttpPost]


### PR DESCRIPTION
Fixes #2074 by exposing config that integrates with the new timeout middleware. This is a nearly identical clone of the Cors feature.