### PR TITLE
Ignore response transform OCEs that occur during error handling

### DIFF
--- a/src/ReverseProxy/SessionAffinity/BaseEncryptedSessionAffinityPolicy.cs
+++ b/src/ReverseProxy/SessionAffinity/BaseEncryptedSessionAffinityPolicy.cs
@@ -26,11 +26,17 @@ internal abstract class BaseEncryptedSessionAffinityPolicy<T> : ISessionAffinity
 
     public abstract string Name { get; }
 
-    public virtual void AffinitizeResponse(HttpContext context, ClusterState cluster, SessionAffinityConfig config, DestinationState destination)
+    public void AffinitizeResponse(HttpContext context, ClusterState cluster, SessionAffinityConfig config, DestinationState destination)
     {
         if (!config.Enabled.GetValueOrDefault())
         {
             throw new InvalidOperationException($"Session affinity is disabled for cluster.");
+        }
+
+        if (context.RequestAborted.IsCancellationRequested)
+        {
+            // Avoid wasting time if the client is already gone.
+            return;
         }
 
         // Affinity key is set on the response only if it's a new affinity.

--- a/src/ReverseProxy/SessionAffinity/BaseHashCookieSessionAffinityPolicy.cs
+++ b/src/ReverseProxy/SessionAffinity/BaseHashCookieSessionAffinityPolicy.cs
@@ -31,6 +31,12 @@ internal abstract class BaseHashCookieSessionAffinityPolicy : ISessionAffinityPo
             throw new InvalidOperationException("Session affinity is disabled for cluster.");
         }
 
+        if (context.RequestAborted.IsCancellationRequested)
+        {
+            // Avoid wasting time if the client is already gone.
+            return;
+        }
+
         // Affinity key is set on the response only if it's a new affinity.
         if (!context.Items.ContainsKey(AffinityKeyId))
         {

--- a/src/ReverseProxy/SessionAffinity/ISessionAffinityPolicy.cs
+++ b/src/ReverseProxy/SessionAffinity/ISessionAffinityPolicy.cs
@@ -65,8 +65,6 @@ public interface ISessionAffinityPolicy
     /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
     ValueTask AffinitizeResponseAsync(HttpContext context, ClusterState cluster, SessionAffinityConfig config, DestinationState destination, CancellationToken cancellationToken)
     {
-        cancellationToken.ThrowIfCancellationRequested();
-
         AffinitizeResponse(context, cluster, config, destination);
         return default;
     }


### PR DESCRIPTION
Closes #2317

We'll call `TransformResponseAsync` with a null `proxyResponse` as part of error handling to give transforms a chance to always run.
If they end up throwing a cancellation exception there's no point in us propagating it out given we're about to report a more specific error anyway.