### PR TITLE
Document that request timeouts are disabled when running under a debugger

### DIFF
--- a/docs/docfx/articles/timeouts.md
+++ b/docs/docfx/articles/timeouts.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-.NET 8 introduced the [Request Timeouts Middleware](https://learn.microsoft.com/aspnet/core/performance/timeouts) to enable configuring request timeouts globally as well as per endpoint. This functionality is also available in YARP 2.1 when running on .NET 8.
+.NET 8 introduced the [Request Timeouts Middleware](https://learn.microsoft.com/aspnet/core/performance/timeouts) to enable configuring request timeouts globally as well as per endpoint. This functionality is also available in YARP 2.1 when running on .NET 8 or newer.
 
 ## Defaults
 Requests do not have any timeouts by default, other than the [Activity Timeout](http-client-config.md#HttpRequest) used to clean up idle requests. A default policy specified in [RequestTimeoutOptions](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.http.timeouts.requesttimeoutoptions) will apply to proxied requests as well.
@@ -11,6 +11,8 @@ Requests do not have any timeouts by default, other than the [Activity Timeout](
 Timeouts and Timeout Policies can be specified per route via [RouteConfig](xref:Yarp.ReverseProxy.Configuration.RouteConfig) and can be bound from the `Routes` sections of the config file. As with other route properties, this can be modified and reloaded without restarting the proxy. Policy names are case insensitive.
 
 Timeouts are specified in a TimeSpan HH:MM:SS format. Specifying both Timeout and TimeoutPolicy on the same route is invalid and will cause the configuration to be rejected.
+
+Note that request timeouts do not apply when a debugger is attached to the process.
 
 Example:
 ```JSON


### PR DESCRIPTION
Timeouts came up a couple of times in issues/discussions and this point isn't obvious to someone testing out their YARP config, maybe this will help.