### PR TITLE
Document that MaxRequestBodySize only applies to the forwarder

### DIFF
--- a/src/ReverseProxy/Configuration/RouteConfig.cs
+++ b/src/ReverseProxy/Configuration/RouteConfig.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
 using Yarp.ReverseProxy.Utilities;
 
 namespace Yarp.ReverseProxy.Configuration;
@@ -86,6 +88,8 @@ public sealed record RouteConfig
     /// <summary>
     /// An optional override for how large request bodies can be in bytes. If set, this overrides the server's default (30MB) per request.
     /// Set to '-1' to disable the limit for this route.
+    /// Note that this limit applies only to the YARP forwarder middleware, it does not apply when reading the request body from a custom middleware registered via
+    /// <see cref="ReverseProxyIEndpointRouteBuilderExtensions.MapReverseProxy(IEndpointRouteBuilder, Action{IReverseProxyApplicationBuilder})"/>.
     /// </summary>
     public long? MaxRequestBodySize { get; init; }
 


### PR DESCRIPTION
Documents https://github.com/microsoft/reverse-proxy/issues/2533#issuecomment-2291912701

> The MaxRequestBodySize set via YARP configuration applies to the request as it's being processed by YARP. It does not apply in any previous middleware you set during MapReverseProxy.
In your case, if you already read the whole body before a limit has been set, it won't be enforced later on since you're not reading from the request anymore (just from the already-buffered copy).