### PR TITLE
Improve UseRequestTimeouts validation

### DIFF
--- a/src/ReverseProxy/Model/ProxyPipelineInitializerMiddleware.cs
+++ b/src/ReverseProxy/Model/ProxyPipelineInitializerMiddleware.cs
@@ -106,10 +106,10 @@ internal sealed class ProxyPipelineInitializerMiddleware
         {
             // A timeout should have been set.
             // Out of an abundance of caution, refuse the request rather than allowing it to proceed without the configured timeout.
-            Throw(route);
+            ThrowIfDebuggerNotAttached(route);
         }
 
-        void Throw(RouteModel route)
+        void ThrowIfDebuggerNotAttached(RouteModel route)
         {
             // The feature is skipped if the debugger is attached.
             if (!Debugger.IsAttached)

--- a/src/ReverseProxy/Model/ProxyPipelineInitializerMiddleware.cs
+++ b/src/ReverseProxy/Model/ProxyPipelineInitializerMiddleware.cs
@@ -6,12 +6,11 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 #if NET8_0_OR_GREATER
+using System.Threading;
 using Microsoft.AspNetCore.Http.Timeouts;
+using Microsoft.Extensions.Options;
 #endif
 using Microsoft.Extensions.Logging;
-#if NET8_0_OR_GREATER
-using Yarp.ReverseProxy.Configuration;
-#endif
 using Yarp.ReverseProxy.Utilities;
 
 namespace Yarp.ReverseProxy.Model;
@@ -23,12 +22,23 @@ internal sealed class ProxyPipelineInitializerMiddleware
 {
     private readonly ILogger _logger;
     private readonly RequestDelegate _next;
+#if NET8_0_OR_GREATER
+    private readonly IOptionsMonitor<RequestTimeoutOptions> _timeoutOptions;
+#endif
 
     public ProxyPipelineInitializerMiddleware(RequestDelegate next,
-        ILogger<ProxyPipelineInitializerMiddleware> logger)
+        ILogger<ProxyPipelineInitializerMiddleware> logger
+#if NET8_0_OR_GREATER
+        , IOptionsMonitor<RequestTimeoutOptions> timeoutOptions
+#endif
+        )
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _next = next ?? throw new ArgumentNullException(nameof(next));
+
+#if NET8_0_OR_GREATER
+        _timeoutOptions = timeoutOptions ?? throw new ArgumentNullException(nameof(timeoutOptions));
+#endif
     }
 
     public Task Invoke(HttpContext context)
@@ -47,19 +57,11 @@ internal sealed class ProxyPipelineInitializerMiddleware
             context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
             return Task.CompletedTask;
         }
+
 #if NET8_0_OR_GREATER
-        // There's no way to detect the presence of the timeout middleware before this, only the options.
-        if (endpoint.Metadata.GetMetadata<RequestTimeoutAttribute>() != null
-            && context.Features.Get<IHttpRequestTimeoutFeature>() == null
-            // The feature is skipped if the request is already canceled. We'll handle canceled requests later for consistency.
-            && !context.RequestAborted.IsCancellationRequested)
-        {
-            Log.TimeoutNotApplied(_logger, route.Config.RouteId);
-            // Out of an abundance of caution, refuse the request rather than allowing it to proceed without the configured timeout.
-            throw new InvalidOperationException($"The timeout was not applied for route '{route.Config.RouteId}', ensure `IApplicationBuilder.UseRequestTimeouts()`"
-                + " is called between `IApplicationBuilder.UseRouting()` and `IApplicationBuilder.UseEndpoints()`.");
-        }
+        EnsureRequestTimeoutPolicyIsAppliedCorrectly(context, endpoint, route);
 #endif
+
         var destinationsState = cluster.DestinationsState;
         context.Features.Set<IReverseProxyFeature>(new ReverseProxyFeature
         {
@@ -90,6 +92,66 @@ internal sealed class ProxyPipelineInitializerMiddleware
             activity.Dispose();
         }
     }
+
+#if NET8_0_OR_GREATER
+    private void EnsureRequestTimeoutPolicyIsAppliedCorrectly(HttpContext context, Endpoint endpoint, RouteModel route)
+    {
+        // There's no way to detect the presence of the timeout middleware before this, only the options.
+        if (endpoint.Metadata.GetMetadata<RequestTimeoutAttribute>() is { } requestTimeout &&
+            context.Features.Get<IHttpRequestTimeoutFeature>() is null &&
+            // The feature is skipped if the request is already canceled. We'll handle canceled requests later for consistency.
+            !context.RequestAborted.IsCancellationRequested &&
+            // The policy may set the timeout to null / infinite.
+            TimeoutPolicyRequestedATimeoutBeSet(requestTimeout))
+        {
+            // A timeout should have been set.
+            // Out of an abundance of caution, refuse the request rather than allowing it to proceed without the configured timeout.
+            Throw(route);
+        }
+
+        void Throw(RouteModel route)
+        {
+            // The feature is skipped if the debugger is attached.
+            if (!Debugger.IsAttached)
+            {
+                Log.TimeoutNotApplied(_logger, route.Config.RouteId);
+
+                throw new InvalidOperationException(
+                    $"The timeout was not applied for route '{route.Config.RouteId}', " +
+                    "ensure `IApplicationBuilder.UseRequestTimeouts()` is called between " +
+                    "`IApplicationBuilder.UseRouting()` and `IApplicationBuilder.UseEndpoints()`.");
+            }
+        }
+    }
+
+    private bool TimeoutPolicyRequestedATimeoutBeSet(RequestTimeoutAttribute requestTimeout)
+    {
+        if (requestTimeout.Timeout is not TimeSpan timeout)
+        {
+            if (requestTimeout.PolicyName is not string policyName)
+            {
+                Debug.Fail("Either Timeout or PolicyName should have been set.");
+                return false;
+            }
+
+            if (!_timeoutOptions.CurrentValue.Policies.TryGetValue(policyName, out var policy))
+            {
+                // This should only happen if the policy existed at some point, but the options were updated to remove it.
+                return false;
+            }
+
+            if (policy.Timeout is null)
+            {
+                // The policy requested no timeout.
+                return false;
+            }
+
+            timeout = policy.Timeout.Value;
+        }
+
+        return timeout != Timeout.InfiniteTimeSpan;
+    }
+#endif
 
     private static class Log
     {


### PR DESCRIPTION
Fixes #2404

We now also detect if the debugger is attached, or if the timeout policy was configured with an infinite timeout.