### PR TITLE
Update HttpSysDelegator to support detaching from and re-initializing queues when the http.sys queue no longer exists

### DIFF
--- a/src/ReverseProxy/Utilities/EventIds.cs
+++ b/src/ReverseProxy/Utilities/EventIds.cs
@@ -68,4 +68,5 @@ internal static class EventIds
     public static readonly EventId RetryingWebSocketDowngradeNoHttp2 = new EventId(62, "RetryingWebSocketDowngradeNoHttp2");
     public static readonly EventId InvalidSecWebSocketKeyHeader = new EventId(63, "InvalidSecWebSocketKeyHeader");
     public static readonly EventId TimeoutNotApplied = new(64, nameof(TimeoutNotApplied));
+    public static readonly EventId DelegationQueueNoLongerExists = new(64, nameof(DelegationQueueNoLongerExists));
 }

--- a/src/ReverseProxy/Utilities/EventIds.cs
+++ b/src/ReverseProxy/Utilities/EventIds.cs
@@ -68,5 +68,5 @@ internal static class EventIds
     public static readonly EventId RetryingWebSocketDowngradeNoHttp2 = new EventId(62, "RetryingWebSocketDowngradeNoHttp2");
     public static readonly EventId InvalidSecWebSocketKeyHeader = new EventId(63, "InvalidSecWebSocketKeyHeader");
     public static readonly EventId TimeoutNotApplied = new(64, nameof(TimeoutNotApplied));
-    public static readonly EventId DelegationQueueNoLongerExists = new(64, nameof(DelegationQueueNoLongerExists));
+    public static readonly EventId DelegationQueueNoLongerExists = new(65, nameof(DelegationQueueNoLongerExists));
 }


### PR DESCRIPTION
This PR fixes #2425 by detaching and attempting to re-attach to destination queues when an ERROR_OBJECT_NO_LONGER_EXISTS  error is received when attempting to delegate requests. 