### PR TITLE
Allow ProxyConfigManager to be resolved earlier

### DIFF
--- a/src/ReverseProxy/Delegation/HttpSysDelegator.cs
+++ b/src/ReverseProxy/Delegation/HttpSysDelegator.cs
@@ -29,7 +29,6 @@ internal sealed class HttpSysDelegator : IHttpSysDelegator, IClusterChangeListen
 
     public HttpSysDelegator(
             ILazyServiceResolver<IServerDelegationFeature> lazyResolveIServerDelegationFeature,
-            //LazyResolveIServerDelegationFeature lazyResolveIServerDelegationFeature,
             ILogger<HttpSysDelegator> logger)
     {
         _lazyResolveIServerDelegationFeature = lazyResolveIServerDelegationFeature;
@@ -185,7 +184,6 @@ internal sealed class HttpSysDelegator : IHttpSysDelegator, IClusterChangeListen
                         }
                     }
 
-                    var queueState = queue.Initialize(serverDelegationFeature);
                     var queueState = queue.Initialize(serverDelegationFeature);
                     if (!queueState.IsInitialized)
                     {

--- a/src/ReverseProxy/Management/IReverseProxyBuilderExtensions.cs
+++ b/src/ReverseProxy/Management/IReverseProxyBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Server.HttpSys;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Yarp.ReverseProxy.Configuration;
@@ -144,6 +145,7 @@ internal static class IReverseProxyBuilderExtensions
         builder.Services.AddSingleton<HttpSysDelegator>();
         builder.Services.TryAddSingleton<IHttpSysDelegator>(p => p.GetRequiredService<HttpSysDelegator>());
         builder.Services.AddSingleton<IClusterChangeListener>(p => p.GetRequiredService<HttpSysDelegator>());
+        builder.Services.AddSingleton<ILazyServiceResolver<IServerDelegationFeature>, LazyResolveIServerDelegationFeature>();
 
         return builder;
     }

--- a/src/ReverseProxy/Utilities/LazyServiceResolver.cs
+++ b/src/ReverseProxy/Utilities/LazyServiceResolver.cs
@@ -1,0 +1,42 @@
+using System;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Yarp.ReverseProxy.Utilities;
+
+internal interface ILazyServiceResolver<T>
+{
+    T? GetService();
+}
+
+internal abstract class LazyServiceResolver<T>
+    : ILazyServiceResolver<T>
+    where T : notnull
+{
+    protected readonly IServiceProvider ServiceProvider;
+    private T? _value;
+    private bool _resolved;
+
+    public LazyServiceResolver(IServiceProvider serviceProvider)
+    {
+        ServiceProvider = serviceProvider;
+    }
+
+    public T? GetService()
+    {
+        if (_resolved)
+        {
+            return _value;
+        }
+        else
+        {
+            _resolved = true;
+            return _value = Resolve();
+        }
+    }
+
+    protected virtual T? Resolve()
+    {
+        return ServiceProvider.GetService<T>();
+    }
+}

--- a/test/ReverseProxy.Tests/Delegation/HttpSysDelegatorTests.cs
+++ b/test/ReverseProxy.Tests/Delegation/HttpSysDelegatorTests.cs
@@ -7,11 +7,13 @@ using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.HttpSys;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
 using Yarp.ReverseProxy.Configuration;
 using Yarp.ReverseProxy.Forwarder;
 using Yarp.ReverseProxy.Model;
+using Yarp.ReverseProxy.Utilities;
 using Yarp.Tests.Common;
 
 namespace Yarp.ReverseProxy.Delegation;
@@ -26,6 +28,9 @@ public class HttpSysDelegatorTests : TestAutoMockBase
 
     public HttpSysDelegatorTests()
     {
+        Mock<ILazyServiceResolver<IServerDelegationFeature>>()
+            .Setup(m => m.GetService())
+            .Returns(Mock<IServerDelegationFeature>().Object);
         Mock<IFeatureCollection>()
             .Setup(m => m.Get<IServerDelegationFeature>())
             .Returns(Mock<IServerDelegationFeature>().Object);


### PR DESCRIPTION
This is for issue 1618 tunnel.
Allowing to be configured, I need to resolve the ProxyConfigManager within a ConfigureKestrel callback.
If you prefer a bigger PR please let me know.