### PR TITLE
Update branching doc

### DIFF
--- a/docs/operations/Branching.md
+++ b/docs/operations/Branching.md
@@ -4,7 +4,6 @@ When we are ready to branch our code, we first need to create the branch:
 
 1. In a local clone, run `git checkout main` and `git pull origin main` to make sure you have the latest `main`
 1. Run `git checkout -b release/1.1.0-previewX` where `X` is the YARP preview number. When releasing a non-preview version, use `release/1.1` instead of `release/1.1.0` so that the branch can be used for future patches.
-1. Update the branch to use 1ES servicing pools (see [example PR](https://github.com/microsoft/reverse-proxy/pull/1265))
 1. If you are releasing a non-preview version:
     - Set the `PreReleaseVersionLabel` in [`eng/Versions.props`] to `rtw`.
     - Run `build.cmd -pack`


### PR DESCRIPTION
The step "Update the branch to use 1ES servicing pools" isn't needed anymore since it's [handled automatically]( https://github.com/microsoft/reverse-proxy/blob/main/eng/common/templates/job/source-build.yml) now.