### PR TITLE
Update dependency package versions

### DIFF
--- a/docs/docfx/docfx.csproj
+++ b/docs/docfx/docfx.csproj
@@ -11,6 +11,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="docfx.console" Version="2.59.4" />
+        <PackageReference Include="docfx.console" Version="$(DocfxConsoleVersion)" />
     </ItemGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,23 +15,23 @@
     <SystemCollectionsImmutableVersion>8.0.0</SystemCollectionsImmutableVersion>
     <SystemIOHashingVersion>8.0.0</SystemIOHashingVersion>
     <MicrosoftBclTimeProviderVersion>8.0.0</MicrosoftBclTimeProviderVersion>
-    <MicrosoftAspNetCoreTestHostVersion>3.1.0</MicrosoftAspNetCoreTestHostVersion>
-    <MicrosoftCrankEventSourcesVersion>0.1.0-alpha.20501.1</MicrosoftCrankEventSourcesVersion>
+    <MicrosoftAspNetCoreTestHostVersion>6.0.36</MicrosoftAspNetCoreTestHostVersion>
+    <MicrosoftCrankEventSourcesVersion>0.2.0-alpha.24576.2</MicrosoftCrankEventSourcesVersion>
     <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.24613.2</MicrosoftDotNetXUnitExtensionsPackageVersion>
-    <CoverletCollectorVersion>1.0.1</CoverletCollectorVersion>
-    <MoqVersion>4.13.1</MoqVersion>
+    <CoverletCollectorVersion>6.0.0</CoverletCollectorVersion>
+    <MoqVersion>4.18.4</MoqVersion>
     <AutofacVersion>4.9.4</AutofacVersion>
     <AutofacExtrasMoqVersion>4.3.0</AutofacExtrasMoqVersion>
-    <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
-    <FluentAssertionsJsonVersion>5.5.0</FluentAssertionsJsonVersion>
-    <PollyVersion>7.2.1</PollyVersion>
-    <LettuceEncryptVersion>1.2.0</LettuceEncryptVersion>
-    <PrometheusNetVersion>4.1.1</PrometheusNetVersion>
+    <FluentAssertionsVersion>6.7.0</FluentAssertionsVersion>
+    <FluentAssertionsJsonVersion>6.1.0</FluentAssertionsJsonVersion>
+    <PollyVersion>8.4.2</PollyVersion>
+    <LettuceEncryptVersion>1.3.0</LettuceEncryptVersion>
+    <PrometheusNetVersion>8.2.1</PrometheusNetVersion>
     <SerilogExtensionsLoggingVersion>3.0.1</SerilogExtensionsLoggingVersion>
     <SerilogFormattingCompactVersion>1.1.0</SerilogFormattingCompactVersion>
     <SerilogSinksConsoleVersion>3.1.1</SerilogSinksConsoleVersion>
     <DocfxConsoleVersion>2.59.4</DocfxConsoleVersion>
-    <YamlDotNetVersion>13.7.1</YamlDotNetVersion>
-    <KubernetesClientVersion>10.1.19</KubernetesClientVersion>
+    <YamlDotNetVersion>16.2.1</YamlDotNetVersion>
+    <KubernetesClientVersion>15.0.1</KubernetesClientVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,6 +15,23 @@
     <SystemCollectionsImmutableVersion>8.0.0</SystemCollectionsImmutableVersion>
     <SystemIOHashingVersion>8.0.0</SystemIOHashingVersion>
     <MicrosoftBclTimeProviderVersion>8.0.0</MicrosoftBclTimeProviderVersion>
+    <MicrosoftAspNetCoreTestHostVersion>3.1.0</MicrosoftAspNetCoreTestHostVersion>
+    <MicrosoftCrankEventSourcesVersion>0.1.0-alpha.20501.1</MicrosoftCrankEventSourcesVersion>
     <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.24613.2</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <CoverletCollectorVersion>1.0.1</CoverletCollectorVersion>
+    <MoqVersion>4.13.1</MoqVersion>
+    <AutofacVersion>4.9.4</AutofacVersion>
+    <AutofacExtrasMoqVersion>4.3.0</AutofacExtrasMoqVersion>
+    <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
+    <FluentAssertionsJsonVersion>5.5.0</FluentAssertionsJsonVersion>
+    <PollyVersion>7.2.1</PollyVersion>
+    <LettuceEncryptVersion>1.2.0</LettuceEncryptVersion>
+    <PrometheusNetVersion>4.1.1</PrometheusNetVersion>
+    <SerilogExtensionsLoggingVersion>3.0.1</SerilogExtensionsLoggingVersion>
+    <SerilogFormattingCompactVersion>1.1.0</SerilogFormattingCompactVersion>
+    <SerilogSinksConsoleVersion>3.1.1</SerilogSinksConsoleVersion>
+    <DocfxConsoleVersion>2.59.4</DocfxConsoleVersion>
+    <YamlDotNetVersion>13.7.1</YamlDotNetVersion>
+    <KubernetesClientVersion>10.1.19</KubernetesClientVersion>
   </PropertyGroup>
 </Project>

