### PR TITLE
Forwarded Header Transforms Doc Comments

### DIFF
--- a/src/ReverseProxy/Transforms/ForwardedTransformExtensions.cs
+++ b/src/ReverseProxy/Transforms/ForwardedTransformExtensions.cs
@@ -113,6 +113,9 @@ public static class ForwardedTransformExtensions
     /// <summary>
     /// Adds the transform which will add X-Forwarded-* request headers.
     /// </summary>
+    /// <remarks>
+    /// Removes the Forwarded header when an X-Forwarded transform is enabled
+    /// </remarks>
     public static TransformBuilderContext AddXForwarded(this TransformBuilderContext context, ForwardedTransformActions action = ForwardedTransformActions.Set)
     {
         context.AddXForwardedFor(action: action);
@@ -173,6 +176,9 @@ public static class ForwardedTransformExtensions
     /// <summary>
     /// Adds the transform which will add the Forwarded header as defined by [RFC 7239](https://tools.ietf.org/html/rfc7239).
     /// </summary>
+    /// <remarks>
+    /// Removes the X-Forwarded headers when an Forwarded transform is enabled
+    /// </remarks>
     public static TransformBuilderContext AddForwarded(this TransformBuilderContext context,
         bool useHost = true, bool useProto = true, NodeFormat forFormat = NodeFormat.Random,
         NodeFormat byFormat = NodeFormat.Random, ForwardedTransformActions action = ForwardedTransformActions.Set)

--- a/src/ReverseProxy/Transforms/ForwardedTransformExtensions.cs
+++ b/src/ReverseProxy/Transforms/ForwardedTransformExtensions.cs
@@ -114,7 +114,7 @@ public static class ForwardedTransformExtensions
     /// Adds the transform which will add X-Forwarded-* request headers.
     /// </summary>
     /// <remarks>
-    /// Removes the Forwarded header when an X-Forwarded transform is enabled
+    /// Also removes the <c>Forwarded</c> header when enabled.
     /// </remarks>
     public static TransformBuilderContext AddXForwarded(this TransformBuilderContext context, ForwardedTransformActions action = ForwardedTransformActions.Set)
     {
@@ -177,7 +177,7 @@ public static class ForwardedTransformExtensions
     /// Adds the transform which will add the Forwarded header as defined by [RFC 7239](https://tools.ietf.org/html/rfc7239).
     /// </summary>
     /// <remarks>
-    /// Removes the X-Forwarded headers when an Forwarded transform is enabled
+    /// Also removes the <c>X-Forwarded</c> headers when enabled.
     /// </remarks>
     public static TransformBuilderContext AddForwarded(this TransformBuilderContext context,
         bool useHost = true, bool useProto = true, NodeFormat forFormat = NodeFormat.Random,


### PR DESCRIPTION
Add contextual doc comments indicating that using `AddForwarded` or `AddXForwarded` header transforms will remove the other from the `RequestTransforms` when either is enabled. Without the comments, this may seem to be an unexpected behavior without reading the source code of the extension methods to understand the effect each method has on the other at runtime.