### PR TITLE
Add route HTTP methods option via ingress annotations

### DIFF
--- a/samples/KubernetesIngress.Sample/README.md
+++ b/samples/KubernetesIngress.Sample/README.md
@@ -68,6 +68,9 @@ metadata:
         - another-queryparameters-value
         Mode: Contains
         IsCaseSensitive: false
+    yarp.ingress.kubernetes.io/route-methods:
+      - GET
+      - POST
 spec:
   rules:
     - http:
@@ -99,6 +102,7 @@ The table below lists the available annotations.
 |yarp.ingress.kubernetes.io/route-headers|List<[RouteHeader](https://microsoft.github.io/reverse-proxy/api/Yarp.ReverseProxy.Configuration.RouteHeader.html)>|
 |yarp.ingress.kubernetes.io/route-queryparameters|List<[RouteQueryParameter](https://microsoft.github.io/reverse-proxy/api/Yarp.ReverseProxy.Configuration.RouteQueryParameter.html)>|
 |yarp.ingress.kubernetes.io/route-order|int|
+|yarp.ingress.kubernetes.io/route-methods|List<string>|
 
 #### Authorization Policy
 
@@ -251,4 +255,14 @@ See https://microsoft.github.io/reverse-proxy/api/Yarp.ReverseProxy.Configuratio
 
 ```
 yarp.ingress.kubernetes.io/route-order: '10'
+```
+
+#### Route Methods
+
+See https://microsoft.github.io/reverse-proxy/api/Yarp.ReverseProxy.Configuration.RouteConfig.html#methods.
+
+```
+yarp.ingress.kubernetes.io/route-methods:
+  - GET
+  - POST
 ```

--- a/src/Kubernetes.Controller/Converters/YarpIngressOptions.cs
+++ b/src/Kubernetes.Controller/Converters/YarpIngressOptions.cs
@@ -27,6 +27,7 @@ internal sealed class YarpIngressOptions
     public List<RouteHeader> RouteHeaders { get; set; }
     public List<RouteQueryParameter> RouteQueryParameters { get; set; }
     public int? RouteOrder { get; set; }
+    public List<string> RouteMethods { get; set; }
 }
 
 internal sealed class RouteHeaderWrapper

--- a/src/Kubernetes.Controller/Converters/YarpParser.cs
+++ b/src/Kubernetes.Controller/Converters/YarpParser.cs
@@ -132,6 +132,7 @@ internal static class YarpParser
         {
             Match = new RouteMatch()
             {
+                Methods = ingressContext.Options.RouteMethods,
                 Hosts = host is not null ? new[] { host } : Array.Empty<string>(),
                 Path = pathMatch,
                 Headers = ingressContext.Options.RouteHeaders,
@@ -288,6 +289,10 @@ internal static class YarpParser
         if (annotations.TryGetValue("yarp.ingress.kubernetes.io/route-order", out var routeOrder))
         {
             options.RouteOrder = int.Parse(routeOrder, CultureInfo.InvariantCulture);
+        }
+        if (annotations.TryGetValue("yarp.ingress.kubernetes.io/route-methods", out var routeMethods))
+        {
+            options.RouteMethods = YamlDeserializer.Deserialize<List<string>>(routeMethods);
         }
         // metadata to support:
         // rewrite target

--- a/test/Kubernetes.Tests/IngressConversionTests.cs
+++ b/test/Kubernetes.Tests/IngressConversionTests.cs
@@ -54,6 +54,7 @@ public class IngressConversionTests
     [InlineData("route-queryparameters")]
     [InlineData("route-headers")]
     [InlineData("route-order")]
+    [InlineData("route-methods")]
     [InlineData("missing-svc")]
     [InlineData("port-diff-name")]
     [InlineData("external-name-ingress")]

--- a/test/Kubernetes.Tests/testassets/route-methods/clusters.json
+++ b/test/Kubernetes.Tests/testassets/route-methods/clusters.json
@@ -1,0 +1,18 @@
+[
+  {
+    "ClusterId": "frontend.default:80",
+    "LoadBalancingPolicy": null,
+    "SessionAffinity": null,
+    "HealthCheck": null,
+    "HttpClient": null,
+    "HttpRequest": null,
+    "Destinations": {
+      "http://10.244.2.38:80": {
+        "Address": "http://10.244.2.38:80",
+        "Health": null,
+        "Metadata": null
+      }
+    },
+    "Metadata": null
+  }
+]

--- a/test/Kubernetes.Tests/testassets/route-methods/ingress.yaml
+++ b/test/Kubernetes.Tests/testassets/route-methods/ingress.yaml
@@ -1,0 +1,67 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: first-ingress
+  namespace: default
+  annotations:
+    yarp.ingress.kubernetes.io/route-methods:
+      - GET
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /foo
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend
+            port:
+              number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: second-ingress
+  namespace: default
+  annotations:
+    yarp.ingress.kubernetes.io/route-methods:
+      - POST
+      - PUT
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /foo
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend
+            port:
+              number: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: default
+spec:
+  selector:
+    app: frontend
+  ports:
+  - name: https
+    port: 80
+    targetPort: 80
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: frontend
+  namespace: default
+subsets:
+  - addresses:
+    - ip: 10.244.2.38
+    ports:
+    - name: https
+      port: 80
+      protocol: TCP

--- a/test/Kubernetes.Tests/testassets/route-methods/routes.json
+++ b/test/Kubernetes.Tests/testassets/route-methods/routes.json
@@ -1,0 +1,36 @@
+[
+  {
+    "RouteId": "first-ingress.default:/foo",
+    "Match": {
+      "Methods": ["GET"],
+      "Hosts": [],
+      "Path": "/foo/{**catch-all}",
+      "Headers": null,
+      "QueryParameters": null
+    },
+    "Order": 10,
+    "ClusterId": "frontend.default:80",
+    "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
+    "CorsPolicy": null,
+    "Metadata": null,
+    "Transforms": null
+  },
+  {
+    "RouteId": "second-ingress.default:/foo",
+    "Match": {
+      "Methods": ["POST", "PUT"],
+      "Hosts": [],
+      "Path": "/foo/{**catch-all}",
+      "Headers": null,
+      "QueryParameters": null
+    },
+    "Order": 10,
+    "ClusterId": "frontend.default:80",
+    "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
+    "CorsPolicy": null,
+    "Metadata": null,
+    "Transforms": null
+  }
+]


### PR DESCRIPTION
Add yarp.ingress.kubernetes.io/route-methods to allow ingress forking based on HTTP methods. This addresses #1828.