--- a/samples/KubernetesIngress.Sample/Combined/Yarp.Kubernetes.IngressController.csproj
+++ b/samples/KubernetesIngress.Sample/Combined/Yarp.Kubernetes.IngressController.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="$(SerilogExtensionsLoggingVersion)" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="$(SerilogFormattingCompactVersion)" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="$(SerilogSinksConsoleVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/KubernetesIngress.Sample/Ingress/Yarp.Kubernetes.Ingress.csproj
+++ b/samples/KubernetesIngress.Sample/Ingress/Yarp.Kubernetes.Ingress.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="$(SerilogExtensionsLoggingVersion)" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="$(SerilogFormattingCompactVersion)" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="$(SerilogSinksConsoleVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/KubernetesIngress.Sample/Monitor/Yarp.Kubernetes.Monitor.csproj
+++ b/samples/KubernetesIngress.Sample/Monitor/Yarp.Kubernetes.Monitor.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="$(SerilogExtensionsLoggingVersion)" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="$(SerilogFormattingCompactVersion)" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="$(SerilogSinksConsoleVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Prometheus/ReverseProxy.Metrics-Prometheus.Sample/ReverseProxy.Metrics.Prometheus.Sample.csproj
+++ b/samples/Prometheus/ReverseProxy.Metrics-Prometheus.Sample/ReverseProxy.Metrics.Prometheus.Sample.csproj
@@ -8,8 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="prometheus-net" Version="4.1.1" />
-    <PackageReference Include="prometheus-net.AspNetCore" Version="4.1.1" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="$(PrometheusNetVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ReverseProxy.LetsEncrypt.Sample/ReverseProxy.LetsEncrypt.Sample.csproj
+++ b/samples/ReverseProxy.LetsEncrypt.Sample/ReverseProxy.LetsEncrypt.Sample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LettuceEncrypt" Version="1.2.0" />
+    <PackageReference Include="LettuceEncrypt" Version="$(LettuceEncryptVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kubernetes.Controller/Yarp.Kubernetes.Controller.csproj
+++ b/src/Kubernetes.Controller/Yarp.Kubernetes.Controller.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KubernetesClient" Version="10.1.19" />
-    <PackageReference Include="YamlDotNet" Version="13.7.1" />
+    <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersion)" />
+    <PackageReference Include="YamlDotNet" Version="$(YamlDotNetVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/Kubernetes.Tests/Yarp.Kubernetes.Tests.csproj
+++ b/test/Kubernetes.Tests/Yarp.Kubernetes.Tests.csproj
@@ -13,7 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+    <PackageReference Include="FluentAssertions.Json" Version="$(FluentAssertionsJsonVersion)" />
+    <PackageReference Include="Polly" Version="$(PollyVersion)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -39,13 +42,5 @@
   <ItemGroup>
     <Compile Include="..\ReverseProxy.Tests\Common\TaskExtensions.cs" Link="Common\TaskExtensions.cs" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="FluentAssertions.Json" Version="5.5.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.2" />
-    <PackageReference Include="Polly" Version="7.2.1" />
-  </ItemGroup>
-
 
 </Project>

--- a/test/ReverseProxy.Tests/Yarp.ReverseProxy.Tests.csproj
+++ b/test/ReverseProxy.Tests/Yarp.ReverseProxy.Tests.csproj
@@ -15,11 +15,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.9.4" />
-    <PackageReference Include="Autofac.Extras.Moq" Version="4.3.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="Autofac" Version="$(AutofacVersion)" />
+    <PackageReference Include="Autofac.Extras.Moq" Version="$(AutofacExtrasMoqVersion)" />
+    <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorVersion)" />
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHostVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Tests.Common/Yarp.Tests.Common.csproj
+++ b/test/Tests.Common/Yarp.Tests.Common.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.9.4" />
-    <PackageReference Include="Autofac.Extras.Moq" Version="4.3.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
-    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="Autofac" Version="$(AutofacVersion)" />
+    <PackageReference Include="Autofac.Extras.Moq" Version="$(AutofacExtrasMoqVersion)" />
+    <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorVersion)" />
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/testassets/BenchmarkApp/BenchmarkApp.csproj
+++ b/testassets/BenchmarkApp/BenchmarkApp.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Crank.EventSources" Version="0.1.0-alpha.20501.1" />
+    <PackageReference Include="Microsoft.Crank.EventSources" Version="$(MicrosoftCrankEventSourcesVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Moved all packages to use centrally-managed versions.
Bumped `KubernetesClient` to the latest version (15.0.1).

Fixes #2689