### PR TITLE
Extend ProbingRequestFactory to support Models and Async calls

### DIFF
--- a/src/ReverseProxy/Health/ActiveHealthCheckMonitor.Log.cs
+++ b/src/ReverseProxy/Health/ActiveHealthCheckMonitor.Log.cs
@@ -30,6 +30,11 @@ internal partial class ActiveHealthCheckMonitor
             EventIds.ActiveHealthProbeConstructionFailedOnCluster,
             "Construction of an active health probe for destination `{destinationId}` on cluster `{clusterId}` failed.");
 
+        private static readonly Action<ILogger, string, string, Exception?> _activeHealthProbeCancelledOnDestination = LoggerMessage.Define<string, string>(
+            LogLevel.Debug,
+            EventIds.ActiveHealthProbeCancelledOnDestination,
+            "Active health probing for destination `{destinationId}` on cluster `{clusterId}` was cancelled.");
+
         private static readonly Action<ILogger, string, Exception?> _startingActiveHealthProbingOnCluster = LoggerMessage.Define<string>(
             LogLevel.Debug,
             EventIds.StartingActiveHealthProbingOnCluster,
@@ -73,6 +78,11 @@ internal partial class ActiveHealthCheckMonitor
         public static void ActiveHealthProbeConstructionFailedOnCluster(ILogger logger, string destinationId, string clusterId, Exception ex)
         {
             _activeHealthProbeConstructionFailedOnCluster(logger, destinationId, clusterId, ex);
+        }
+
+        public static void ActiveHealthProbeCancelledOnDestination(ILogger logger, string destinationId, string clusterId)
+        {
+            _activeHealthProbeCancelledOnDestination(logger, destinationId, clusterId, null);
         }
 
         public static void StartingActiveHealthProbingOnCluster(ILogger logger, string clusterId)

--- a/src/ReverseProxy/Health/ActiveHealthCheckMonitor.cs
+++ b/src/ReverseProxy/Health/ActiveHealthCheckMonitor.cs
@@ -172,10 +172,17 @@ internal partial class ActiveHealthCheckMonitor : IActiveHealthCheckMonitor, ICl
         probeActivity?.AddTag("proxy.cluster_id", cluster.ClusterId);
         probeActivity?.AddTag("proxy.destination_id", destination.DestinationId);
 
+        using var cts = new CancellationTokenSource(timeout);
+
         HttpRequestMessage request;
         try
         {
-            request = await _probingRequestFactory.CreateRequestAsync(cluster, destination);
+            request = await _probingRequestFactory.CreateRequestAsync(cluster, destination, cts.Token);
+        }
+        catch (OperationCanceledException oce) when (!cts.IsCancellationRequested)
+        {
+            Log.ActiveHealthProbeCancelledOnDestination(_logger, destination.DestinationId, cluster.ClusterId);
+            return new DestinationProbingResult(destination, null, oce);
         }
         catch (Exception ex)
         {
@@ -186,8 +193,6 @@ internal partial class ActiveHealthCheckMonitor : IActiveHealthCheckMonitor, ICl
             return new DestinationProbingResult(destination, null, ex);
         }
 
-        using var cts = new CancellationTokenSource(timeout);
-
         try
         {
             Log.SendingHealthProbeToEndpointOfDestination(_logger, request.RequestUri, destination.DestinationId, cluster.ClusterId);
@@ -197,6 +202,11 @@ internal partial class ActiveHealthCheckMonitor : IActiveHealthCheckMonitor, ICl
             probeActivity?.SetStatus(ActivityStatusCode.Ok);
 
             return new DestinationProbingResult(destination, response, null);
+        }
+        catch (OperationCanceledException oce) when (!cts.IsCancellationRequested)
+        {
+            Log.ActiveHealthProbeCancelledOnDestination(_logger, destination.DestinationId, cluster.ClusterId);
+            return new DestinationProbingResult(destination, null, oce);
         }
         catch (Exception ex)
         {

--- a/src/ReverseProxy/Health/DefaultProbingRequestFactory.cs
+++ b/src/ReverseProxy/Health/DefaultProbingRequestFactory.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
@@ -41,6 +42,6 @@ internal sealed class DefaultProbingRequestFactory : IProbingRequestFactory
         return request;
     }
 
-    public ValueTask<HttpRequestMessage> CreateRequestAsync(ClusterState cluster, DestinationState destination) =>
+    public ValueTask<HttpRequestMessage> CreateRequestAsync(ClusterState cluster, DestinationState destination, CancellationToken cancellationToken = default) =>
         ValueTask.FromResult(CreateRequest(cluster.Model, destination.Model));
 }

--- a/src/ReverseProxy/Health/IProbingRequestFactory.cs
+++ b/src/ReverseProxy/Health/IProbingRequestFactory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Yarp.ReverseProxy.Model;
 
