### PR TITLE
Update notExists to true when value is empty

### DIFF
--- a/src/ReverseProxy/Routing/HeaderMatcherPolicy.cs
+++ b/src/ReverseProxy/Routing/HeaderMatcherPolicy.cs
@@ -70,13 +70,13 @@ internal sealed class HeaderMatcherPolicy : MatcherPolicy, IEndpointComparerPoli
 
             foreach (var matcher in matchers)
             {
-                var headerExists = headers.TryGetValue(matcher.Name, out var requestHeaderValues);
+                headers.TryGetValue(matcher.Name, out var requestHeaderValues);
                 var valueIsEmpty = StringValues.IsNullOrEmpty(requestHeaderValues);
 
                 var matched = matcher.Mode switch
                 {
                     HeaderMatchMode.Exists => !valueIsEmpty,
-                    HeaderMatchMode.NotExists => !headerExists || valueIsEmpty,
+                    HeaderMatchMode.NotExists => valueIsEmpty,
                     HeaderMatchMode.ExactHeader => !valueIsEmpty && TryMatchExactOrPrefix(matcher, requestHeaderValues),
                     HeaderMatchMode.HeaderPrefix => !valueIsEmpty && TryMatchExactOrPrefix(matcher, requestHeaderValues),
                     HeaderMatchMode.Contains => !valueIsEmpty && TryMatchContainsOrNotContains(matcher, requestHeaderValues),

--- a/src/ReverseProxy/Routing/HeaderMatcherPolicy.cs
+++ b/src/ReverseProxy/Routing/HeaderMatcherPolicy.cs
@@ -76,7 +76,7 @@ internal sealed class HeaderMatcherPolicy : MatcherPolicy, IEndpointComparerPoli
                 var matched = matcher.Mode switch
                 {
                     HeaderMatchMode.Exists => !valueIsEmpty,
-                    HeaderMatchMode.NotExists => !headerExists,
+                    HeaderMatchMode.NotExists => !headerExists || valueIsEmpty,
                     HeaderMatchMode.ExactHeader => !valueIsEmpty && TryMatchExactOrPrefix(matcher, requestHeaderValues),
                     HeaderMatchMode.HeaderPrefix => !valueIsEmpty && TryMatchExactOrPrefix(matcher, requestHeaderValues),
                     HeaderMatchMode.Contains => !valueIsEmpty && TryMatchContainsOrNotContains(matcher, requestHeaderValues),

--- a/test/ReverseProxy.Tests/Routing/HeaderMatcherPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Routing/HeaderMatcherPolicyTests.cs
@@ -154,7 +154,7 @@ public class HeaderMatcherPolicyTests
     [InlineData("", HeaderMatchMode.Exists, false)]
     [InlineData("abc", HeaderMatchMode.Exists, true)]
     [InlineData(null, HeaderMatchMode.NotExists, true)]
-    [InlineData("", HeaderMatchMode.NotExists, false)]
+    [InlineData("", HeaderMatchMode.NotExists, true)]
     [InlineData("abc", HeaderMatchMode.NotExists, false)]
     public async Task ApplyAsync_MatchingScenarios_AnyHeaderValue(string incomingHeaderValue, HeaderMatchMode mode, bool shouldMatch)
     {


### PR DESCRIPTION
Currently **Exists** and **NotExists** are the same when value is empty. Headers with empty values have no semantic meaning in HTTP. So I updated NotExists with empty value to true. This will go against the current behavior by design. 
Feel free to post any comments or suggestions. Initial discussion is here https://github.com/microsoft/reverse-proxy/pull/2258#discussion_r1335320211
