### PR TITLE
Fix race condition in passive health test

### DIFF
--- a/test/ReverseProxy.FunctionalTests/PassiveHealthCheckTests.cs
+++ b/test/ReverseProxy.FunctionalTests/PassiveHealthCheckTests.cs
@@ -52,8 +52,8 @@ public class PassiveHealthCheckTests
     public async Task PassiveHealthChecksEnabled_MultipleDestinationFailures_ProxyReturnsServiceUnavailable()
     {
         var destinationReached = false;
-        IProxyStateLookup? lookup = null;
-        string? clusterId = null;
+        IProxyStateLookup lookup = null;
+        string clusterId = null;
 
         var test = new TestEnvironment(
             context =>

--- a/test/ReverseProxy.FunctionalTests/PassiveHealthCheckTests.cs
+++ b/test/ReverseProxy.FunctionalTests/PassiveHealthCheckTests.cs
@@ -52,6 +52,8 @@ public class PassiveHealthCheckTests
     public async Task PassiveHealthChecksEnabled_MultipleDestinationFailures_ProxyReturnsServiceUnavailable()
     {
         var destinationReached = false;
+        IProxyStateLookup? lookup = null;
+        string? clusterId = null;
 
         var test = new TestEnvironment(
             context =>
@@ -74,20 +76,51 @@ public class PassiveHealthCheckTests
                     }
                 };
 
+                clusterId = c.ClusterId;
+
                 return (c, r);
             },
             ConfigureProxy = proxyBuilder => proxyBuilder.Services.AddSingleton<IForwarderHttpClientFactory>(new MockHttpClientFactory((_, _) => throw new IOException())),
+            ConfigureProxyApp = proxyApp =>
+            {
+                lookup = proxyApp.ApplicationServices.GetRequiredService<IProxyStateLookup>();
+            },
         };
 
         await test.Invoke(async uri =>
         {
             using var client = new HttpClient();
+
+            for (var i = 0; i < 10; i++)
+            {
+                using var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, uri));
+                Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+            }
+
+            Assert.NotNull(lookup);
+            Assert.NotNull(clusterId);
+
+            // The destination list will be updated asynchronously in the background.
+            // Wait until that update takes effect.
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+            while (true)
+            {
+                Assert.True(lookup.TryGetCluster(clusterId, out var cluster));
+                Assert.Single(cluster.DestinationsState.AllDestinations);
+
+                if (cluster.DestinationsState.AvailableDestinations.Count == 0)
+                {
+                    break;
+                }
+
+                await Task.Delay(10, cts.Token);
+            }
+
             for (var i = 0; i < 42; i++)
             {
                 using var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, uri));
-
-                Assert.Equal(i < 10 ? HttpStatusCode.BadGateway : HttpStatusCode.ServiceUnavailable, response.StatusCode);
-                await Task.Yield();
+                Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
             }
         });
 


### PR DESCRIPTION
Saw this being noisy in CI a few times.

The destinations will be updated in the background, a simple `Task.Yield` isn't a reliable way to avoid the race condition.