@@ -25,7 +26,8 @@ public interface IProbingRequestFactory
     /// </summary>
     /// <param name="cluster">The cluster being probed.</param>
     /// <param name="destination">The destination being probed.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>Probing <see cref="HttpRequestMessage"/>.</returns>
-    ValueTask<HttpRequestMessage> CreateRequestAsync(ClusterState cluster, DestinationState destination) =>
+    ValueTask<HttpRequestMessage> CreateRequestAsync(ClusterState cluster, DestinationState destination, CancellationToken cancellationToken = default) =>
         ValueTask.FromResult(CreateRequest(cluster.Model, destination.Model));
 }

--- a/src/ReverseProxy/Utilities/EventIds.cs
+++ b/src/ReverseProxy/Utilities/EventIds.cs
@@ -71,4 +71,5 @@ internal static class EventIds
     public static readonly EventId DelegationQueueNoLongerExists = new(65, nameof(DelegationQueueNoLongerExists));
     public static readonly EventId ForwardingRequestCancelled = new(66, nameof(ForwardingRequestCancelled));
     public static readonly EventId DelegationQueueDisposed = new(67, nameof(DelegationQueueDisposed));
+    public static readonly EventId ActiveHealthProbeCancelledOnDestination = new(68, nameof(ActiveHealthProbeCancelledOnDestination));
 }

--- a/test/ReverseProxy.Tests/Health/ActiveHealthCheckMonitorTests.cs
+++ b/test/ReverseProxy.Tests/Health/ActiveHealthCheckMonitorTests.cs
@@ -77,7 +77,7 @@ public class ActiveHealthCheckMonitorTests
 
         if (overrideAsyncMethod)
         {
-            requestFactory.Setup(p => p.CreateRequestAsync(It.IsAny<ClusterState>(), It.IsAny<DestinationState>()))
+            requestFactory.Setup(p => p.CreateRequestAsync(It.IsAny<ClusterState>(), It.IsAny<DestinationState>(), It.IsAny<CancellationToken>()))
                 .Returns(() => ValueTask.FromResult(CreateCustomRequest()));
         }
         else
