### PR TITLE
Stop using -pt images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)
-        image: 1es-windows-2022-pt
+        image: 1es-windows-2022
         os: windows
     customBuildTags:
     - ES365AIMigrationTooling
@@ -63,7 +63,7 @@ extends:
           - job: Windows
             pool:
               name: $(DncEngInternalBuildPool)
-              image: 1es-windows-2022-pt
+              image: 1es-windows-2022
               os: windows
             variables:
             - group: Publish-Build-Assets


### PR DESCRIPTION
Internal pipelines are broken since Thursday because of using these images.