### PR TITLE
Fix mismatched internal/public enum copies

### DIFF
--- a/src/TelemetryConsumption/WebSockets/WebSocketCloseReason.cs
+++ b/src/TelemetryConsumption/WebSockets/WebSocketCloseReason.cs
@@ -13,4 +13,5 @@ public enum WebSocketCloseReason : int
     ServerGracefulClose,
     ClientDisconnect,
     ServerDisconnect,
+    ActivityTimeout,
 }

--- a/test/ReverseProxy.FunctionalTests/TelemetryEnumTests.cs
+++ b/test/ReverseProxy.FunctionalTests/TelemetryEnumTests.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Yarp.ReverseProxy;
+
+public class TelemetryEnumTests
+{
+    [Theory]
+    [InlineData(typeof(Telemetry.Consumption.ForwarderStage), typeof(Forwarder.ForwarderStage))]
+    [InlineData(typeof(Telemetry.Consumption.WebSocketCloseReason), typeof(WebSocketsTelemetry.WebSocketCloseReason))]
+    public void ExposedEnumsMatchInternalCopies(Type publicEnum, Type internalEnum)
+    {
+        Assert.Equal(internalEnum.GetEnumNames(), publicEnum.GetEnumNames());
+        Assert.Equal(internalEnum.GetEnumValues().Cast<int>().ToArray(), publicEnum.GetEnumValues().Cast<int>().ToArray());
+    }
+}


### PR DESCRIPTION
The public copy of `WebSocketCloseReason` we expose from the telemetry package was missing the `ActivityTimeout` entry.