@@ -99,6 +99,132 @@ public class ActiveHealthCheckMonitorTests
         await monitor.CheckHealthAsync(new[] { cluster });
 
         VerifySentProbeAndResult(cluster, httpClient, policy, new[] { ("https://localhost:20000/cluster/api/health/", 1) }, userAgent: @"^FooBar\/9001$");
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_FactoryCancelledExternally_ProbePassedToPolicyWithException()
+    {
+        var policy = new Mock<IActiveHealthCheckPolicy>();
+        policy.SetupGet(p => p.Name).Returns("policy");
+
+        var externalCts = new CancellationTokenSource();
+        var requestFactory = new Mock<IProbingRequestFactory>();
+
+        // First destination: factory throws OperationCanceledException (external cancellation)
+        // Second destination: succeeds normally
+        var callCount = 0;
+        requestFactory.Setup(p => p.CreateRequestAsync(It.IsAny<ClusterState>(), It.IsAny<DestinationState>(), It.IsAny<CancellationToken>()))
+            .Returns<ClusterState, DestinationState, CancellationToken>((cluster, destination, ct) =>
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    // Simulate external cancellation (not timeout) - throw without the timeout CTS being cancelled
+                    throw new OperationCanceledException(externalCts.Token);
+                }
+
+                return ValueTask.FromResult(new HttpRequestMessage(HttpMethod.Get, $"https://localhost:20000/{destination.DestinationId}/health/"));
+            });
+
+        var options = Options.Create(new ActiveHealthCheckMonitorOptions { DefaultTimeout = TimeSpan.FromSeconds(30) });
+        var monitor = new ActiveHealthCheckMonitor(options, new[] { policy.Object }, requestFactory.Object, new Mock<TimeProvider>().Object, GetLogger());
+
+        var httpClient = GetHttpClient();
+        var cluster = GetClusterInfo("cluster", "policy", true, httpClient.Object, destinationCount: 2);
+
+        await monitor.CheckHealthAsync(new[] { cluster });
+
+        // Policy should receive 2 results: one with exception (cancelled), one successful
+        policy.Verify(
+            p => p.ProbingCompleted(
+                cluster,
+                It.Is<IReadOnlyList<DestinationProbingResult>>(r =>
+                    r.Count == 2 &&
+                    r.Any(x => x.Exception is OperationCanceledException) &&
+                    r.Any(x => x.Response != null && x.Response.StatusCode == HttpStatusCode.OK)))
+            , Times.Once);
+        policy.Verify(p => p.Name);
+        policy.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_SendAsyncCancelledExternally_ProbePassedToPolicyWithException()
+    {
+        var policy = new Mock<IActiveHealthCheckPolicy>();
+        policy.SetupGet(p => p.Name).Returns("policy");
+
+        var externalCts = new CancellationTokenSource();
+        var options = Options.Create(new ActiveHealthCheckMonitorOptions { DefaultTimeout = TimeSpan.FromSeconds(30) });
+        var monitor = new ActiveHealthCheckMonitor(options, new[] { policy.Object }, new DefaultProbingRequestFactory(), new Mock<TimeProvider>().Object, GetLogger());
+
+        // First destination: SendAsync throws OperationCanceledException (external cancellation)
+        // Second destination: succeeds normally
+        var callCount = 0;
+        var httpClient = new Mock<HttpMessageInvoker>(() => new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object));
+        httpClient.Setup(c => c.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+            .Returns<HttpRequestMessage, CancellationToken>((request, ct) =>
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    // Simulate external cancellation (not timeout) - throw without the timeout CTS being cancelled
+                    throw new OperationCanceledException(externalCts.Token);
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Version = request.Version });
+            });
+
+        var cluster = GetClusterInfo("cluster", "policy", true, httpClient.Object, destinationCount: 2);
+
+        await monitor.CheckHealthAsync(new[] { cluster });
+
+        // Policy should receive 2 results: one with exception (cancelled), one successful
+        policy.Verify(
+            p => p.ProbingCompleted(
+                cluster,
+                It.Is<IReadOnlyList<DestinationProbingResult>>(r =>
+                    r.Count == 2 &&
+                    r.Any(x => x.Exception is OperationCanceledException) &&
+                    r.Any(x => x.Response != null && x.Response.StatusCode == HttpStatusCode.OK)))
+            , Times.Once);
+        policy.Verify(p => p.Name);
+        policy.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_TimeoutCancellation_TreatedAsError()
+    {
+        var policy = new Mock<IActiveHealthCheckPolicy>();
+        policy.SetupGet(p => p.Name).Returns("policy");
+
+        var options = Options.Create(new ActiveHealthCheckMonitorOptions { DefaultTimeout = TimeSpan.FromMilliseconds(1) });
+        var monitor = new ActiveHealthCheckMonitor(options, new[] { policy.Object }, new DefaultProbingRequestFactory(), new Mock<TimeProvider>().Object, GetLogger());
+
+        var tcs = new TaskCompletionSource<HttpResponseMessage>();
+        var httpClient = new Mock<HttpMessageInvoker>(() => new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object));
+        httpClient.Setup(c => c.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+            .Returns<HttpRequestMessage, CancellationToken>((request, ct) =>
+            {
+                // Register callback to cancel the TCS when timeout occurs
+                ct.Register(() => tcs.TrySetCanceled(ct));
+                return tcs.Task;
+            });
+
+        var cluster = GetClusterInfo("cluster", "policy", true, httpClient.Object, destinationCount: 1);
+
+        await monitor.CheckHealthAsync(new[] { cluster });
+
+        // Policy should receive 1 result with an exception (timeout is an error, not skipped)
+        policy.Verify(
+            p => p.ProbingCompleted(
+                cluster,
+                It.Is<IReadOnlyList<DestinationProbingResult>>(r =>
+                    r.Count == 1 &&
+                    r[0].Response == null &&
+                    r[0].Exception is OperationCanceledException)),
+            Times.Once);
+        policy.Verify(p => p.Name);
+        policy.VerifyNoOtherCalls();
     }
 
     [Fact]
@@ -299,6 +425,9 @@ public class ActiveHealthCheckMonitorTests
 
         timeProvider.FireAllTimers();
 
+        Assert.Equal(2, timeProvider.TimerCount);
+        timeProvider.VerifyTimer(0, Interval0);
+        timeProvider.VerifyTimer(1, Interval1);
         VerifySentProbeAndResult(cluster0, httpClient0, policy0, new[] { ("https://localhost:20000/cluster0/api/health/", 1), ("https://localhost:20001/cluster0/api/health/", 1) }, policyCallTimes: 1);
         VerifySentProbeAndResult(cluster2, httpClient2, policy1, new[] { ("https://localhost:20000/cluster2/api/health/", 1), ("https://localhost:20001/cluster2/api/health/", 1) }, policyCallTimes: 1);
 


### PR DESCRIPTION
This change updates the `IProbingRequestFactory`'s `CreateRequest` API to use `DestinationState` and `ClusterState` instead of `DestinationModel`, `ClusterModel` and makes the method async.

Simplifies scenarios where consumers need to access or update health state without relying on internal models.

Allows access to the ID and allows overloads to rely on `ConditionalWeakTable` mappings on the objects.

This change originated from a discussion with @MihaZupan, and subsequent filing of bug #2890 