### PR TITLE
Add generic Otel distributed tracing instructions

### DIFF
--- a/docs/docfx/articles/distributed-tracing.md
+++ b/docs/docfx/articles/distributed-tracing.md
@@ -108,7 +108,7 @@ app.Run();
 
 Note that the `AddHttpClientInstrumentation()` call is required along with the `AddSource("Yarp.ReverseProxy")` call to make the request spans emit.
 
-See [ASP.NET Documentation on Observability with OpenTelemetry](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/observability-with-otel).
+See [ASP.NET Documentation on Observability with OpenTelemetry](https://learn.microsoft.com/dotnet/core/diagnostics/observability-with-otel).
 
 
 Provided that the traces are being logged to the same store for the proxy and destination servers, then the tracing analysis tools can correlate the requests and provide gant charts etc covering the end-to-end processing of the requests as they transition across the servers.


### PR DESCRIPTION
See #2394 : Docs don't give a generic OTel example and don't explain the need to include AddHttpClientInstrumentation for this to work. (This is obscured because Azure Monitor/App Insights do this for you automatically but if you're doing vanilla OTel, it's on you.)