### PR TITLE
Fix Hierarchical tracing test broken by ForceDefaultIdFormat

### DIFF
--- a/test/ReverseProxy.FunctionalTests/DistributedTracingTests.cs
+++ b/test/ReverseProxy.FunctionalTests/DistributedTracingTests.cs
@@ -51,6 +51,13 @@ public class DistributedTracingTests
             },
         };
 
+        // Microsoft.ApplicationInsights (transitive dependency brought in by
+        // Microsoft.Testing.Extensions.Telemetry) sets Activity.ForceDefaultIdFormat = true
+        // globally, which forces every new Activity to use W3C format regardless of the
+        // parent activity's format. Disable the override so that child activities inherit
+        // the parent's format as they would in a normal application.
+        Activity.ForceDefaultIdFormat = false;
+
         var clientActivity = new Activity("Foo");
         clientActivity.SetIdFormat(idFormat);
         clientActivity.TraceStateString = "Bar";


### PR DESCRIPTION
Fixes #3020

Copilot's description:

    Microsoft.Testing.Extensions.Telemetry (part of the test runner) brings
    in Microsoft.ApplicationInsights/2.23.0, which sets
    Activity.ForceDefaultIdFormat = true globally.  This forces all new
    Activities to use W3C format regardless of the parent activity's format,
    causing the Hierarchical test case to emit traceparent/tracestate
    headers instead of the expected Request-Id header.

Introduced in #2940