### PR TITLE
Workaround broken .NET 9.0 HttpSys linux packages

### DIFF
--- a/src/ReverseProxy/Delegation/DummyHttpSysDelegator.cs
+++ b/src/ReverseProxy/Delegation/DummyHttpSysDelegator.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Yarp.ReverseProxy.Delegation;
+
+// Only used as part of a workaround for https://github.com/dotnet/aspnetcore/issues/59166.
+internal sealed class DummyHttpSysDelegator : IHttpSysDelegator
+{
+    public void ResetQueue(string queueName, string urlPrefix) { }
+}

--- a/src/ReverseProxy/Management/ReverseProxyServiceCollectionExtensions.cs
+++ b/src/ReverseProxy/Management/ReverseProxyServiceCollectionExtensions.cs
@@ -52,9 +52,16 @@ public static class ReverseProxyServiceCollectionExtensions
             .AddActiveHealthChecks()
             .AddPassiveHealthCheck()
             .AddLoadBalancingPolicies()
-            .AddHttpSysDelegation()
             .AddDestinationResolver()
             .AddProxy();
+
+        if (OperatingSystem.IsWindows())
+        {
+            // Workaround for https://github.com/dotnet/aspnetcore/issues/59166
+            // .NET 9.0 packages for Ubuntu ship a broken Microsoft.AspNetCore.Server.HttpSys assembly.
+            // Avoid loading types from that assembly on Linux unless the user explicitly tries to do so.
+            builder.AddHttpSysDelegation();
+        }
 
         services.TryAddSingleton<ProxyEndpointFactory>();
 

--- a/src/ReverseProxy/Management/ReverseProxyServiceCollectionExtensions.cs
+++ b/src/ReverseProxy/Management/ReverseProxyServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Yarp.ReverseProxy.Configuration;
 using Yarp.ReverseProxy.Configuration.ConfigProvider;
+using Yarp.ReverseProxy.Delegation;
 using Yarp.ReverseProxy.Forwarder;
 using Yarp.ReverseProxy.Management;
 using Yarp.ReverseProxy.Routing;
@@ -57,10 +58,15 @@ public static class ReverseProxyServiceCollectionExtensions
 
         if (OperatingSystem.IsWindows())
         {
-            // Workaround for https://github.com/dotnet/aspnetcore/issues/59166
+            // Workaround for https://github.com/dotnet/aspnetcore/issues/59166.
             // .NET 9.0 packages for Ubuntu ship a broken Microsoft.AspNetCore.Server.HttpSys assembly.
             // Avoid loading types from that assembly on Linux unless the user explicitly tries to do so.
             builder.AddHttpSysDelegation();
+        }
+        else
+        {
+            // Add a no-op delegator in case someone is injecting the interface in their cross-plat logic.
+            builder.Services.TryAddSingleton<IHttpSysDelegator, DummyHttpSysDelegator>();
         }
 
         services.TryAddSingleton<ProxyEndpointFactory>();


### PR DESCRIPTION
Workaround https://github.com/dotnet/aspnetcore/issues/59166
Closes #2652