### PR TITLE
Turn off a bunch of optional features in the benchmark

### DIFF
--- a/testassets/BenchmarkApp/Properties/launchSettings.json
+++ b/testassets/BenchmarkApp/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "BenchmarkApp": {
       "commandName": "Project",
-      "commandLineArgs": "--urls http://localhost:5000 --clusterUrls http://localhost:10010",
+      "commandLineArgs": "--urls http://localhost:5000 --clusterUrls http://httpbin.org",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/testassets/BenchmarkApp/appsettings.Development.json
+++ b/testassets/BenchmarkApp/appsettings.Development.json
@@ -1,9 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Debug",
-      "Microsoft": "Debug",
-      "Microsoft.Hosting.Lifetime": "Information"
-    }
-  }
-}

--- a/testassets/BenchmarkApp/appsettings.json
+++ b/testassets/BenchmarkApp/appsettings.json
@@ -1,15 +1,4 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information",
-      "Microsoft.AspNetCore.Hosting.Diagnostics": "None"
-    },
-    "EventLog": {
-      "LogLevel": {
-        "Default": "None"
-      }
-    }
-  },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "LogLevel": ""
 }


### PR DESCRIPTION
Skips logic such as ASP.NET's auth middlewares, routing, .... Also skips some optional features like the `X-Forwarded` headers being added by default.

This way it more closely matches what we do in the proxy-httpclient scenario: https://github.com/aspnet/Benchmarks/blob/main/src/BenchmarksApps/HttpClient/Proxy/Program.cs

Net effect a is ~17 % RPS bump on the basic h1-h1 scenario.