### PR TITLE
Suppress SYSLIB0057 in tests

### DIFF
--- a/test/ReverseProxy.FunctionalTests/Yarp.ReverseProxy.FunctionalTests.csproj
+++ b/test/ReverseProxy.FunctionalTests/Yarp.ReverseProxy.FunctionalTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(TestTFMs)</TargetFrameworks>
+    <NoWarn>$(NoWarn);SYSLIB0057</NoWarn>
     <OutputType>Library</OutputType>
     <RootNamespace>Yarp.ReverseProxy</RootNamespace>
 

--- a/test/ReverseProxy.Tests/Yarp.ReverseProxy.Tests.csproj
+++ b/test/ReverseProxy.Tests/Yarp.ReverseProxy.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(TestTFMs)</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Yarp.ReverseProxy</RootNamespace>
-    <NoWarn>SYSLIB0039</NoWarn>
+    <NoWarn>$(NoWarn);SYSLIB0039;SYSLIB0057</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/testassets/BenchmarkApp/BenchmarkApp.csproj
+++ b/testassets/BenchmarkApp/BenchmarkApp.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(TestTFMs)</TargetFrameworks>
+    <NoWarn>$(NoWarn);SYSLIB0057</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This fixes the build failure in #2579

https://learn.microsoft.com/en-gb/dotnet/fundamentals/syslib-diagnostics/syslib0057 suggests new ways to load certs, which are only available with .NET 9.
Since we can't use that yet on older platforms, I'm just suppressing the analyzer in our tests.