### PR TITLE
Move TFMs to shared variables

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+  <Import Project="TFMs.props" />
 
   <PropertyGroup>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>

--- a/TFMs.props
+++ b/TFMs.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <LatestDevTFM>net9.0</LatestDevTFM>
+    <ReleaseTFMs>net6.0;net7.0;net8.0</ReleaseTFMs>
+    <TestTFMs>net6.0;net7.0;net8.0;net9.0</TestTFMs>
+  </PropertyGroup>
+</Project>

--- a/docs/docfx/articles/getting-started.md
+++ b/docs/docfx/articles/getting-started.md
@@ -12,20 +12,19 @@ We plan on providing a project template and pre-built exe in the future.
 YARP is implemented on top of .NET Core infrastructure and is usable on Windows, Linux or MacOS.
 Development can be done with the SDK and your favorite editor, [Microsoft Visual Studio](https://visualstudio.microsoft.com/vs/) or [Visual Studio Code](https://code.visualstudio.com/).
 
-YARP 2.0.0 supports ASP.NET Core 6.0 and newer.
+YARP 2.1.0 supports ASP.NET Core 6.0 and newer, including ASP.NET Core 8.0.
 You can download the .NET SDK from https://dotnet.microsoft.com/download/dotnet/.
 
-Visual Studio support for .NET 6 is included in Visual Studio 2022.
+Visual Studio support for .NET 8 is included in Visual Studio 2022 17.8.
 
 ### Create a new project
 
-A complete version of the project built using the steps below can be found at [Minimal YARP Sample](https://github.com/microsoft/reverse-proxy/tree/release/latest/samples/ReverseProxy.Minimal.Sample).
-For a version that does not use [top-level statements](https://docs.microsoft.com/dotnet/csharp/fundamentals/program-structure/top-level-statements), see the [Basic YARP Sample](https://github.com/microsoft/reverse-proxy/tree/release/latest/samples/BasicYarpSample).
+A complete version of the project built using the steps below can be found at [Basic YARP Sample](https://github.com/microsoft/reverse-proxy/tree/release/latest/samples/BasicYarpSample).
 
 Start by creating an "Empty" ASP.NET Core application using the command line:
 
 ```Console
-dotnet new web -n MyProxy -f net6.0
+dotnet new web -n MyProxy -f net8.0
 ```
 
 Or create a new ASP.NET Core web application in Visual Studio 2022, and choose "Empty" for the project template. 
@@ -34,7 +33,7 @@ Or create a new ASP.NET Core web application in Visual Studio 2022, and choose "
 
  ```XML
 <ItemGroup> 
-  <PackageReference Include="Yarp.ReverseProxy" Version="1.1.0-rc.2.22152.2" />
+  <PackageReference Include="Yarp.ReverseProxy" Version="2.1.0" />
 </ItemGroup> 
 ```
 

--- a/docs/docfx/index.md
+++ b/docs/docfx/index.md
@@ -7,7 +7,7 @@ title: YARP Documentation
 
 Welcome to the documentation for YARP! YARP is a library to help create reverse proxy servers that are high-performance, production-ready, and highly customizable. Please provide us your feedback by going to [the GitHub repository](https://github.com/microsoft/reverse-proxy).
 
-This is the documentation for YARP 2.0.
+This is the documentation for YARP 2.1.
 For documentation of YARP 1.1.1, see https://github.com/microsoft/reverse-proxy/tree/release/1.1/docs/docfx/articles.
 
 ## Why YARP

--- a/docs/docfx/toc.yml
+++ b/docs/docfx/toc.yml
@@ -1,4 +1,4 @@
-- name: About YARP 2.0
+- name: About YARP 2.1
   href: index.md
 - name: Articles
   href: articles/

--- a/reverse-proxy.sln
+++ b/reverse-proxy.sln
@@ -8,6 +8,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		global.json = global.json
 		NuGet.config = NuGet.config
+		TFMs.props = TFMs.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yarp.ReverseProxy", "src\ReverseProxy\Yarp.ReverseProxy.csproj", "{568EF8AE-7624-490D-A19F-C25D076FF091}"

--- a/samples/BasicYarpSample/BasicYarpSample.csproj
+++ b/samples/BasicYarpSample/BasicYarpSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/KubernetesIngress.Sample/Combined/Dockerfile
+++ b/samples/KubernetesIngress.Sample/Combined/Dockerfile
@@ -18,6 +18,7 @@ COPY ["src/ReverseProxy/Yarp.ReverseProxy.csproj", "src/ReverseProxy/"]
 COPY ["src/Kubernetes.Controller/Yarp.Kubernetes.Controller.csproj", "src/Kubernetes.Controller/"]
 COPY ["src/Directory.Build.props", "src/"]
 COPY ["Directory.Build.*", "./"]
+COPY ["TFMs.props", ""]
 COPY ["NuGet.config", ""]
 COPY ["eng/Versions.props", "eng/"]
 

--- a/samples/KubernetesIngress.Sample/Combined/Yarp.Kubernetes.IngressController.csproj
+++ b/samples/KubernetesIngress.Sample/Combined/Yarp.Kubernetes.IngressController.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <UserSecretsId>78d1f3b4-abce-4c5a-b914-3321fab1f8d0</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <IsPackable>$('System.TeamProject') != 'internal'</IsPackable>

--- a/samples/KubernetesIngress.Sample/Ingress/Dockerfile
+++ b/samples/KubernetesIngress.Sample/Ingress/Dockerfile
@@ -18,6 +18,7 @@ COPY ["src/ReverseProxy/Yarp.ReverseProxy.csproj", "src/ReverseProxy/"]
 COPY ["src/Kubernetes.Controller/Yarp.Kubernetes.Controller.csproj", "src/Kubernetes.Controller/"]
 COPY ["src/Directory.Build.props", "src/"]
 COPY ["Directory.Build.*", "./"]
+COPY ["TFMs.props", ""]
 COPY ["NuGet.config", ""]
 COPY ["eng/Versions.props", "eng/"]
 

--- a/samples/KubernetesIngress.Sample/Ingress/Yarp.Kubernetes.Ingress.csproj
+++ b/samples/KubernetesIngress.Sample/Ingress/Yarp.Kubernetes.Ingress.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <UserSecretsId>b2dc6cd7-acbb-4d65-ad19-74771ff3c80f</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <IsPackable>$('System.TeamProject') != 'internal'</IsPackable>

--- a/samples/KubernetesIngress.Sample/Monitor/Dockerfile
+++ b/samples/KubernetesIngress.Sample/Monitor/Dockerfile
@@ -18,6 +18,7 @@ COPY ["src/ReverseProxy/Yarp.ReverseProxy.csproj", "src/ReverseProxy/"]
 COPY ["src/Kubernetes.Controller/Yarp.Kubernetes.Controller.csproj", "src/Kubernetes.Controller/"]
 COPY ["src/Directory.Build.props", "src/"]
 COPY ["Directory.Build.*", "./"]
+COPY ["TFMs.props", ""]
 COPY ["NuGet.config", ""]
 COPY ["eng/Versions.props", "eng/"]
 

--- a/samples/KubernetesIngress.Sample/Monitor/Yarp.Kubernetes.Monitor.csproj
+++ b/samples/KubernetesIngress.Sample/Monitor/Yarp.Kubernetes.Monitor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <UserSecretsId>42f98116-26c4-4115-b6af-c5dec1f88c84</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <IsPackable>$('System.TeamProject') != 'internal'</IsPackable>

--- a/samples/KubernetesIngress.Sample/backend/Dockerfile
+++ b/samples/KubernetesIngress.Sample/backend/Dockerfile
@@ -9,6 +9,7 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0  AS publish
 WORKDIR /src
 # We need to install the SDK manually because we might target an unreleased SDK
 COPY ["global.json", ""]
+COPY ["TFMs.props", "Directory.Build.props"]
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --jsonfile global.json
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT 1
 

--- a/samples/KubernetesIngress.Sample/backend/backend.csproj
+++ b/samples/KubernetesIngress.Sample/backend/backend.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <RootNamespace>Backend</RootNamespace>
     <UserSecretsId>aaa98da6-d0d4-4ad6-9821-f66057413c3a</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/samples/Prometheus/HttpLoadApp/HttpLoadApp.csproj
+++ b/samples/Prometheus/HttpLoadApp/HttpLoadApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/samples/Prometheus/ReverseProxy.Metrics-Prometheus.Sample/ReverseProxy.Metrics.Prometheus.Sample.csproj
+++ b/samples/Prometheus/ReverseProxy.Metrics-Prometheus.Sample/ReverseProxy.Metrics.Prometheus.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.Sample</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/samples/ReverseProxy.Auth.Sample/ReverseProxy.Auth.Sample.csproj
+++ b/samples/ReverseProxy.Auth.Sample/ReverseProxy.Auth.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.Sample</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/samples/ReverseProxy.Code.Sample/ReverseProxy.Code.Sample.csproj
+++ b/samples/ReverseProxy.Code.Sample/ReverseProxy.Code.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.Sample</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/samples/ReverseProxy.Config.Sample/ReverseProxy.Config.Sample.csproj
+++ b/samples/ReverseProxy.Config.Sample/ReverseProxy.Config.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.Sample</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/samples/ReverseProxy.ConfigFilter.Sample/ReverseProxy.ConfigFilter.Sample.csproj
+++ b/samples/ReverseProxy.ConfigFilter.Sample/ReverseProxy.ConfigFilter.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.Sample</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/samples/ReverseProxy.Direct.Sample/ReverseProxy.Direct.Sample.csproj
+++ b/samples/ReverseProxy.Direct.Sample/ReverseProxy.Direct.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.Sample</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/samples/ReverseProxy.HttpSysDelegation.Sample/ReverseProxy/ReverseProxy.HttpSysDelegation.Sample.csproj
+++ b/samples/ReverseProxy.HttpSysDelegation.Sample/ReverseProxy/ReverseProxy.HttpSysDelegation.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/samples/ReverseProxy.HttpSysDelegation.Sample/SampleHttpSysServer/SampleHttpSysServer.csproj
+++ b/samples/ReverseProxy.HttpSysDelegation.Sample/SampleHttpSysServer/SampleHttpSysServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/samples/ReverseProxy.LetsEncrypt.Sample/ReverseProxy.LetsEncrypt.Sample.csproj
+++ b/samples/ReverseProxy.LetsEncrypt.Sample/ReverseProxy.LetsEncrypt.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/ReverseProxy.Metrics.Sample/ReverseProxy.Metrics.Sample.csproj
+++ b/samples/ReverseProxy.Metrics.Sample/ReverseProxy.Metrics.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.Sample</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/samples/ReverseProxy.Transforms.Sample/ReverseProxy.Transforms.Sample.csproj
+++ b/samples/ReverseProxy.Transforms.Sample/ReverseProxy.Transforms.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.Sample</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/samples/SampleServer/SampleServer.csproj
+++ b/samples/SampleServer/SampleServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>SampleServer</RootNamespace>
   </PropertyGroup>

--- a/src/Kubernetes.Controller/Yarp.Kubernetes.Controller.csproj
+++ b/src/Kubernetes.Controller/Yarp.Kubernetes.Controller.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Toolkit for building a Kubernetes Ingress Controller in .NET using the infrastructure from ASP.NET and .NET</Description>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <OutputType>Library</OutputType>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
     <IsPackable>true</IsPackable>

--- a/src/ReverseProxy/Yarp.ReverseProxy.csproj
+++ b/src/ReverseProxy/Yarp.ReverseProxy.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <Description>Reverse proxy toolkit for building fast proxy servers in .NET using the infrastructure from ASP.NET and .NET</Description>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Yarp.ReverseProxy</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
-    <IsAotCompatible>true</IsAotCompatible>
+    <IsAotCompatible Condition="'$(TargetFramework)' != 'net6.0'">true</IsAotCompatible>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>yarp;dotnet;reverse-proxy;aspnetcore</PackageTags>
   </PropertyGroup>

--- a/src/TelemetryConsumption/Yarp.Telemetry.Consumption.csproj
+++ b/src/TelemetryConsumption/Yarp.Telemetry.Consumption.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <Description>Yarp.ReverseProxy extension package for in-process telemetry consumption</Description>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ReleaseTFMs)</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Yarp.Telemetry.Consumption</RootNamespace>
     <Nullable>enable</Nullable>
-    <IsAotCompatible>true</IsAotCompatible>
+    <IsAotCompatible Condition="'$(TargetFramework)' != 'net6.0'">true</IsAotCompatible>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>yarp;dotnet;reverse-proxy;aspnetcore;telemetry</PackageTags>
   </PropertyGroup>

--- a/test/Kubernetes.Tests/Yarp.Kubernetes.Tests.csproj
+++ b/test/Kubernetes.Tests/Yarp.Kubernetes.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(TestTFMs)</TargetFrameworks>
     <OutputType>Library</OutputType>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
     <RootNamespace>Yarp.Kubernetes</RootNamespace>

--- a/test/ReverseProxy.FunctionalTests/Yarp.ReverseProxy.FunctionalTests.csproj
+++ b/test/ReverseProxy.FunctionalTests/Yarp.ReverseProxy.FunctionalTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(TestTFMs)</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Yarp.ReverseProxy</RootNamespace>
 

--- a/test/ReverseProxy.Tests/Yarp.ReverseProxy.Tests.csproj
+++ b/test/ReverseProxy.Tests/Yarp.ReverseProxy.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(TestTFMs)</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Yarp.ReverseProxy</RootNamespace>
     <NoWarn>SYSLIB0039</NoWarn>

--- a/test/Tests.Common/Yarp.Tests.Common.csproj
+++ b/test/Tests.Common/Yarp.Tests.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(TestTFMs)</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Yarp.Common.Tests</RootNamespace>
   </PropertyGroup>

--- a/testassets/BenchmarkApp/BenchmarkApp.csproj
+++ b/testassets/BenchmarkApp/BenchmarkApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(TestTFMs)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/testassets/ReverseProxy.Code/ReverseProxy.Code.csproj
+++ b/testassets/ReverseProxy.Code/ReverseProxy.Code.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(TestTFMs)</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.ReverseProxy.Sample</RootNamespace>
   </PropertyGroup>

--- a/testassets/ReverseProxy.Config/ReverseProxy.Config.csproj
+++ b/testassets/ReverseProxy.Config/ReverseProxy.Config.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(TestTFMs)</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.ReverseProxy.Sample</RootNamespace>
   </PropertyGroup>

--- a/testassets/ReverseProxy.Direct/ReverseProxy.Direct.csproj
+++ b/testassets/ReverseProxy.Direct/ReverseProxy.Direct.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>$(TestTFMs)</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Yarp.ReverseProxy.Sample</RootNamespace>
   </PropertyGroup>

--- a/testassets/TestClient/TestClient.csproj
+++ b/testassets/TestClient/TestClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>$(LatestDevTFM)</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/testassets/TestServer/TestServer.csproj
+++ b/testassets/TestServer/TestServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>$(LatestDevTFM)</TargetFramework>
     <OutputType>Exe</OutputType>
     <RootNamespace>SampleServer</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
#2498 minus the dropping 7.0 part
Also backporting https://github.com/microsoft/reverse-proxy/pull/2367

Should hopefully mean we don't have to touch the 30 csproj files the next time we want to make a change.