### PR TITLE
Add 'contents: write' permissions to docfx build GitHub Action

### DIFF
--- a/.github/workflows/docfx_build.yml
+++ b/.github/workflows/docfx_build.yml
@@ -7,6 +7,8 @@ jobs:
   build:
     name: Build
     runs-on: windows-latest
+    permissions:
+      contents: write # for push access to the gh-pages branch
     steps:
       # Check out the branch that triggered this workflow to the 'source' subdirectory
       - name: Checkout Code


### PR DESCRIPTION
Grants the `GITHUB_TOKEN` permissions to push the updated docs to the `gh-pages` branch.

https://github.com/microsoft/reverse-proxy/blob/da387609b0abfb0d4afc58ac44dcb386668263df/.github/workflows/docfx_build.yml#L46-L47

Guessing `contents` is the right category based on https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#:~:text=contents,GitHub%20Apps.%22