### PR TITLE
Clarify websocket activity failure

### DIFF
--- a/src/ReverseProxy/Forwarder/ForwarderError.cs
+++ b/src/ReverseProxy/Forwarder/ForwarderError.cs
@@ -103,4 +103,9 @@ public enum ForwarderError : int
     /// Failed while creating the request message.
     /// </summary>
     RequestCreation,
+
+    /// <summary>
+    /// An upgraded request was idle and canceled due to the activity timeout.
+    /// </summary>
+    UpgradeActivityTimeout,
 }

--- a/src/ReverseProxy/WebSocketsTelemetry/WebSocketCloseReason.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/WebSocketCloseReason.cs
@@ -10,4 +10,5 @@ internal enum WebSocketCloseReason : int
     ServerGracefulClose,
     ClientDisconnect,
     ServerDisconnect,
+    ActivityTimeout,
 }

--- a/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetryStream.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetryStream.cs
@@ -59,6 +59,9 @@ internal sealed class WebSocketsTelemetryStream : DelegatingStream
             ForwarderError.UpgradeRequestDestination => WebSocketCloseReason.ServerDisconnect,
             ForwarderError.UpgradeResponseDestination => WebSocketCloseReason.ServerDisconnect,
 
+            // Activity Timeout
+            ForwarderError.UpgradeActivityTimeout => WebSocketCloseReason.ActivityTimeout,
+
             // Both sides gracefully closed the underlying connection without sending a WebSocket close,
             // or the server closed the connection and we canceled the client and suppressed the errors.
             null => WebSocketCloseReason.ServerDisconnect,

--- a/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
@@ -701,9 +701,7 @@ public class HttpForwarderTests
 
         Assert.Equal(StatusCodes.Status101SwitchingProtocols, httpContext.Response.StatusCode);
 
-        // When both are idle it's a race which gets reported as canceled first.
-        Assert.True(ForwarderError.UpgradeRequestClient == result
-            || ForwarderError.UpgradeResponseDestination == result);
+        Assert.Equal(ForwarderError.UpgradeActivityTimeout, result);
 
         events.AssertContainProxyStages(upgrade: true);
     }


### PR DESCRIPTION
This addresses outstanding feedback from @mihazupan about the error reporting changes in #2167. The intent was to more correctly attribute blame for disconnects to something caused by the client or destination. For ActivityTimeouts the blame would go to whoever we were currently expecting data from. However, in the WebSocket case we may be expecting data in both ways all the time, and an ActivityTimeout can be considered a no-blame situation that deserves separate consideration.

I'm not sure if the same consideration should apply to gRPC/streaming.