### PR TITLE
Delete debug assert in HttpEventListenerService

### DIFF
--- a/src/TelemetryConsumption/Http/HttpEventListenerService.cs
+++ b/src/TelemetryConsumption/Http/HttpEventListenerService.cs
@@ -244,7 +244,7 @@ internal sealed class HttpEventListenerService : EventListenerService<HttpEventL
             case 15:
                 Debug.Assert(eventData.EventName == "RequestFailedDetailed" && payload.Count == 1);
                 // This event is more expensive to collect and requires an opt-in keyword.
-                Debug.Fail("We shouldn't be seeing this event as the base EventListenerService always uses EventKeywords.None.");
+                // We should only see it if a different EventListener opted in (potentially from a different process).
                 break;
 
             case 16:


### PR DESCRIPTION
This assert was randomly firing during local test runs for me. While the base `EventListenerService` doesn't opt-in to the `RequestFailedDetailed` keyword, a different event listener somewhere else may (e.g. VS diagnostic tools).

The product code is clearly doing the right checks here:
https://github.com/dotnet/runtime/blob/51b51bffbb4733a50c93a39f047b29ff424494d9/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs#L76-L84
so I don't think we should care about this assert in YARP.