### PR TITLE
Upgrade to V4 arcade publishing

### DIFF
--- a/azure-pipelines-nonprod.yml
+++ b/azure-pipelines-nonprod.yml
@@ -7,8 +7,6 @@ variables:
   value: AspNetCore
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
-- name: _PublishUsingPipelines
-  value: true
 - name: _BuildConfig
   value: Release
 # Rely on task Arcade injects, not auto-injected build step.
@@ -67,12 +65,13 @@ extends:
           enableMicrobuild: true
           enablePublishBuildArtifacts: true
           enablePublishTestResults: true
+          publishingVersion: 4
           enablePublishBuildAssets: true
-          enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
           enableTelemetry: true
           mergeTestResults: true
           jobs:
           - job: Windows
+            enablePublishing: true
             pool:
               name: $(DncEngInternalBuildPool)
               image: 1es-windows-2022
@@ -82,7 +81,6 @@ extends:
             - name: _OfficialBuildArgs
               value: /p:DotNetSignType=$(_SignType)
                      /p:TeamName=$(_TeamName)
-                     /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
                      /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             - name: _SignType
               value: real
@@ -108,7 +106,7 @@ extends:
                 PublishLocation: Container
     - template: /eng/common/templates-official/post-build/post-build.yml@self
       parameters:
-        publishingInfraVersion: 3
+        publishingInfraVersion: 4
         enableSymbolValidation: false
         enableSourceLinkValidation: false
         enableSigningValidation: false

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -8,8 +8,6 @@ variables:
     value: AspNetCore
   - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
     value: true
-  - name: _PublishUsingPipelines
-    value: true
   - name: _BuildConfig
     value: Release
   - template: /eng/common/templates/variables/pool-providers.yml
@@ -36,7 +34,6 @@ stages:
       enablePublishBuildArtifacts: true
       enablePublishTestResults: true
       enablePublishBuildAssets: true
-      enablePublishUsingPipelines: true
       enableTelemetry: true
       mergeTestResults: true
       jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,8 +7,6 @@ variables:
   value: AspNetCore
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
-- name: _PublishUsingPipelines
-  value: true
 - name: _BuildConfig
   value: Release
 # Rely on task Arcade injects, not auto-injected build step.
@@ -61,12 +59,13 @@ extends:
           enableMicrobuild: true
           enablePublishBuildArtifacts: true
           enablePublishTestResults: true
+          publishingVersion: 4
           enablePublishBuildAssets: true
-          enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
           enableTelemetry: true
           mergeTestResults: true
           jobs:
           - job: Windows
+            enablePublishing: true
             pool:
               name: $(DncEngInternalBuildPool)
               image: 1es-windows-2022
@@ -76,7 +75,6 @@ extends:
             - name: _OfficialBuildArgs
               value: /p:DotNetSignType=$(_SignType)
                      /p:TeamName=$(_TeamName)
-                     /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
                      /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             - name: _SignType
               value: real
@@ -102,7 +100,7 @@ extends:
                 PublishLocation: Container
     - template: /eng/common/templates-official/post-build/post-build.yml@self
       parameters:
-        publishingInfraVersion: 3
+        publishingInfraVersion: 4
         enableSymbolValidation: false
         enableSourceLinkValidation: false
         enableSigningValidation: false

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
    <PropertyGroup>
-      <PublishingVersion>3</PublishingVersion>
+      <PublishingVersion>4</PublishingVersion>
    </PropertyGroup>
 
    <PropertyGroup>


### PR DESCRIPTION
## Summary
- switch Arcade publishing to V4
- remove obsolete V3 pipeline publishing plumbing
- update post-build validation to use V4 artifacts

Part of dotnet/arcade#16697