### PR TITLE
Allow building EOL TFMs for .NET 7.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,7 @@
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Unblocks #2656 #2657 #2661

Until we drop 7.0, we have to suppress the `NETSDK1138: The target framework is out of support` warning.