### PR TITLE
fix csharp example in load balancing page

### DIFF
--- a/docs/docfx/articles/load-balancing.md
+++ b/docs/docfx/articles/load-balancing.md
@@ -48,7 +48,7 @@ var clusters = new[]
     {
         ClusterId = "cluster1",
         LoadBalancingPolicy = LoadBalancingPolicies.RoundRobin,
-        Destinations = new Dictionary<string, Destination>(StringComparer.OrdinalIgnoreCase)
+        Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
         {
             { "destination1", new DestinationConfig() { Address = "https://localhost:10000" } },
             { "destination2", new DestinationConfig() { Address = "https://localhost:10010" } }


### PR DESCRIPTION
small fix to make the csharp example code compile in the load balancing page